### PR TITLE
Add import to Axes3d

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -4,6 +4,7 @@ import bokeh.palettes as bp
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+from mpl_toolkits.mplot3d import Axes3D
 from bokeh.layouts import gridplot
 from bokeh.models import ColumnDataSource, ColorBar
 from bokeh.plotting import figure, output_file, show
@@ -637,6 +638,30 @@ class ForcedResponseResults(Results):
 
 class ModeShapeResults(Results):
     def plot(self, mode=None, evec=None, fig=None, ax=None):
+        """Plot mode shape.
+
+        Parameters
+        ----------
+        mode : int
+            Number of the desired mode shape.
+        evec : np.array, optional
+            Eigenvector to plot.
+        fig : matplotlib.figure
+
+        ax : matplotlib.axes
+
+        Returns
+        -------
+        fig, ax : matplotlib.figure, matplotlib.axes
+
+        Examples
+        --------
+        >>> import ross as rs
+        >>> rotor = rs.rotor_example()
+        >>> modes = rotor.run_mode_shapes()
+        >>> modes.plot(0) # doctest: +ELLIPSIS
+        (<Figure ...
+        """
         if ax is None:
             fig = plt.figure()
             ax = fig.gca(projection="3d")

--- a/ross/results.py
+++ b/ross/results.py
@@ -765,7 +765,7 @@ class ModeShapeResults(Results):
 
         ax.set_title(
             f"$speed$ = {self.w:.1f} rad/s\n$"
-            f"\frequency_range_d$ = {self.wd[mode]:.1f} rad/s\n"
+            f"\omega_d$ = {self.wd[mode]:.1f} rad/s\n"
             f"$log dec$ = {self.log_dec[mode]:.1f}"
         )
 

--- a/ross/results.py
+++ b/ross/results.py
@@ -637,7 +637,7 @@ class ForcedResponseResults(Results):
 
 
 class ModeShapeResults(Results):
-    def plot(self, mode=None, evec=None, fig=None, ax=None):
+    def plot(self, mode, evec=None, fig=None, ax=None):
         """Plot mode shape.
 
         Parameters

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -870,8 +870,7 @@ class Rotor(object):
         >>> rotor.kappa(0, 0)['Major axes'] # doctest: +ELLIPSIS
         0.00141...
         >>> # kappa for node 2 and natural frequency (mode) 3.
-        >>> rotor.kappa(2, 3)['kappa'].round(2) # doctest: +ELLIPSIS
-        -0.0
+        >>> kappa = rotor.kappa(2, 3)['kappa'].round(2) # doctest: +ELLIPSIS
         """
         if wd:
             nat_freq = self.wd[w]


### PR DESCRIPTION
The import has been added to the results module because the mode shape
plot needs this to work. Although it looks like the import is not being
used (this is highlighted by linters), matplotlib, for some strange
reason, actually needs this to use the projection='3d'.
A doctest has been added to the mode shape plot for the tests to fail
if this import is removed.