### PR TITLE
Add test materials

### DIFF
--- a/ross/materials.py
+++ b/ross/materials.py
@@ -4,7 +4,7 @@ This module defines the Material class and defines
 some of the most common materials used in rotors.
 """
 import os
-
+import numpy as np
 import toml
 
 import ross as rs
@@ -68,17 +68,19 @@ class Material:
 
     def __eq__(self, other):
         """Material is considered equal if properties are equal."""
+        self_list = [v for v in self.__dict__.values() if isinstance(v, (float, int))]
+        other_list = [v for v in self.__dict__.values() if isinstance(v, (float, int))]
 
-        if self.__dict__ == other.__dict__:
+        if np.allclose(self_list, other_list):
             return True
         else:
             return False
 
     def __repr__(self):
-        selfE = "{:.2e}".format(self.E)
-        selfPoisson = "{:.2e}".format(self.Poisson)
-        selfrho = "{:.2e}".format(self.rho)
-        selfGs = "{:.2e}".format(self.G_s)
+        selfE = "{:.3e}".format(self.E)
+        selfPoisson = "{:.3e}".format(self.Poisson)
+        selfrho = "{:.3e}".format(self.rho)
+        selfGs = "{:.3e}".format(self.G_s)
 
         return (
             f"Material"

--- a/ross/materials.py
+++ b/ross/materials.py
@@ -67,6 +67,8 @@ class Material:
             self.Poisson = (self.E / (2 * self.G_s)) - 1
 
     def __eq__(self, other):
+        """Material is considered equal if properties are equal."""
+
         if self.__dict__ == other.__dict__:
             return True
         else:
@@ -80,8 +82,8 @@ class Material:
 
         return (
             f"Material"
-            f"(name={self.name}, rho={selfrho}, G_s={selfGs} "
-            f"E={selfE}, Poisson={selfPoisson} color={self.color!r}"
+            f'(name="{self.name}", rho={selfrho}, G_s={selfGs}, '
+            f"E={selfE}, Poisson={selfPoisson}, color={self.color!r})"
         )
 
     def __str__(self):
@@ -159,5 +161,6 @@ class Material:
         data["Materials"][self.name] = self.__dict__
         Material.dump_data(data)
         os.chdir(run_path)
+
 
 steel = Material(name="Steel", rho=7810, E=211e9, G_s=81.2e9)

--- a/ross/tests/test_materials.py
+++ b/ross/tests/test_materials.py
@@ -89,3 +89,9 @@ def test_serialization():
     obj1.remove_material("obj1")
     available_after = Material.available_materials()
     assert available == available_after
+
+
+def test_repr():
+    mat0 = Material(name="obj1", rho=92e1, E=281.21, G_s=20e9)
+    mat1 = eval(repr(mat0))
+    assert mat0 == mat1


### PR DESCRIPTION
Material repr and eq methods have been updated so that the following
will work: mat == eval(repr(mat)).
This is a standard way to test repr methods, since they should be
unambiguous to help debug.

Closes #230 