### PR TITLE
This removes the requirements.txt file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - python: 3.7
 
 install:
-  - pip install -r requirements.txt
+  - pip install -e .[dev]
 
 script:
   - pytest ross

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     - PYTHON: "C:\\Python37-x64"
 
 install:
-  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install -e .[dev]"
 
 build: off
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,9 +137,9 @@ html_theme_options = {
     # Note the "1" or "True" value above as the third argument to indicate
     # an arbitrary url.
     "navbar_links": [
-        ("Tutorial", "tutorial/index"),
-        ("Examples", "gallery/index"),
-        ("API", "api/index"),
+        ("Tutorial", "examples/tutorial"),
+        ("Examples", "examples"),
+        ("API", "api"),
     ],
     # Render the next and previous page links in navbar. (Default: true)
     "navbar_sidebarrel": False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-numpy
-scipy
-matplotlib
-seaborn
-bokeh
-xlrd
-toml
-pytest

--- a/setup.py
+++ b/setup.py
@@ -45,16 +45,13 @@ REQUIRED = [
     "matplotlib",
     "toml",
     "pandas",
-    "pytest",
     "bokeh",
     "coverage",
     "xlrd",
 ]
 
 # What packages are optional?
-EXTRAS = {
-    # 'fancy feature': ['django'],
-}
+EXTRAS = {"dev": ["pytest"]}
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------


### PR DESCRIPTION
This removes the requirements file avoiding the need to have the
dependencies listed in two different files.
With the modifications the user can install with:
`$ pip install .`
And a developer can use:
`$ pip install -e .[dev]`
which is also used on the appveyor/travis files.