### PR TITLE
Fix code coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-addopts = --doctest-modules
-
+addopts = --doctest-modules --cov=ross ross/tests/

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ REQUIRED = [
 ]
 
 # What packages are optional?
-EXTRAS = {"dev": ["pytest"]}
+EXTRAS = {"dev": ["pytest", "codecov"]}
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ REQUIRED = [
 ]
 
 # What packages are optional?
-EXTRAS = {"dev": ["pytest", "pytest-cov", "codecov"]}
+EXTRAS = {"dev": ["pytest", "pytest-cov", "coverage", "codecov"]}
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ REQUIRED = [
 ]
 
 # What packages are optional?
-EXTRAS = {"dev": ["pytest", "codecov"]}
+EXTRAS = {"dev": ["pytest", "pytest-cov", "codecov"]}
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------


### PR DESCRIPTION
Code coverage is broken due to commit 97956c9 which removed the codecov
from the travisci installation packages.
Closes #235 