### PR TITLE
Improving plot_rotor

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -289,7 +289,7 @@ class BearingElement(Element):
 
         return C
 
-    def patch(self, position, ax, bk_ax):
+    def patch(self, position, length, ax, bk_ax):
         """Bearing element patch.
         Patch that will be used to draw the bearing element.
         Parameters
@@ -300,6 +300,8 @@ class BearingElement(Element):
             Axes in which the plot will be drawn.
         position : tuple
             Position (z, y) in which the patch will be drawn.
+        length : float
+            minimum length of shaft elements
         Returns
         -------
         ax : matplotlib axes
@@ -308,7 +310,7 @@ class BearingElement(Element):
             Returns the axes object with the plot.
         """
         zpos, ypos = position
-
+        le = length
         h = -0.5 * ypos  # height
 
         #  node (x pos), outer diam. (y pos)
@@ -323,10 +325,10 @@ class BearingElement(Element):
         )
 
         # bokeh plot - upper bearing visual representarion
-        bk_ax.quad(top=-ypos,
-                   bottom=-2 * ypos,
-                   left=zpos - ypos,
-                   right=zpos + ypos,
+        bk_ax.quad(top=-ypos+le/3,
+                   bottom=-ypos,
+                   left=zpos-le/6,
+                   right=zpos+le/6,
                    line_color=bokeh_colors[0],
                    line_width=1,
                    fill_alpha=1,
@@ -335,9 +337,9 @@ class BearingElement(Element):
                    )
         # bokeh plot - lower bearing visual representation
         bk_ax.quad(top=ypos,
-                   bottom=2 * ypos,
-                   left=zpos - ypos,
-                   right=zpos + ypos,
+                   bottom=ypos-le/3,
+                   left=zpos-le/6,
+                   right=zpos+le/6,
                    line_color=bokeh_colors[0],
                    line_width=1,
                    fill_alpha=1,

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -304,10 +304,6 @@ class BearingElement(Element):
             minimum length of shaft elements
         Returns
         -------
-        ax : matplotlib axes
-            Returns the axes object with the plot.
-        bk_ax : bokeh plotting axes
-            Returns the axes object with the plot.
         """
         zpos, ypos = position
         le = length
@@ -327,8 +323,8 @@ class BearingElement(Element):
         # bokeh plot - upper bearing visual representarion
         bk_ax.quad(top=-ypos+le/3,
                    bottom=-ypos,
-                   left=zpos-le/6,
-                   right=zpos+le/6,
+                   left=zpos - le/6,
+                   right=zpos + le/6,
                    line_color=bokeh_colors[0],
                    line_width=1,
                    fill_alpha=1,
@@ -338,8 +334,8 @@ class BearingElement(Element):
         # bokeh plot - lower bearing visual representation
         bk_ax.quad(top=ypos,
                    bottom=ypos-le/3,
-                   left=zpos-le/6,
-                   right=zpos+le/6,
+                   left=zpos - le/6,
+                   right=zpos + le/6,
                    line_color=bokeh_colors[0],
                    line_width=1,
                    fill_alpha=1,

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.patches as mpatches
 import bokeh.palettes as bp
+from bokeh.models import ColumnDataSource
 from ross.element import Element
 import pytest
 import toml
@@ -91,6 +92,7 @@ class DiskElement(Element):
                     DiskElement(**disk_elements_dict["DiskElement"][element])
                 )
         return disk_elements
+
     def M(self):
         """
         This method will return the mass matrix for an instance of a disk
@@ -208,46 +210,44 @@ class DiskElement(Element):
             mpatches.Circle(xy=(zpos, -(ypos + D)), radius=0.01, color=self.color)
         )
 
-        # bokeh plot - plot disks elements
-        bk_disk_points_u = [
-            [zpos, zpos + le, zpos - le],
-            [ypos, ypos*4, ypos*4]
-        ]
+        # bokeh plot - coordinates to plot disks elements
+        z_upper = [zpos, zpos + le, zpos - le]
+        y_upper = [ypos, ypos * 4, ypos * 4]
 
-        bk_disk_points_l = [
-            [zpos, zpos + le, zpos - le],
-            [-ypos, -ypos*4, -ypos*4]
-        ]
+        z_lower = [zpos, zpos + le, zpos - le]
+        y_lower = [-ypos, -ypos * 4, -ypos * 4]
+
+        z_circle = z_upper[0]
+        y_circle = y_upper[1]
+
+        source = ColumnDataSource(
+            dict(z_l=z_lower, y_l=y_lower, z_u=z_upper, y_u=y_upper)
+        )
 
         bk_ax.patch(
-            x=bk_disk_points_u[0],
-            y=bk_disk_points_u[1],
+            x="z_u",
+            y="y_u",
+            source=source,
             alpha=1,
             line_width=2,
             color=bokeh_colors[9],
-            legend="Disk"
+            legend="Disk",
         )
         bk_ax.patch(
-            x=bk_disk_points_l[0],
-            y=bk_disk_points_l[1],
+            x="z_l",
+            y="y_l",
+            source=source,
             alpha=1,
             line_width=2,
-            color=bokeh_colors[9]
+            color=bokeh_colors[9],
         )
         bk_ax.circle(
-            x=bk_disk_points_u[0][0],
-            y=bk_disk_points_u[1][1],
-            radius=le,
-            fill_alpha=1,
-            color=bokeh_colors[9]
-            )
+            x=z_circle, y=y_circle, radius=le, fill_alpha=1, color=bokeh_colors[9]
+        )
         bk_ax.circle(
-            x=bk_disk_points_l[0][0],
-            y=bk_disk_points_l[1][1],
-            radius=le,
-            fill_alpha=1,
-            color=bokeh_colors[9]
-            )
+            x=z_circle, y=-y_circle, radius=le, fill_alpha=1, color=bokeh_colors[9]
+        )
+
 
     @classmethod
     def from_geometry(cls, n, material, width, i_d, o_d):

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -159,7 +159,7 @@ class DiskElement(Element):
         # fmt: on
         return G
 
-    def patch(self, position, ax, bk_ax):
+    def patch(self, position, length, ax, bk_ax):
         """Disk element patch.
         Patch that will be used to draw the disk element.
         Parameters
@@ -170,6 +170,8 @@ class DiskElement(Element):
             Axes in which the plot will be drawn.
         position : float
             Position in which the patch will be drawn.
+        length : float
+            minimum length of shaft elements
         Returns
         -------
         ax : matplotlib axes
@@ -178,6 +180,7 @@ class DiskElement(Element):
             Returns the axes object with the plot.
         """
         zpos, ypos = position
+        le = length / 8
         D = ypos * 2
         hw = 0.02
 
@@ -207,13 +210,13 @@ class DiskElement(Element):
 
         # bokeh plot - plot disks elements
         bk_disk_points_u = [
-            [zpos, zpos + hw, zpos - hw],
-            [ypos, ypos + D, ypos + D]
+            [zpos, zpos + le, zpos - le],
+            [ypos, ypos*4, ypos*4]
         ]
 
         bk_disk_points_l = [
-            [zpos, zpos + hw, zpos - hw],
-            [-ypos, -(ypos + D), -(ypos + D)]
+            [zpos, zpos + le, zpos - le],
+            [-ypos, -ypos*4, -ypos*4]
         ]
 
         bk_ax.patch(
@@ -232,16 +235,16 @@ class DiskElement(Element):
             color=bokeh_colors[9]
         )
         bk_ax.circle(
-            x=zpos,
-            y=ypos + D,
-            radius=0.02,
+            x=bk_disk_points_u[0][0],
+            y=bk_disk_points_u[1][1],
+            radius=le,
             fill_alpha=1,
             color=bokeh_colors[9]
             )
         bk_ax.circle(
-            x=zpos,
-            y=-(ypos + D),
-            radius=0.02,
+            x=bk_disk_points_l[0][0],
+            y=bk_disk_points_l[1][1],
+            radius=le,
             fill_alpha=1,
             color=bokeh_colors[9]
             )

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -259,6 +259,10 @@ class Rotor(object):
         nodes_o_d.append(df_shaft["o_d"].iloc[-1])
         self.nodes_o_d = nodes_o_d
 
+        nodes_le = list(df_shaft.groupby("n_l")["L"].min())
+        nodes_le.append(df_shaft["L"].iloc[-1])
+        self.nodes_le = nodes_le
+
         self.nodes = list(range(len(self.nodes_pos)))
         self.elements_length = [sh_el.L for sh_el in self.shaft_elements]
         self.L = nodes_pos[-1]

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -421,7 +421,7 @@ class Rotor(object):
         )
 
         TOOLS = "pan,wheel_zoom,box_zoom,hover,reset,save,"
-        TOOLTIPS1 = [("Frquency:", "@y0 Hz"), ("Number of Elements", "@x0")]
+        TOOLTIPS1 = [("Frequency:", "@y0 Hz"), ("Number of Elements", "@x0")]
         TOOLTIPS2 = [("Relative Error:", "@y1"), ("Number of Elements", "@x1")]
         # create a new plot and add a renderer
         freq_arr = figure(
@@ -443,7 +443,7 @@ class Rotor(object):
             width=500,
             height=500,
             title="Relative Error Evaluation",
-            x_axis_label="Number of Rlements",
+            x_axis_label="Number of Elements",
             y_axis_label="Relative Rrror",
         )
         rel_error.line(
@@ -1216,12 +1216,14 @@ class Rotor(object):
         # check slenderness ratio of beam elements
         SR = np.array([])
         for shaft in self.shaft_elements:
-            if shaft.sld_ratio < 30:
+            if shaft.slenderness_ratio < 30:
                 SR = np.append(SR, shaft.n)
         if len(SR) != 0:
-            print(
-                "Warning: The beam elements " + str(SR) + " have slenderness\n"
-                "ratio (G*A*L^2 / EI) greater than 30. Results may not converge correctly"
+            warnings.warn(
+                "The beam elements "
+                + str(SR)
+                + " have slenderness ratio (G*A*L^2 / EI) greater than 30."
+                + " Results may not converge correctly"
             )
 
         if ax is None:
@@ -1253,8 +1255,8 @@ class Rotor(object):
             x_range=[-0.1 * shaft_end, 1.1 * shaft_end],
             y_range=[-0.3 * shaft_end, 0.3 * shaft_end],
             title="Rotor model",
-            x_axis_label="Axial location",
-            y_axis_label="Shaft radius",
+            x_axis_label="Axial location (m)",
+            y_axis_label="Shaft radius (m)",
             match_aspect=True,
         )
 
@@ -1269,9 +1271,11 @@ class Rotor(object):
 
         # plot nodes
         text = []
+        x_pos = []
         for node, position in enumerate(self.nodes_pos[::nodes]):
             # bokeh plot
             text.append(str(node))
+            x_pos.append(position)
 
             # matplotlib
             ax.plot(
@@ -1294,7 +1298,6 @@ class Rotor(object):
             )
 
         # bokeh plot - plot nodes
-        x_pos = np.linspace(0, self.nodes_pos[-1], len(self.nodes_pos))
         y_pos = np.linspace(0, 0, len(self.nodes_pos))
 
         source = ColumnDataSource(dict(x=x_pos, y=y_pos, text=text))
@@ -1318,7 +1321,7 @@ class Rotor(object):
         # plot shaft elements
         for sh_elm in self.shaft_elements:
             position = self.nodes_pos[sh_elm.n]
-            sh_elm.patch(position, ax, bk_ax)
+            sh_elm.patch(position, SR, ax, bk_ax)
 
         # plot disk elements
         for disk in self.disk_elements:

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -144,7 +144,7 @@ class ShaftElement(Element):
 
         # Slenderness ratio of beam elements (G*A*L^2) / (E*I)
         sld = (self.material.G_s * self.A * self.L ** 2) / (self.material.E * self.Ie)
-        self.sld_ratio = sld        
+        self.slenderness_ratio = sld    
 
         # picking a method to calculate the shear coefficient
         # List of avaible methods:
@@ -392,7 +392,7 @@ class ShaftElement(Element):
 
         return G
 
-    def patch(self, position, ax, bk_ax):
+    def patch(self, position, SR, ax, bk_ax):
         """Shaft element patch.
         Patch that will be used to draw the shaft element.
         Parameters
@@ -405,15 +405,19 @@ class ShaftElement(Element):
             Position in which the patch will be drawn.
         Returns
         -------
-        ax : matplotlib axes
-            Returns the axes object with the plot.
-        bk_ax : bokeh plotting axes
-            Returns the axes object with the plot.
         """
-        position_u = [position, self.i_d/2]  # upper
-        position_l = [position, -self.o_d/2]  # lower
+        position_u = [position, self.i_d / 2]  # upper
+        position_l = [position, -self.o_d / 2]  # lower
         width = self.L
-        height = self.o_d/2 - self.i_d/2
+        height = self.o_d / 2 - self.i_d / 2
+        if self.n in SR:
+            mpl_color = "yellow"
+            bk_color = "yellow"
+            legend = "Shaft - Slenderness Ratio < 30"
+        else:
+            mpl_color = self.color
+            bk_color = bokeh_colors[2]
+            legend = "Shaft"
 
         #  matplotlib - plot the upper half of the shaft
         ax.add_patch(
@@ -424,8 +428,9 @@ class ShaftElement(Element):
                 linestyle="--",
                 linewidth=0.5,
                 ec="k",
-                fc=self.color,
+                fc=mpl_color,
                 alpha=0.8,
+                label=legend,
             )
         )
         #  matplotlib - plot the lower half of the shaft
@@ -437,30 +442,33 @@ class ShaftElement(Element):
                 linestyle="--",
                 linewidth=0.5,
                 ec="k",
-                fc=self.color,
+                fc=mpl_color,
                 alpha=0.8,
             )
         )
+
         # bokeh plot - plot the shaft
-        bk_ax.quad(top=self.o_d/2,
-                   bottom=self.i_d/2,
-                   left=position,
-                   right=position + self.L,
-                   line_color=bokeh_colors[0],
-                   line_width=1,
-                   fill_alpha=0.5,
-                   fill_color=bokeh_colors[2],
-                   legend="Shaft"
-                   )
-        bk_ax.quad(top=-self.i_d/2,
-                   bottom=-self.o_d/2,
-                   left=position,
-                   right=position + self.L,
-                   line_color=bokeh_colors[0],
-                   line_width=1,
-                   fill_alpha=0.5,
-                   fill_color=bokeh_colors[2],
-                   )
+        bk_ax.quad(
+            top=self.o_d / 2,
+            bottom=self.i_d / 2,
+            left=position,
+            right=position + self.L,
+            line_color=bokeh_colors[0],
+            line_width=1,
+            fill_alpha=0.5,
+            fill_color=bk_color,
+            legend=legend,
+        )
+        bk_ax.quad(
+            top=-self.i_d / 2,
+            bottom=-self.o_d / 2,
+            left=position,
+            right=position + self.L,
+            line_color=bokeh_colors[0],
+            line_width=1,
+            fill_alpha=0.5,
+            fill_color=bk_color,
+        )
 
     @classmethod
     def section(

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -142,6 +142,10 @@ class ShaftElement(Element):
         self.Ie = np.pi * (o_d ** 4 - i_d ** 4) / 64
         phi = 0
 
+        # Slenderness ratio of beam elements (G*A*L^2) / (E*I)
+        sld = (self.material.G_s * self.A * self.L ** 2) / (self.material.E * self.Ie)
+        self.sld_ratio = sld        
+
         # picking a method to calculate the shear coefficient
         # List of avaible methods:
         # hutchinson - kappa as per Hutchinson (2001)
@@ -406,10 +410,10 @@ class ShaftElement(Element):
         bk_ax : bokeh plotting axes
             Returns the axes object with the plot.
         """
-        position_u = [position, self.i_d]  # upper
-        position_l = [position, -self.o_d]  # lower
+        position_u = [position, self.i_d/2]  # upper
+        position_l = [position, -self.o_d/2]  # lower
         width = self.L
-        height = self.o_d - self.i_d
+        height = self.o_d/2 - self.i_d/2
 
         #  matplotlib - plot the upper half of the shaft
         ax.add_patch(
@@ -438,8 +442,8 @@ class ShaftElement(Element):
             )
         )
         # bokeh plot - plot the shaft
-        bk_ax.quad(top=self.o_d,
-                   bottom=self.i_d,
+        bk_ax.quad(top=self.o_d/2,
+                   bottom=self.i_d/2,
                    left=position,
                    right=position + self.L,
                    line_color=bokeh_colors[0],
@@ -448,8 +452,8 @@ class ShaftElement(Element):
                    fill_color=bokeh_colors[2],
                    legend="Shaft"
                    )
-        bk_ax.quad(top=-self.i_d,
-                   bottom=-self.o_d,
+        bk_ax.quad(top=-self.i_d/2,
+                   bottom=-self.o_d/2,
                    left=position,
                    right=position + self.L,
                    line_color=bokeh_colors[0],


### PR DESCRIPTION
There was an error that shaft elements were plotting with 2 times their respective radius.
I enlarged the plot window size and distributed the axis size so that the rotor is presented with the correct proportions in relation to its dimensions.

Also, adds the slenderness ratio parameter (equation: G * A * L ** 2 / E * I ) to each shaft element. It calculates the ratio using some global distance measures, rather than basing it upon individual element dimensions. The user is returned an warning message if it's lower than a certain value, which could affect the convergence analysis.