### PR TITLE
Update api

### DIFF
--- a/ross/__init__.py
+++ b/ross/__init__.py
@@ -1,4 +1,3 @@
-from . import materials as mtr
 from . import element
 from . import bearing_seal_element as bse
 from . import disk_element as disk

--- a/ross/__init__.py
+++ b/ross/__init__.py
@@ -4,10 +4,7 @@ from . import results as rst
 from . import rotor_assembly as rotor
 from . import shaft_element as shaft
 from .materials import *
-from .rotor_assembly import *
+from .bearing_seal_element import *
 from .disk_element import *
 from .shaft_element import *
-from .shaft_element import *
-from .results import *
-from .bearing_seal_element import *
-from .element import *
+from .rotor_assembly import *

--- a/ross/__init__.py
+++ b/ross/__init__.py
@@ -1,8 +1,3 @@
-from . import bearing_seal_element as bse
-from . import disk_element as disk
-from . import results as rst
-from . import rotor_assembly as rotor
-from . import shaft_element as shaft
 from .materials import *
 from .bearing_seal_element import *
 from .disk_element import *

--- a/ross/__init__.py
+++ b/ross/__init__.py
@@ -1,4 +1,3 @@
-from . import element
 from . import bearing_seal_element as bse
 from . import disk_element as disk
 from . import results as rst

--- a/ross/materials.py
+++ b/ross/materials.py
@@ -6,6 +6,9 @@ some of the most common materials used in rotors.
 import toml
 
 
+__all__ = ["Material", "steel"]
+
+
 class Material:
     """Material.
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -116,6 +116,7 @@ class Rotor(object):
     >>> bearing0 = rs.BearingElement(0, kxx=stf, cxx=0)
     >>> bearing1 = rs.BearingElement(2, kxx=stf, cxx=0)
     >>> rotor = rs.Rotor(shaft_elm, [disk0], [bearing0, bearing1])
+    >>> rotor.run()
     >>> rotor.wd[0] # doctest: +ELLIPSIS
     215.3707...
     """

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -111,7 +111,7 @@ class Rotor(object):
     ...                        rotary_inertia=True,
     ...                        gyroscopic=True)
     >>> shaft_elm = [tim0, tim1]
-    >>> disk0 = rs.DiskElement(1, 0.07, 0.05, 0.28)
+    >>> disk0 = rs.DiskElement.from_geometry(1, steel, 0.07, 0.05, 0.28)
     >>> stf = 1e6
     >>> bearing0 = rs.BearingElement(0, kxx=stf, cxx=0)
     >>> bearing1 = rs.BearingElement(2, kxx=stf, cxx=0)

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -96,25 +96,26 @@ class Rotor(object):
     Examples
     --------
     >>> #  Rotor without damping with 2 shaft elements 1 disk and 2 bearings
-    >>> from ross.materials import steel
+    >>> import ross as rs
+    >>> steel = rs.materials.steel
     >>> z = 0
     >>> le = 0.25
     >>> i_d = 0
     >>> o_d = 0.05
-    >>> tim0 = ShaftElement(le, i_d, o_d, steel,
-    ...                    shear_effects=True,
-    ...                    rotary_inertia=True,
-    ...                    gyroscopic=True)
-    >>> tim1 = ShaftElement(le, i_d, o_d, steel,
-    ...                    shear_effects=True,
-    ...                    rotary_inertia=True,
-    ...                    gyroscopic=True)
+    >>> tim0 = rs.ShaftElement(le, i_d, o_d, steel,
+    ...                        shear_effects=True,
+    ...                        rotary_inertia=True,
+    ...                        gyroscopic=True)
+    >>> tim1 = rs.ShaftElement(le, i_d, o_d, steel,
+    ...                        shear_effects=True,
+    ...                        rotary_inertia=True,
+    ...                        gyroscopic=True)
     >>> shaft_elm = [tim0, tim1]
-    >>> disk0 = DiskElement(1, steel, 0.07, 0.05, 0.28)
+    >>> disk0 = rs.DiskElement(1, 0.07, 0.05, 0.28)
     >>> stf = 1e6
-    >>> bearing0 = BearingElement(0, kxx=stf, cxx=0)
-    >>> bearing1 = BearingElement(2, kxx=stf, cxx=0)
-    >>> rotor = Rotor(shaft_elm, [disk0], [bearing0, bearing1])
+    >>> bearing0 = rs.BearingElement(0, kxx=stf, cxx=0)
+    >>> bearing1 = rs.BearingElement(2, kxx=stf, cxx=0)
+    >>> rotor = rs.Rotor(shaft_elm, [disk0], [bearing0, bearing1])
     >>> rotor.wd[0] # doctest: +ELLIPSIS
     215.3707...
     """
@@ -279,8 +280,10 @@ class Rotor(object):
 
         #  diameter at node position
 
-        print("To check the rotor geometry, use the method plot_rotor()\n"
-              "To calculate the rotor state, use the method run()")
+        print(
+            "To check the rotor geometry, use the method plot_rotor()\n"
+            "To calculate the rotor state, use the method run()"
+        )
 
     def __eq__(self, other):
         if self.elements == other.elements and self.parameters == other.parameters:
@@ -549,7 +552,12 @@ class Rotor(object):
         if self.sparse is True:
             try:
                 evalues, evectors = las.eigs(
-                    A, k=self.n_eigen, sigma=0, ncv=2*self.n_eigen, which="LM", v0=self._v0
+                    A,
+                    k=self.n_eigen,
+                    sigma=0,
+                    ncv=2 * self.n_eigen,
+                    which="LM",
+                    v0=self._v0,
                 )
                 # store v0 as a linear combination of the previously
                 # calculated eigenvectors to use in the next call to eigs
@@ -1028,7 +1036,7 @@ class Rotor(object):
         --------
         """
         return signal.lsim(self.lti, F, t, X0=ic)
-    
+
     def plot_rotor(self, nodes=1, ax=None, bk_ax=None):
         """Plots a rotor object.
 
@@ -1076,22 +1084,22 @@ class Rotor(object):
 
         # bokeh plot - create a new plot
         bk_ax = figure(
-           tools="pan, box_zoom, wheel_zoom, reset, save",
-           width=900,
-           height=500,
-           y_range=[-6 * max_diameter, 6 * max_diameter],
-           title="Rotor model",
-           x_axis_label='Axial location (m)',
-           y_axis_label='Shaft radius (m)'
+            tools="pan, box_zoom, wheel_zoom, reset, save",
+            width=900,
+            height=500,
+            y_range=[-6 * max_diameter, 6 * max_diameter],
+            title="Rotor model",
+            x_axis_label="Axial location (m)",
+            y_axis_label="Shaft radius (m)",
         )
 
         # bokeh plot - plot shaft centerline
         bk_ax.line(
-            [-0.2 * shaft_end, 1.2 * shaft_end], 
+            [-0.2 * shaft_end, 1.2 * shaft_end],
             [0, 0],
             line_width=3,
             line_dash="dotdash",
-            line_color=bokeh_colors[0]
+            line_color=bokeh_colors[0],
         )
 
         # plot nodes
@@ -1126,23 +1134,25 @@ class Rotor(object):
 
         source = ColumnDataSource(dict(x=x_pos, y=y_pos, text=text))
 
-        bk_ax.square(x=x_pos,
-                     y=y_pos,
-                     size=30,
-                     angle=np.pi/4,
-                     fill_alpha=0.8,
-                     fill_color=bokeh_colors[6]
-                     )
+        bk_ax.square(
+            x=x_pos,
+            y=y_pos,
+            size=30,
+            angle=np.pi / 4,
+            fill_alpha=0.8,
+            fill_color=bokeh_colors[6],
+        )
 
-        glyph = Text(x="x",
-                     y="y",
-                     text="text",
-                     text_font_style="bold",
-                     text_baseline="middle",
-                     text_align="center",
-                     text_alpha=1.0,
-                     text_color=bokeh_colors[0]
-                     )
+        glyph = Text(
+            x="x",
+            y="y",
+            text="text",
+            text_font_style="bold",
+            text_baseline="middle",
+            text_align="center",
+            text_alpha=1.0,
+            text_color=bokeh_colors[0],
+        )
         bk_ax.add_glyph(source, glyph)
 
         # plot shaft elements
@@ -2007,14 +2017,8 @@ class Rotor(object):
         )
 
         TOOLS = "pan,wheel_zoom,box_zoom,hover,reset,save,"
-        TOOLTIPS1 = [
-            ('Frquency:', '@y0 Hz'),
-            ('Number of Elements', '@x0')
-        ]
-        TOOLTIPS2 = [
-            ('Relative Error:', '@y1'),
-            ('Number of Elements', '@x1')
-        ]
+        TOOLTIPS1 = [("Frquency:", "@y0 Hz"), ("Number of Elements", "@x0")]
+        TOOLTIPS2 = [("Relative Error:", "@y1"), ("Number of Elements", "@x1")]
         # create a new plot and add a renderer
         freq_arr = figure(
             tools=TOOLS,

--- a/ross/tests/test_disk_element.py
+++ b/ross/tests/test_disk_element.py
@@ -7,10 +7,37 @@ from ross.materials import steel
 
 @pytest.fixture
 def disk():
-    return DiskElement.from_geometry(0, steel, 0.07, 0.05, 0.28)
+    return DiskElement(0, 0.07, 0.05, 0.32956)
 
 
 def test_mass_matrix_disk(disk):
+    # fmt: off
+    Md1 = np.array([[0.07, 0., 0., 0.],
+                    [0., 0.07, 0., 0.],
+                    [0., 0., 0.05, 0.],
+                    [0., 0., 0., 0.05]])
+    # fmt: on
+
+    assert_almost_equal(disk.M(), Md1, decimal=5)
+
+
+def test_gyroscopic_matrix_disk(disk):
+    # fmt: off
+    Gd1 = np.array([[0., 0., 0., 0.],
+                    [0., 0., 0., 0.],
+                    [0., 0., 0., 0.32956],
+                    [0., 0., -0.32956, 0.]])
+    # fmt: on
+
+    assert_almost_equal(disk.G(), Gd1, decimal=5)
+
+
+@pytest.fixture
+def disk_from_geometry():
+    return DiskElement.from_geometry(0, steel, 0.07, 0.05, 0.28)
+
+
+def test_mass_matrix_disk1(disk_from_geometry):
     Md1 = np.array(
         [
             [32.58973, 0.0, 0.0, 0.0],
@@ -19,10 +46,10 @@ def test_mass_matrix_disk(disk):
             [0.0, 0.0, 0.0, 0.17809],
         ]
     )
-    assert_almost_equal(disk.M(), Md1, decimal=5)
+    assert_almost_equal(disk_from_geometry.M(), Md1, decimal=5)
 
 
-def test_gyroscopic_matrix_disk(disk):
+def test_gyroscopic_matrix_disk1(disk_from_geometry):
     Gd1 = np.array(
         [
             [0.0, 0.0, 0.0, 0.0],
@@ -31,4 +58,4 @@ def test_gyroscopic_matrix_disk(disk):
             [0.0, 0.0, -0.32956, 0.0],
         ]
     )
-    assert_almost_equal(disk.G(), Gd1, decimal=5)
+    assert_almost_equal(disk_from_geometry.G(), Gd1, decimal=5)

--- a/ross/tests/test_disk_element.py
+++ b/ross/tests/test_disk_element.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import assert_almost_equal
 from ross.disk_element import DiskElement
 from ross.materials import steel
 

--- a/ross/tests/test_examples.py
+++ b/ross/tests/test_examples.py
@@ -1,8 +1,7 @@
 from ross import *
+from ross.materials import steel
 import numpy as np
 import pytest
-
-steel = mtr.steel
 
 
 def rotor_example1(w=0, n_el=48):

--- a/ross/tests/test_examples.py
+++ b/ross/tests/test_examples.py
@@ -1,4 +1,4 @@
-from ross import *
+import ross as rs
 from ross.materials import steel
 import numpy as np
 import pytest
@@ -20,19 +20,19 @@ def rotor_example1(w=0, n_el=48):
     shaft_elm = []
     for i in range(n_el):
         shaft_elm.append(
-            shaft.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
+            rs.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
         )
-    disk0 = disk.DiskElement.from_geometry(
+    disk0 = rs.DiskElement.from_geometry(
         n=(n_el / 1.5) * 0.5, material=steel, width=0.07, i_d=0.05, o_d=0.28
     )
-    disk1 = disk.DiskElement.from_geometry(
+    disk1 = rs.DiskElement.from_geometry(
         n=(n_el / 1.5), material=steel, width=0.07, i_d=0.05, o_d=0.35
     )
 
-    bearing0 = bse.BearingElement(n=0, kxx=1e6, kyy=1e6, cxx=0, cyy=0)
-    bearing1 = bse.BearingElement(n=n_el, kxx=1e6, kyy=1e6, cxx=0, cyy=0)
+    bearing0 = rs.BearingElement(n=0, kxx=1e6, kyy=1e6, cxx=0, cyy=0)
+    bearing1 = rs.BearingElement(n=n_el, kxx=1e6, kyy=1e6, cxx=0, cyy=0)
 
-    return rotor.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
+    return rs.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
 
 
 def test_example1_w_equals_0rpm():
@@ -68,18 +68,18 @@ def rotor_example2(w=0, n_el=48):
     shaft_elm = []
     for i in range(n_el):
         shaft_elm.append(
-            shaft.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
+            rs.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
         )
-    return rotor.Rotor(
+    return rs.Rotor(
         shaft_elm,
         [
-            disk.DiskElement.from_geometry(
+            rs.DiskElement.from_geometry(
                 n=n_el, material=steel, width=0.07, i_d=0.05, o_d=0.35
             )
         ],
         [
-            bse.BearingElement(n=0, kxx=10e6, kyy=10e6, cxx=0, cyy=0),
-            bse.BearingElement(n=int((n_el / 1.5)), kxx=10e6, kyy=10e6, cxx=0, cyy=0),
+            rs.BearingElement(n=0, kxx=10e6, kyy=10e6, cxx=0, cyy=0),
+            rs.BearingElement(n=int((n_el / 1.5)), kxx=10e6, kyy=10e6, cxx=0, cyy=0),
         ],
         w=w,
     )
@@ -117,19 +117,19 @@ def rotor_example3(w=0, n_el=48):
     shaft_elm = []
     for i in range(n_el):
         shaft_elm.append(
-            shaft.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
+            rs.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
         )
-    disk0 = disk.DiskElement.from_geometry(
+    disk0 = rs.DiskElement.from_geometry(
         n=(n_el / 3), material=steel, width=0.07, i_d=0.05, o_d=0.28
     )
-    disk1 = disk.DiskElement.from_geometry(
+    disk1 = rs.DiskElement.from_geometry(
         n=(n_el / 1.5), material=steel, width=0.07, i_d=0.05, o_d=0.35
     )
 
-    bearing0 = bse.BearingElement(n=0, kxx=1e6, kyy=8e5, cxx=0, cyy=0)
-    bearing1 = bse.BearingElement(n=n_el, kxx=1e6, kyy=8e5, cxx=0, cyy=0)
+    bearing0 = rs.BearingElement(n=0, kxx=1e6, kyy=8e5, cxx=0, cyy=0)
+    bearing1 = rs.BearingElement(n=n_el, kxx=1e6, kyy=8e5, cxx=0, cyy=0)
 
-    return rotor.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
+    return rs.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
 
 
 def test_example3_w_equals_0rpm():
@@ -163,19 +163,19 @@ def rotor_example4(w=0, n_el=48):
     shaft_elm = []
     for i in range(n_el):
         shaft_elm.append(
-            shaft.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
+            rs.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
         )
-    disk0 = disk.DiskElement.from_geometry(
+    disk0 = rs.DiskElement.from_geometry(
         n=(n_el / 1.5) * 0.5, material=steel, width=0.07, i_d=0.05, o_d=0.28
     )
-    disk1 = disk.DiskElement.from_geometry(
+    disk1 = rs.DiskElement.from_geometry(
         n=(n_el / 1.5), material=steel, width=0.07, i_d=0.05, o_d=0.35
     )
 
-    bearing0 = bse.BearingElement(n=0, kxx=1e6, kyy=1e6, cxx=3e3, cyy=3e3)
-    bearing1 = bse.BearingElement(n=n_el, kxx=1e6, kyy=1e6, cxx=3e3, cyy=3e3)
+    bearing0 = rs.BearingElement(n=0, kxx=1e6, kyy=1e6, cxx=3e3, cyy=3e3)
+    bearing1 = rs.BearingElement(n=n_el, kxx=1e6, kyy=1e6, cxx=3e3, cyy=3e3)
 
-    return rotor.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
+    return rs.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
 
 
 def test_example4_w_equals_0rpm():
@@ -220,19 +220,19 @@ def rotor_example5(w=0, n_el=48):
     shaft_elm = []
     for i in range(n_el):
         shaft_elm.append(
-            shaft.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
+            rs.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
         )
-    disk0 = disk.DiskElement.from_geometry(
+    disk0 = rs.DiskElement.from_geometry(
         n=(n_el / 3), material=steel, width=0.07, i_d=0.05, o_d=0.28
     )
-    disk1 = disk.DiskElement.from_geometry(
+    disk1 = rs.DiskElement.from_geometry(
         n=(n_el / 1.5), material=steel, width=0.07, i_d=0.05, o_d=0.35
     )
 
-    bearing0 = bse.BearingElement(n=0, kxx=1e6, kyy=2e5, cxx=0, cyy=0)
-    bearing1 = bse.BearingElement(n=n_el, kxx=1e6, kyy=2e5, cxx=0, cyy=0)
+    bearing0 = rs.BearingElement(n=0, kxx=1e6, kyy=2e5, cxx=0, cyy=0)
+    bearing1 = rs.BearingElement(n=n_el, kxx=1e6, kyy=2e5, cxx=0, cyy=0)
 
-    return rotor.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
+    return rs.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
 
 
 def test_example5_w_equals4000rpm():
@@ -260,19 +260,19 @@ def rotor_example6(w=0, n_el=48):
     shaft_elm = []
     for i in range(n_el):
         shaft_elm.append(
-            shaft.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
+            rs.ShaftElement(L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.05)
         )
-    disk0 = disk.DiskElement.from_geometry(
+    disk0 = rs.DiskElement.from_geometry(
         n=(n_el / 1.5) * 0.5, material=steel, width=0.07, i_d=0.05, o_d=0.28
     )
-    disk1 = disk.DiskElement.from_geometry(
+    disk1 = rs.DiskElement.from_geometry(
         n=(n_el / 1.5), material=steel, width=0.07, i_d=0.05, o_d=0.35
     )
 
-    bearing0 = bse.BearingElement(n=0, kxx=1e6, kyy=1e6, cxx=0, kxy=5e5, cyy=0)
-    bearing1 = bse.BearingElement(n=n_el, kxx=1e6, kyy=1e6, cxx=0, kxy=5e5, cyy=0)
+    bearing0 = rs.BearingElement(n=0, kxx=1e6, kyy=1e6, cxx=0, kxy=5e5, cyy=0)
+    bearing1 = rs.BearingElement(n=n_el, kxx=1e6, kyy=1e6, cxx=0, kxy=5e5, cyy=0)
 
-    return rotor.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
+    return rs.Rotor(shaft_elm, [disk0, disk1], [bearing0, bearing1], w=w)
 
 
 def test_example6_w_equals4000rpm():
@@ -299,19 +299,19 @@ def rotor_example7(w=0, n_el=48):
     shaft_elm = []
     for i in range(n_el):
         shaft_elm.append(
-            shaft.ShaftElement(
+            rs.ShaftElement(
                 L=1.5 / n_el, material=steel, n=i, i_d=0, o_d=0.025 + 0.015 * (i / n_el)
             )
         )
 
-    disk0 = disk.DiskElement.from_geometry(
+    disk0 = rs.DiskElement.from_geometry(
         n=(n_el / 2), material=steel, width=0.07, i_d=0.05, o_d=0.28
     )
 
-    bearing0 = bse.BearingElement(n=0, kxx=1e7, kyy=1e7, cxx=1e3, cyy=1e3)
-    bearing1 = bse.BearingElement(n=n_el, kxx=1e7, kyy=1e7, cxx=1e3, cyy=1e3)
+    bearing0 = rs.BearingElement(n=0, kxx=1e7, kyy=1e7, cxx=1e3, cyy=1e3)
+    bearing1 = rs.BearingElement(n=n_el, kxx=1e7, kyy=1e7, cxx=1e3, cyy=1e3)
 
-    return rotor.Rotor(shaft_elm, [disk0], [bearing0, bearing1], w=w)
+    return rs.Rotor(shaft_elm, [disk0], [bearing0, bearing1], w=w)
 
 
 def test_example7_w_equals3000rpm():


### PR DESCRIPTION
The main purpose of this PR is to simplify the command interface to the user and to avoid polluting the `rs.` namespace when the library is imported.
Ideally, when the user does the import and checks the namespace:
```python
import ross as rs
rs.<tab>
```
autocompletion tools, such as those available when we use a jupyter notebook, should show only the classes / functions that the user will need to call the library (BearingElement, Rotor etc.)
Using `rs.<tab>` was bringing objects such as the `ABC` module, `abstractmethod` function and so on, which are used by our library but should not appear to the user.