### PR TITLE
Replace bearing plot style / remove element length dependency from glyphs

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -316,7 +316,7 @@ class BearingElement(Element):
 
         return G
 
-    def patch(self, position, ax, **kwargs):
+    def patch(self, position, mean, ax, **kwargs):
         """Bearing element patch.
         Patch that will be used to draw the bearing element.
 
@@ -324,6 +324,8 @@ class BearingElement(Element):
         ----------
         position : tuple
             Position (z, y) in which the patch will be drawn.
+        mean : float
+            Mean value of shaft element outer diameters
         ax : matplotlib axes, optional
             Axes in which the plot will be drawn.
 
@@ -336,20 +338,21 @@ class BearingElement(Element):
 
         # geometric factors
         zpos, ypos = position
-        coils = 6
-        step = ypos / 4
+        coils = 6               # number of points to generate spring
+        step = mean / 5         # spring step
         a = 2.2                 # range(1.8 to 2.8)
-        b = 1.5                 # range(1.2 to 1.5)
-        c = ypos / 2.7
-        d = (coils / a)*step
+        b = 1.4                 # range(1.2 to 1.5)
+        c = mean / 2.9          # defines width
+        d = (coils / a)*step    # modifies damper width
+        n = 5                   # number of ground lines
 
         zs0 = zpos - c
         zs1 = zpos + c
-        ys0 = b * ypos
+        ys0 = ypos + mean / 2
 
         # plot bottom base
-        x_bot = [zpos, zpos, zpos-c, zpos+c]
-        yl_bot = [ypos, b*ypos, b*ypos, b*ypos]
+        x_bot = [zpos, zpos, zs0, zs1]
+        yl_bot = [ypos, ys0, ys0, ys0]
         yu_bot = [-y for y in yl_bot]
         ax.add_line(mlines.Line2D(x_bot, yl_bot, **kwargs))
         ax.add_line(mlines.Line2D(x_bot, yu_bot, **kwargs))
@@ -366,6 +369,21 @@ class BearingElement(Element):
 
         ax.add_line(mlines.Line2D(x_top, yl_top, **kwargs))
         ax.add_line(mlines.Line2D(x_top, yu_top, **kwargs))
+
+        # plot ground
+        zl_g = [zs0 - step, zs1 + step]
+        yl_g = [yl_top[0], yl_top[0]]
+        yu_g = [-y for y in yl_g]
+        ax.add_line(mlines.Line2D(zl_g, yl_g, **kwargs))
+        ax.add_line(mlines.Line2D(zl_g, yu_g, **kwargs))
+
+        step2 = (zl_g[1] - zl_g[0]) / n
+        for i in range(n + 1):
+            zl_g2 = [(zs0 - step) + step2*(i), (zs0 - step) + step2*(i+1)]
+            yl_g2 = [yl_g[0], 1.1 * yl_g[0]]
+            yu_g2 = [-y for y in yl_g2]
+            ax.add_line(mlines.Line2D(zl_g2, yl_g2, **kwargs))
+            ax.add_line(mlines.Line2D(zl_g2, yu_g2, **kwargs))
 
         # plot spring
         z_spring = np.array([zs0, zs0, zs0, zs0])
@@ -386,7 +404,7 @@ class BearingElement(Element):
         ax.add_line(mlines.Line2D(z_spring, yu_spring, **kwargs))
 
         # plot damper
-        z_damper1 = [zpos + c, zpos + c]
+        z_damper1 = [zs1, zs1]
         yl_damper1 = [ys0, ys0 + d]
         yu_damper1 = [-y for y in yl_damper1]
 
@@ -412,7 +430,7 @@ class BearingElement(Element):
         ax.add_line(mlines.Line2D(z_damper3, yl_damper3, **kwargs))
         ax.add_line(mlines.Line2D(z_damper3, yu_damper3, **kwargs))
 
-    def bokeh_patch(self, position, bk_ax, **kwargs):
+    def bokeh_patch(self, position, mean, bk_ax, **kwargs):
         """Bearing element patch.
         Patch that will be used to draw the bearing element.
 
@@ -420,6 +438,8 @@ class BearingElement(Element):
         ----------
         position : tuple
             Position (z, y) in which the patch will be drawn.
+        mean : float
+            Mean value of shaft element outer diameters
         bk_ax : bokeh plotting axes, optional
             Axes in which the plot will be drawn.
 
@@ -432,20 +452,21 @@ class BearingElement(Element):
 
         # geometric factors
         zpos, ypos = position
-        coils = 6
-        step = ypos / 4
+        coils = 6               # number of points to generate spring
+        step = mean / 5         # spring step
         a = 2.2                 # range(1.8 to 2.8)
-        b = 1.5                 # range(1.2 to 1.5)
-        c = ypos / 2.7
-        d = (coils / a)*step
+        b = 1.4                 # range(1.2 to 1.5)
+        c = mean / 2.9          # defines width
+        d = (coils / a)*step    # modifies damper width
+        n = 5                   # number of ground lines
 
         zs0 = zpos - c
         zs1 = zpos + c
-        ys0 = b * ypos
+        ys0 = ypos + mean / 2
 
         # plot bottom base
-        x_bot = [zpos, zpos,   zpos-c, zpos+c]
-        yl_bot = [ypos, b*ypos, b*ypos, b*ypos]
+        x_bot = [zpos, zpos, zs0, zs1]
+        yl_bot = [ypos, ys0, ys0, ys0]
         yu_bot = [-y for y in yl_bot]
         bk_ax.line(x=x_bot, y=yl_bot, **kwargs)
         bk_ax.line(x=x_bot, y=yu_bot, **kwargs)
@@ -462,6 +483,21 @@ class BearingElement(Element):
 
         bk_ax.line(x=x_top, y=yl_top, legend="Bearing", **kwargs)
         bk_ax.line(x=x_top, y=yu_top, legend="Bearing", **kwargs)
+
+        # plot ground
+        zl_g = [zs0 - step, zs1 + step]
+        yl_g = [yl_top[0], yl_top[0]]
+        yu_g = [-y for y in yl_g]
+        bk_ax.line(x=zl_g, y=yl_g, **kwargs)
+        bk_ax.line(x=zl_g, y=yu_g, **kwargs)
+
+        step2 = (zl_g[1] - zl_g[0]) / n
+        for i in range(n+1):
+            zl_g2 = [(zs0 - step) + step2*(i), (zs0 - step) + step2*(i+1)]
+            yl_g2 = [yl_g[0], 1.1 * yl_g[0]]
+            yu_g2 = [-y for y in yl_g2]
+            bk_ax.line(x=zl_g2, y=yl_g2, **kwargs)
+            bk_ax.line(x=zl_g2, y=yu_g2, **kwargs)
 
         # plot spring
         z_spring = np.array([zs0, zs0, zs0, zs0])
@@ -482,7 +518,7 @@ class BearingElement(Element):
         bk_ax.line(x=z_spring, y=yu_spring, **kwargs)
 
         # plot damper
-        z_damper1 = [zpos + c, zpos + c]
+        z_damper1 = [zs1, zs1]
         yl_damper1 = [ys0, ys0 + d]
         yu_damper1 = [-y for y in yl_damper1]
 

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -3,6 +3,7 @@ import warnings
 import bokeh.palettes as bp
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
+import matplotlib.lines as mlines
 import numpy as np
 import scipy.interpolate as interpolate
 
@@ -315,91 +316,197 @@ class BearingElement(Element):
 
         return G
 
-    def patch(self, position, length, ax):
+    def patch(self, position, ax, **kwargs):
         """Bearing element patch.
         Patch that will be used to draw the bearing element.
 
         Parameters
         ----------
-        ax : matplotlib axes, optional
-            Axes in which the plot will be drawn.
-        bk_ax : bokeh plotting axes, optional
-            Axes in which the plot will be drawn.
         position : tuple
             Position (z, y) in which the patch will be drawn.
+        ax : matplotlib axes, optional
+            Axes in which the plot will be drawn.
+
         Returns
         -------
         """
+        default_values = dict(lw=1., alpha=1., c='k')
+        for k, v in default_values.items():
+            kwargs.setdefault(k, v)
+
+        # geometric factors
         zpos, ypos = position
-        step = ypos / 3
+        coils = 6
+        step = ypos / 4
+        a = 2.2                 # range(1.8 to 2.8)
+        b = 1.5                 # range(1.2 to 1.5)
+        c = ypos / 2.7
+        d = (coils / a)*step
 
-        #  node (x pos), outer diam. (y pos)
-        bearing_points_u = [
-            [zpos - step, ypos],  # upper
-            [zpos - step, ypos + 2*step],
-            [zpos + step, ypos + 2*step],
-            [zpos + step, ypos],
-            [zpos - step, ypos],
+        zs0 = zpos - c
+        zs1 = zpos + c
+        ys0 = b * ypos
+
+        # plot bottom base
+        x_bot = [zpos, zpos, zpos-c, zpos+c]
+        yl_bot = [ypos, b*ypos, b*ypos, b*ypos]
+        yu_bot = [-y for y in yl_bot]
+        ax.add_line(mlines.Line2D(x_bot, yl_bot, **kwargs))
+        ax.add_line(mlines.Line2D(x_bot, yu_bot, **kwargs))
+
+        # plot top base
+        x_top = [zpos, zpos, zs0, zs1]
+        yl_top = [
+            b * ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step
         ]
-        bearing_points_l = [
-            [zpos - step, -ypos],  # upper
-            [zpos - step, -ypos - 2*step],
-            [zpos + step, -ypos - 2*step],
-            [zpos + step, -ypos],
-            [zpos - step, -ypos],
+        yu_top = [-y for y in yl_top]
+
+        ax.add_line(mlines.Line2D(x_top, yl_top, **kwargs))
+        ax.add_line(mlines.Line2D(x_top, yu_top, **kwargs))
+
+        # plot spring
+        z_spring = np.array([zs0, zs0, zs0, zs0])
+        yl_spring = np.array(
+            [ys0,
+             ys0 + step,
+             ys0 + coils * step,
+             ys0 + (coils + 1) * step
+             ]
+        )
+
+        for i in range(coils):
+            z_spring = np.insert(z_spring, i + 2, zs0 - (-1) ** i * step)
+            yl_spring = np.insert(yl_spring, i + 2, ys0 + (i + 1) * step)
+        yu_spring = [-y for y in yl_spring]
+
+        ax.add_line(mlines.Line2D(z_spring, yl_spring, **kwargs))
+        ax.add_line(mlines.Line2D(z_spring, yu_spring, **kwargs))
+
+        # plot damper
+        z_damper1 = [zpos + c, zpos + c]
+        yl_damper1 = [ys0, ys0 + d]
+        yu_damper1 = [-y for y in yl_damper1]
+
+        ax.add_line(mlines.Line2D(z_damper1, yl_damper1, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper1, yu_damper1, **kwargs))
+
+        z_damper2 = [zs1 - step, zs1 - step, zs1 + step, zs1 + step]
+        yl_damper2 = [ys0 + 2 * d, ys0 + d, ys0 + d, ys0 + 2 * d]
+        yu_damper2 = [-y for y in yl_damper2]
+
+        ax.add_line(mlines.Line2D(z_damper2, yl_damper2, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper2, yu_damper2, **kwargs))
+
+        z_damper3 = [zs1 - step, zs1 + step, zs1, zs1]
+        yl_damper3 = [
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + (coils + 1) * step
         ]
+        yu_damper3 = [-y for y in yl_damper3]
 
-        ax.add_patch(
-            mpatches.Polygon(bearing_points_u, color=self.color, picker=True)
-        )
-        ax.add_patch(
-            mpatches.Polygon(bearing_points_l, color=self.color, picker=True)
-        )
+        ax.add_line(mlines.Line2D(z_damper3, yl_damper3, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper3, yu_damper3, **kwargs))
 
-    def bokeh_patch(self, position, length, bk_ax):
+    def bokeh_patch(self, position, bk_ax, **kwargs):
         """Bearing element patch.
         Patch that will be used to draw the bearing element.
 
         Parameters
         ----------
-        ax : matplotlib axes, optional
-            Axes in which the plot will be drawn.
-        bk_ax : bokeh plotting axes, optional
-            Axes in which the plot will be drawn.
         position : tuple
             Position (z, y) in which the patch will be drawn.
-        length : float
-            minimum length of shaft elements
+        bk_ax : bokeh plotting axes, optional
+            Axes in which the plot will be drawn.
 
         Returns
         -------
         """
-        zpos, ypos = position
-        step = ypos / 3
+        default_values = dict(line_width=3, line_alpha=1, color=bokeh_colors[1])
+        for k, v in default_values.items():
+            kwargs.setdefault(k, v)
 
-        # bokeh plot - upper bearing visual representation
-        bk_ax.quad(
-            top=ypos + 2*step,
-            bottom=ypos,
-            left=zpos - step,
-            right=zpos + step,
-            line_color=bokeh_colors[0],
-            line_width=1,
-            fill_alpha=0.8,
-            fill_color=bokeh_colors[1],
-            legend="Bearing",
+        # geometric factors
+        zpos, ypos = position
+        coils = 6
+        step = ypos / 4
+        a = 2.2                 # range(1.8 to 2.8)
+        b = 1.5                 # range(1.2 to 1.5)
+        c = ypos / 2.7
+        d = (coils / a)*step
+
+        zs0 = zpos - c
+        zs1 = zpos + c
+        ys0 = b * ypos
+
+        # plot bottom base
+        x_bot = [zpos, zpos,   zpos-c, zpos+c]
+        yl_bot = [ypos, b*ypos, b*ypos, b*ypos]
+        yu_bot = [-y for y in yl_bot]
+        bk_ax.line(x=x_bot, y=yl_bot, **kwargs)
+        bk_ax.line(x=x_bot, y=yu_bot, **kwargs)
+
+        # plot top base
+        x_top = [zpos, zpos, zs0, zs1]
+        yl_top = [
+            b * ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step
+        ]
+        yu_top = [-y for y in yl_top]
+
+        bk_ax.line(x=x_top, y=yl_top, legend="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yu_top, legend="Bearing", **kwargs)
+
+        # plot spring
+        z_spring = np.array([zs0, zs0, zs0, zs0])
+        yl_spring = np.array(
+            [ys0,
+             ys0 + step,
+             ys0 + coils * step,
+             ys0 + (coils + 1) * step
+             ]
         )
-        # bokeh plot - lower bearing visual representation
-        bk_ax.quad(
-            top=-ypos,
-            bottom=-ypos - 2*step,
-            left=zpos - step,
-            right=zpos + step,
-            line_color=bokeh_colors[0],
-            line_width=1,
-            fill_alpha=0.8,
-            fill_color=bokeh_colors[1],
-        )
+
+        for i in range(coils):
+            z_spring = np.insert(z_spring, i + 2, zs0 - (-1) ** i * step)
+            yl_spring = np.insert(yl_spring, i + 2, ys0 + (i + 1) * step)
+        yu_spring = [-y for y in yl_spring]
+
+        bk_ax.line(x=z_spring, y=yl_spring, **kwargs)
+        bk_ax.line(x=z_spring, y=yu_spring, **kwargs)
+
+        # plot damper
+        z_damper1 = [zpos + c, zpos + c]
+        yl_damper1 = [ys0, ys0 + d]
+        yu_damper1 = [-y for y in yl_damper1]
+
+        bk_ax.line(x=z_damper1, y=yl_damper1, **kwargs)
+        bk_ax.line(x=z_damper1, y=yu_damper1, **kwargs)
+
+        z_damper2 = [zs1 - step, zs1 - step, zs1 + step, zs1 + step]
+        yl_damper2 = [ys0 + 2 * d, ys0 + d, ys0 + d, ys0 + 2 * d]
+        yu_damper2 = [-y for y in yl_damper2]
+
+        bk_ax.line(x=z_damper2, y=yl_damper2, **kwargs)
+        bk_ax.line(x=z_damper2, y=yu_damper2, **kwargs)
+
+        z_damper3 = [zs1 - step, zs1 + step, zs1, zs1]
+        yl_damper3 = [
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + (coils + 1) * step
+        ]
+        yu_damper3 = [-y for y in yl_damper3]
+
+        bk_ax.line(x=z_damper3, y=yl_damper3, **kwargs)
+        bk_ax.line(x=z_damper3, y=yu_damper3, **kwargs)
 
     @classmethod
     def table_to_toml(cls, n, file):

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -165,7 +165,7 @@ class DiskElement(Element):
         # fmt: on
         return G
 
-    def patch(self, position, length, ax):
+    def patch(self, position, ax):
         """Disk element patch.
         Patch that will be used to draw the disk element.
         Parameters
@@ -206,7 +206,7 @@ class DiskElement(Element):
             mpatches.Circle(xy=(zpos, -ypos*4), radius=step, color=self.color)
         )
 
-    def bokeh_patch(self, position, length, bk_ax):
+    def bokeh_patch(self, position, bk_ax):
         """Disk element patch.
         Patch that will be used to draw the disk element.
         Parameters

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1212,10 +1212,11 @@ class Rotor(object):
             position = (self.nodes_pos[disk.n], self.nodes_o_d[disk.n] / 2)
             disk.patch(position, ax)
 
+        mean_od = np.mean(self.nodes_o_d)
         # plot bearings
         for bearing in self.bearing_seal_elements:
             position = (self.nodes_pos[bearing.n], self.nodes_o_d[bearing.n] / 2)
-            bearing.patch(position, ax)
+            bearing.patch(position, mean_od, ax)
 
         return ax
 
@@ -1311,10 +1312,11 @@ class Rotor(object):
 
         bk_ax.add_tools(hover)
 
+        mean_od = np.mean(self.nodes_o_d) / 2
         # plot bearings
         for bearing in self.bearing_seal_elements:
             position = (self.nodes_pos[bearing.n], self.nodes_o_d[bearing.n] / 2)
-            bearing.bokeh_patch(position, bk_ax)
+            bearing.bokeh_patch(position, mean_od, bk_ax)
 
         show(bk_ax)
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -259,7 +259,7 @@ class Rotor(object):
         nodes_i_d.append(df_shaft["i_d"].iloc[-1])
         self.nodes_i_d = nodes_i_d
 
-        nodes_o_d = list(df_shaft.groupby("n_l")["o_d"].min())
+        nodes_o_d = list(df_shaft.groupby("n_l")["o_d"].max())
         nodes_o_d.append(df_shaft["o_d"].iloc[-1])
         self.nodes_o_d = nodes_o_d
 
@@ -1141,6 +1141,7 @@ class Rotor(object):
         --------
         """
         return signal.lsim(self.lti, F, t, X0=ic)
+
     def _plot_rotor_matplotlib(self, nodes=1, check_sld=False, ax=None):
         """Plots a rotor object.
 
@@ -1209,14 +1210,12 @@ class Rotor(object):
         # plot disk elements
         for disk in self.disk_elements:
             position = (self.nodes_pos[disk.n], self.nodes_o_d[disk.n] / 2)
-            length = min(self.nodes_le)
-            disk.patch(position, length, ax)
+            disk.patch(position, ax)
 
         # plot bearings
         for bearing in self.bearing_seal_elements:
-            position = (self.nodes_pos[bearing.n], -self.nodes_o_d[bearing.n] / 2)
-            length = min(self.nodes_le)
-            bearing.patch(position, length, ax)
+            position = (self.nodes_pos[bearing.n], self.nodes_o_d[bearing.n] / 2)
+            bearing.patch(position, ax)
 
         return ax
 
@@ -1308,16 +1307,14 @@ class Rotor(object):
         # plot disk elements
         for disk in self.disk_elements:
             position = (self.nodes_pos[disk.n], self.nodes_o_d[disk.n] / 2)
-            length = min(self.nodes_le)
-            hover = disk.bokeh_patch(position, length, bk_ax)
+            hover = disk.bokeh_patch(position, bk_ax)
 
         bk_ax.add_tools(hover)
 
         # plot bearings
         for bearing in self.bearing_seal_elements:
-            position = (self.nodes_pos[bearing.n], -self.nodes_o_d[bearing.n] / 2)
-            length = min(self.nodes_le)
-            bearing.bokeh_patch(position, length, bk_ax)
+            position = (self.nodes_pos[bearing.n], self.nodes_o_d[bearing.n] / 2)
+            bearing.bokeh_patch(position, bk_ax)
 
         show(bk_ax)
 


### PR DESCRIPTION
- Bearing representation changes from a simple square to a spring-damper set.
- Fix bug glyphs were plotted on the minimum outer diameters of a shaft node.
- Removes length attribute from `patch()` and `bokeh_patch()` of BearingElement and DiskElement classes.

Bokeh plot
![bokeh_plot(2)](https://user-images.githubusercontent.com/45969994/62865813-ce870a80-bce5-11e9-84ae-243a21b2006c.png)

Matplotlib plot
![Figure_1](https://user-images.githubusercontent.com/45969994/62865820-d34bbe80-bce5-11e9-81ca-4a73ad6057e2.png)

