### PR TITLE
Change codecov to run only on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install -e .[dev]
 
 script:
-  - pytest ross
+  - pytest ross --cov=ross
 
 after_success:
   - codecov

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules --cov=ross ross/tests/
+addopts = --doctest-modules


### PR DESCRIPTION
This changes the pytest.ini file and the .travis.yml file so that
pytest-cov will run only on travis. If the user wants to run locally,
they will have to call $pytest --cov=ross.