### PR TITLE
Add warning for invalid table entries

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -312,6 +312,12 @@ class BearingElement(Element):
         except xlrd.biffh.XLRDError:
             df = pd.read_csv(file)
         try:
+            for index, row in df.iterrows():
+                for i in range(0, row.size):
+                    if pd.isna(row[i]):
+                        warnings.warn("NaN found in row " + str(index) + " column " + str(i) + ".\n"
+                                      "It will be replaced with zero.")
+                        row[i] = 0
             return cls(n, kxx=df['kxx'].tolist(), cxx=df['cxx'].tolist(), kyy=df['kyy'].tolist(),
                        kxy=df['kxy'].tolist(), kyx=df['kyx'].tolist(), cyy=df['cyy'].tolist(),
                        cxy=df['cxy'].tolist(), cyx=df['cyx'].tolist(), w=df['w'].tolist())


### PR DESCRIPTION
If the user tries to instantiate a bearing element from a table and the
table contains invalid entries, such as empty cells, the program will show a
warning message and replace these cells with a zero value.
Close #97 