### PR TITLE
Added interpolate to rotor_assembly.py

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -6,6 +6,7 @@ import scipy.linalg as la
 import scipy.sparse.linalg as las
 import scipy.signal as signal
 import scipy.io as sio
+from scipy import interpolate
 from copy import copy, deepcopy
 from collections import Iterable
 import shutil


### PR DESCRIPTION
The function interp1d was used but the interpolate function was not being
imported.