### PR TITLE
Change methods' names

### DIFF
--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -204,10 +204,10 @@ class DiskElement(Element):
         ax.add_patch(mpatches.Polygon(disk_points_l, facecolor=self.color))
 
         ax.add_patch(
-            mpatches.Circle(xy=(zpos, ypos + D), radius=0.01, color=self.color)
+            mpatches.Circle(xy=(zpos, ypos + D), radius=hw, color=self.color)
         )
         ax.add_patch(
-            mpatches.Circle(xy=(zpos, -(ypos + D)), radius=0.01, color=self.color)
+            mpatches.Circle(xy=(zpos, -(ypos + D)), radius=hw, color=self.color)
         )
 
         # bokeh plot - coordinates to plot disks elements

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1070,7 +1070,7 @@ class Rotor(object):
 
         return results
 
-    def forced_response(self, force=None, frequency_range=None, modes=None):
+    def run_forced_response(self, force=None, frequency_range=None, modes=None):
         freq_resp = self.run_freq_response(frequency_range=frequency_range, modes=modes)
 
         forced_resp = np.zeros(
@@ -1150,7 +1150,7 @@ class Rotor(object):
         except TypeError:
             force = self._unbalance_force(node, magnitude, phase, frequency_range)
 
-        forced_response = self.forced_response(force, frequency_range)
+        forced_response = self.run_forced_response(force, frequency_range)
 
         return forced_response
 
@@ -1212,13 +1212,13 @@ class Rotor(object):
         # check slenderness ratio of beam elements
         SR = np.array([])
         for shaft in self.shaft_elements:
-            if shaft.slenderness_ratio < 30:
+            if shaft.slenderness_ratio < 1.6:
                 SR = np.append(SR, shaft.n)
         if len(SR) != 0:
             warnings.warn(
                 "The beam elements "
                 + str(SR)
-                + " have slenderness ratio (G*A*L^2 / EI) greater than 30."
+                + " have slenderness ratio (G*A*L^2 / EI) of less than 1.6."
                 + " Results may not converge correctly"
             )
 
@@ -1335,7 +1335,7 @@ class Rotor(object):
 
         return bk_ax, ax
 
-    def campbell(self, speed_range, frequencies=6, frequency_type="wd"):
+    def run_campbell(self, speed_range, frequencies=6, frequency_type="wd"):
         """Calculates the Campbell diagram.
 
         This function will calculate the damped natural frequencies
@@ -1401,7 +1401,7 @@ class Rotor(object):
 
         return results
 
-    def mode_shapes(self):
+    def run_mode_shapes(self):
 
         kappa_modes = []
         for mode in range(len(self.wn)):
@@ -1792,7 +1792,7 @@ class Rotor(object):
     def remove(rotor_name):
         shutil.rmtree(Path(os.path.dirname(ross.__file__)) / "rotors" / rotor_name)
 
-    def static(self):
+    def run_static(self):
         # gravity aceleration vector
         grav = np.zeros((len(self.M()), 1))
 

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1570,6 +1570,69 @@ def test_static_analysis_rotor6(rotor6):
     )
 
 
+def test_from_section():
+    #  Rotor built from classmethod from_section
+    #  2 disks and 2 bearings
+    leng_data = [0.5, 1.0, 2.0, 1.0, 0.5]
+    leng_data2 = [0.5, 1.0, 2.0, 1.0]
+    o_ds_data = [0.1, 0.2, 0.3, 0.2, 0.1]
+    o_ds_data2 = [0.1, 0.2, 0.3, 0.2]    
+    i_ds_data = [0, 0, 0, 0, 0]
+    disk_data = [
+        DiskElement.from_geometry(n=2, material=steel, width=0.07, i_d=0.05, o_d=0.28),
+        DiskElement.from_geometry(n=3, material=steel, width=0.07, i_d=0.05, o_d=0.35),
+    ]
+    brg_seal_data = [
+        BearingElement(n=0, kxx=1e6, cxx=0, kyy=1e6, cyy=0),
+        BearingElement(n=5, kxx=1e6, cxx=0, kyy=1e6, cyy=0),
+    ]
+
+    rotor1 = Rotor.from_section(
+        leng_data=leng_data,
+        o_ds_data=o_ds_data,
+        i_ds_data=i_ds_data,
+        disk_data=disk_data,
+        brg_seal_data=brg_seal_data,
+        w=0,
+        nel_r=4,
+    )
+
+    assert_allclose(len(rotor1.shaft_elements), 20, atol=0)
+    assert_allclose(rotor1.shaft_elements[0].L, 0.125, atol=0)
+    assert_allclose(rotor1.shaft_elements[4].L, 0.25, atol=0)
+    assert_allclose(rotor1.shaft_elements[8].L, 0.5, atol=0)
+    assert_allclose(rotor1.shaft_elements[12].L, 0.25, atol=0)
+    assert_allclose(rotor1.shaft_elements[16].L, 0.125, atol=0)
+    assert_allclose(rotor1.disk_elements[0].n, 8, atol=0)
+    assert_allclose(rotor1.disk_elements[1].n, 12, atol=0)
+    assert_allclose(rotor1.bearing_seal_elements[0].n, 0, atol=0)
+    assert_allclose(rotor1.bearing_seal_elements[1].n, 20, atol=0)
+
+    with pytest.raises(ValueError) as excinfo:
+        Rotor.from_section(
+            leng_data=leng_data2,
+            o_ds_data=o_ds_data,
+            i_ds_data=i_ds_data,
+            disk_data=disk_data,
+            brg_seal_data=brg_seal_data,
+            w=0,
+            nel_r=4,
+        )
+    assert "The matrices lenght do not match." == str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        Rotor.from_section(
+            leng_data=leng_data,
+            o_ds_data=o_ds_data2,
+            i_ds_data=i_ds_data,
+            disk_data=disk_data,
+            brg_seal_data=brg_seal_data,
+            w=0,
+            nel_r=4,
+        )
+    assert "The matrices lenght do not match." == str(excinfo.value)
+
+
 def test_save_load():
 
     a = rotor_example()

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1246,7 +1246,7 @@ def test_evals_rotor3_rotor4(rotor3, rotor4):
 
 def test_campbell(rotor4):
     speed = np.linspace(0, 300, 3)
-    camp = rotor4.campbell(speed)[:, :, 0]
+    camp = rotor4.run_campbell(speed)[:, :, 0]
     camp_desired = np.array(
         [
             [
@@ -1339,11 +1339,11 @@ def test_freq_response(rotor4):
     )
 
     omega = np.linspace(0.0, 450.0, 4)
-    freq_resp = rotor4.freq_response(frequency_range=omega)
+    freq_resp = rotor4.run_freq_response(frequency_range=omega)
     magdb = 20.0 * np.log10(freq_resp.magnitude)
     assert_allclose(magdb[:4, :4, :4], magdb_exp)
 
-    freq_resp = rotor4.freq_response(frequency_range=omega, modes=list(range(4)))
+    freq_resp = rotor4.run_freq_response(frequency_range=omega, modes=list(range(4)))
     magdb = 20.0 * np.log10(freq_resp.magnitude)
     assert_allclose(magdb[:4, :4, :4], magdb_exp_modes_4)
 
@@ -1400,7 +1400,7 @@ def test_freq_response_w_force(rotor4):
     )
 
     omega = np.linspace(0.0, 450.0, 4)
-    freq_resp = rotor4.forced_response(force=F0, frequency_range=omega)
+    freq_resp = rotor4.run_forced_response(force=F0, frequency_range=omega)
     mag = freq_resp.magnitude
     assert_allclose(mag[:4, :4], mag_exp)
 
@@ -1447,7 +1447,7 @@ def test_mesh_convergence(rotor3):
 
 
 def test_static_analysis_rotor3(rotor3):
-    rotor3.static()
+    rotor3.run_static()
 
     assert_almost_equal(
         rotor3.disp_y,
@@ -1495,7 +1495,7 @@ def rotor5():
 
 
 def test_static_analysis_rotor5(rotor5):
-    rotor5.static()
+    rotor5.run_static()
 
     assert_almost_equal(
         rotor5.disp_y,
@@ -1547,7 +1547,7 @@ def rotor6():
 
 
 def test_static_analysis_rotor6(rotor6):
-    rotor6.static()
+    rotor6.run_static()
 
     assert_almost_equal(
         rotor6.disp_y,


### PR DESCRIPTION
This is mostly to add "run_" to some Rotor methods, like:
* campbell;
* forced_response;
* mode_shape;
* static

Also, change the value to evaluate the slenderness ratio (SR) to 1.6. Since our convergence analysis have shown good results even for SR < 30, I decided changing it for 1.6, which is equivalent to a length / diameter ratio of 0.5.