### PR TITLE
Fix equality for bearing element

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -199,26 +199,26 @@ class BearingElement(Element):
         )
 
     def __eq__(self, other):
-        try:
-            if pytest.approx(self.__dict__) == other.__dict__:
-                return True
-            else:
-                return False
-
-        except TypeError:
-
-            self_dict = self.__dict__
-            other_dict = other.__dict__
-
-            self_dict["w"] = 0
-            other_dict["w"] = 0
-
-            if (
-                self.__dict__["w"] == other.__dict__["w"]
-            ).__bool__() and self_dict == other_dict:
-                return True
-            else:
-                return False
+        compared_attributes = [
+            "kxx",
+            "kyy",
+            "kxy",
+            "kyx",
+            "cxx",
+            "cyy",
+            "cxy",
+            "cyx",
+            "w",
+        ]
+        if isinstance(other, self.__class__):
+            return all(
+                (
+                    np.array(getattr(self, attr)).all()
+                    == np.array(getattr(other, attr)).all()
+                    for attr in compared_attributes
+                )
+            )
+        return False
 
     def save(self, file_name):
         data = self.load_data(file_name)

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -132,3 +132,10 @@ def bearing_constant():
 def test_bearing_constant(bearing_constant):
     assert_allclose(bearing_constant.kxx.interpolated(314.2), 8e7, rtol=1e5)
     assert_allclose(bearing_constant.cxx.interpolated(300.9), 0, rtol=1e5)
+
+
+def test_equality(bearing0, bearing1, bearing_constant):
+    assert bearing0 == bearing0
+    assert bearing0 == bearing1
+    assert not bearing0 == bearing_constant
+    assert not bearing0 == 1


### PR DESCRIPTION
Fixes the equality for bearing element, allowing the comparison with
objects from different types, e.g. bearing == 1 will return False,
before an AttributeError was raised since int doesn't have .__dict__.
This also removes pytest as a dependence for the user.