### PR TITLE
Add check to see if rotor is inside stator

### DIFF
--- a/ross/fluid_flow/fluid_flow.py
+++ b/ross/fluid_flow/fluid_flow.py
@@ -206,6 +206,7 @@ class PressureMatrix:
             zno = i * self.dz
             self.z[0][i] = zno
             plot_eccentricity_error = False
+            position = -1
             for j in range(self.ntheta):
                 gama = j * self.dtheta
                 [radius_external, self.xre[i][j], self.yre[i][j]] =\
@@ -217,8 +218,9 @@ class PressureMatrix:
                 if not plot_eccentricity_error:
                     if abs(self.xri[i][j]) > abs(self.xre[i][j]) or abs(self.yri[i][j]) > abs(self.yre[i][j]):
                         plot_eccentricity_error = True
+                        position = i
             if plot_eccentricity_error:
-                self.plot_eccentricity()
+                self.plot_eccentricity(position)
                 sys.exit("Error: The given parameters create a rotor that is not inside the stator. "
                          "Check the plotted figure and fix accordingly.")
 

--- a/ross/fluid_flow/fluid_flow.py
+++ b/ross/fluid_flow/fluid_flow.py
@@ -115,7 +115,7 @@ class PressureMatrix:
     Examples
     --------
     >>> from ross.fluid_flow import fluid_flow as flow
-    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
     >>> nz = 20
     >>> ntheta = 100
     >>> nradius = 11

--- a/ross/fluid_flow/fluid_flow.py
+++ b/ross/fluid_flow/fluid_flow.py
@@ -205,6 +205,7 @@ class PressureMatrix:
         for i in range(self.nz):
             zno = i * self.dz
             self.z[0][i] = zno
+            plot_eccentricity_error = False
             for j in range(self.ntheta):
                 gama = j * self.dtheta
                 [radius_external, self.xre[i][j], self.yre[i][j]] =\
@@ -213,6 +214,13 @@ class PressureMatrix:
                     self.internal_radius_function(zno, gama)
                 self.re[i][j] = radius_external
                 self.ri[i][j] = radius_internal
+                if not plot_eccentricity_error:
+                    if abs(self.xri[i][j]) > abs(self.xre[i][j]) or abs(self.yri[i][j]) > abs(self.yre[i][j]):
+                        plot_eccentricity_error = True
+            if plot_eccentricity_error:
+                self.plot_eccentricity()
+                sys.exit("Error: The given parameters create a rotor that is not inside the stator. "
+                         "Check the plotted figure and fix accordingly.")
 
     def internal_radius_function(self, z, gama):
         """This function calculates the radius of the rotor given the


### PR DESCRIPTION
When instantiating the fluid flow class, the program will check if the parameters given create a valid structure, i.e., with a rotor that is inside the stator. If they don't, it will plot the eccentricity and exit with a error message. Close #98 