### PR TITLE
Add instructions to set upstream as default

### DIFF
--- a/doc/git_configuration.rst
+++ b/doc/git_configuration.rst
@@ -24,10 +24,35 @@ From the command line:
 Step 2: Keep in sync with changes in Ross
 -----------------------------------------
 
+Setup your local repository so it pulls from upstream by default:
+
 ::
 
     git config branch.master.remote upstream
     git config branch.master.merge refs/heads/master
+
+This can also be done by editing the config file inside your .git directory.
+It should look like this:
+
+::
+
+    [core]
+            repositoryformatversion = 0
+            filemode = true
+            bare = false
+            logallrefupdates = true
+    [remote "origin"]
+            url = https://github.com/your-user-name/ross.git
+            fetch = +refs/heads/*:refs/remotes/origin/*
+    [remote "upstream"]
+            url = https://github.com/ross-rotordynamics/ross.git
+            fetch = +refs/heads/*:refs/remotes/upstream/*
+            fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
+    [branch "master"]
+            remote = origin
+            merge = refs/heads/master
+
+The part :code:`fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*` will make pull requests available.
 
 ---------------------------------
 Step 3: Make a new feature branch


### PR DESCRIPTION
This adds some instructions to set upstream as the default location from
 which your repository will pull. This can also be done by editing the
 config file inside the .git directory. It also adds a configuration
 option so that branchs from pull requests will also be easily available.