### PR TITLE
Change appveyor badge to track master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rotodynamic Open Source Software (ROSS)
 
 [![Build Status](https://travis-ci.com/ross-rotordynamics/ross.svg?branch=master)](https://travis-ci.com/ross-rotordynamics/ross)
-[![Build status](https://ci.appveyor.com/api/projects/status/tvsj4jh7bowvn0ht?svg=true)](https://ci.appveyor.com/project/raphaeltimbo/ross)
+[![Build status](https://ci.appveyor.com/api/projects/status/tvsj4jh7bowvn0ht/branch/master?svg=true)](https://ci.appveyor.com/project/raphaeltimbo/ross/branch/master)
 <a href="https://codecov.io/gh/ross-rotordynamics/ross">
 <img src="https://codecov.io/gh/ross-rotordynamics/ross/branch/master/graph/badge.svg">
 </a>


### PR DESCRIPTION
This changes the appveyor badge that appears in the repository main page
to track only builds that are related to the master branch.
We should have the badge only for the master branch since PRs with
failing builds will not be merged anyway.
The previous badge was tracking all builds, including those from new
pull requests that were failing before merging to master.