### PR TITLE
Add methods to allow inputs from table in bearing element

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -364,6 +364,15 @@ class SealElement(BearingElement):
 
 
 def bearing_element_from_excel(n, file):
+    """Instantiate a bearing using inputs from an excel file.
+    Parameters
+    ----------
+    n : int. The node in which the bearing will be located in the rotor.
+    file: str. Path to the excel file containing the bearing parameters.
+    Returns
+    -------
+    A bearing object.
+    """
     try:
         df = pd.read_excel(file)
     except FileNotFoundError:

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -8,6 +8,7 @@ from ross.element import Element
 import pytest
 import pandas as pd
 import sys
+import xlrd
 
 __all__ = ["BearingElement", "SealElement"]
 bokeh_colors = bp.RdGy[11]
@@ -363,12 +364,12 @@ class SealElement(BearingElement):
         )
 
 
-def bearing_element_from_excel(n, file):
-    """Instantiate a bearing using inputs from an excel file.
+def bearing_element_from_table(n, file):
+    """Instantiate a bearing using inputs from a table, either excel or csv.
     Parameters
     ----------
     n : int. The node in which the bearing will be located in the rotor.
-    file: str. Path to the excel file containing the bearing parameters.
+    file: str. Path to the file containing the bearing parameters.
     Returns
     -------
     A bearing object.
@@ -377,6 +378,8 @@ def bearing_element_from_excel(n, file):
         df = pd.read_excel(file)
     except FileNotFoundError:
         sys.exit(file + " not found.")
+    except xlrd.biffh.XLRDError:
+        df = pd.read_csv(file)
     try:
         return BearingElement(n, kxx=df['kxx'].tolist(), cxx=df['cxx'].tolist(), kyy=df['kyy'].tolist(),
                               kxy=df['kxy'].tolist(), kyx=df['kyx'].tolist(), cyy=df['cyy'].tolist(),
@@ -385,4 +388,3 @@ def bearing_element_from_excel(n, file):
         sys.exit("One or more column names did not match the expected. "
                  "Make sure the table header contains the parameters for the "
                  "BearingElement class.")
-

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -6,6 +6,8 @@ import matplotlib.patches as mpatches
 import bokeh.palettes as bp
 from ross.element import Element
 import pytest
+import pandas as pd
+import sys
 
 __all__ = ["BearingElement", "SealElement"]
 bokeh_colors = bp.RdGy[11]
@@ -359,3 +361,19 @@ class SealElement(BearingElement):
             bk_seal_points_l[0], bk_seal_points_l[1],
             alpha=0.5, line_width=2, color=bokeh_colors[6]
         )
+
+
+def bearing_element_from_excel(n, file):
+    try:
+        df = pd.read_excel(file)
+    except FileNotFoundError:
+        sys.exit(file + " not found.")
+    try:
+        return BearingElement(n, kxx=df['kxx'].tolist(), cxx=df['cxx'].tolist(), kyy=df['kyy'].tolist(),
+                              kxy=df['kxy'].tolist(), kyx=df['kyx'].tolist(), cyy=df['cyy'].tolist(),
+                              cxy=df['cxy'].tolist(), cyx=df['cyx'].tolist(), w=df['w'].tolist())
+    except KeyError:
+        sys.exit("One or more column names did not match the expected. "
+                 "Make sure the table header contains the parameters for the "
+                 "BearingElement class.")
+

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ REQUIRED = [
     "pytest",
     "bokeh",
     "coverage",
+    "xlrd",
 ]
 
 # What packages are optional?


### PR DESCRIPTION
Two methods were added to bearing element. The first one allows instantiating a bearing object from a table. The second one converts from table to dictionary, that can be saved as a toml file.
Close #79 