### PR TITLE
Add test to rotor_example eigenvalues sort

### DIFF
--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -50,6 +50,14 @@ def test_index_eigenvalues_rotor1(rotor1):
     assert_almost_equal([4, 2, 0, 1, 3, 5], rotor1._index(evalues2))
 
 
+def test_evals_sorted_rotor_example():
+    rotor = rotor_example()
+    evalues, evectors = rotor._eigen(0, sorted_=False)
+    idx = rotor._index(evalues)
+    expected_idx = np.array([1, 3, 5, 7, 9, 11])
+    assert_allclose(expected_idx, idx[:6])
+
+
 def test_mass_matrix_rotor1(rotor1):
     # fmt: off
     Mr1 = np.array([[ 1.421,  0.   ,  0.   ,  0.049,  0.496,  0.   ,  0.   , -0.031,  0.   ,  0.   ,  0.   ,  0.   ],
@@ -1205,7 +1213,7 @@ def test_H_kappa(rotor7):
     )
     assert_allclose(
         rotor7.H_kappa(3, 0),
-        [[ 5.92899683e-06, -1.24262274e-17], [-1.24262274e-17, 5.92899683e-06]],
+        [[5.92899683e-06, -1.24262274e-17], [-1.24262274e-17, 5.92899683e-06]],
         rtol=1e-2,
     )
     assert_allclose(


### PR DESCRIPTION
The purpose of this test is to check if the index of the sorted
eigenvalues are the same on windows and linux.
Values were different when trying doctest.

Closes #145 

