### PR TITLE
Add interpolate to rotor_assembly

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -8,6 +8,7 @@ import scipy.signal as signal
 import scipy.io as sio
 from copy import copy, deepcopy
 from collections import Iterable
+from scipy import interpolate
 import shutil
 import matplotlib as mpl
 import matplotlib.pyplot as plt


### PR DESCRIPTION
The function interp1d is used but the module scipy.interpolate was not
being imported.