### PR TITLE
Change name variable in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def version(path):
 
 
 # Package meta-data.
-NAME = "ross"
+NAME = "ross-rotordynamics"
 DESCRIPTION = "ross: rotordynamic open-source software"
 URL = "https://github.com/ross-rotordynamics/ross"
 EMAIL = "raphaelts@gmail.com"


### PR DESCRIPTION
In order to upload to PyPi, the name in setup.py should be unique. As 'ross' was already taken, we changed to 'ross-rotordynamics'.