### PR TITLE
Remove plot when creating rotor

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -279,8 +279,8 @@ class Rotor(object):
 
         #  diameter at node position
 
-        self.plot_rotor()
-        print("To calculate eigenvalues and frequencies, use the method run().")
+        print("To check the rotor geometry, use the method plot_rotor()\n"
+              "To calculate the rotor state, use the method run()")
 
     def __eq__(self, other):
         if self.elements == other.elements and self.parameters == other.parameters:


### PR DESCRIPTION
The rotor geometry was plotted when the object was instantiated. The
purpose of this was to show the user the rotor geometry so that the user
could check if everything was correct before eigenvalues, eigenvectors
etc. were calculated.
The problem with this approach is that the rotor will be automatically
plotted in situations where this is not wanted by the user, such as when
running a script where several rotors will be instantiated or when we
are running the tests locally, in this case, several windows with plots
will appear and the tests will take a long time.
With this PR the plot of the rotor after instantiation will be optional
to the user. A message is provided to let the user know that the
plot_rotor() method can be used.
Additionally, the message "calculate eigenvalues and frequencies", which
is redundant, has been modified to "calculate rotor state".