### PR TITLE
Add new "Tag" attribute to elements

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -119,6 +119,9 @@ class BearingElement(Element):
         (defaults to 0)
     w: array, optional
         Array with the speeds (rad/s).
+     tag : str, optional
+         A tag to name the element
+         Default is None
     Examples
     --------
     >>> # A bearing element located in the first rotor node, with these
@@ -138,7 +141,7 @@ class BearingElement(Element):
     """
 
     def __init__(
-        self, n, kxx, cxx, kyy=None, kxy=0, kyx=0, cyy=None, cxy=0, cyx=0, w=None
+        self, n, kxx, cxx, kyy=None, kxy=0, kyx=0, cyy=None, cxy=0, cyx=0, w=None, tag=None
     ):
 
         args = ["kxx", "kyy", "kxy", "kyx", "cxx", "cyy", "cxy", "cyx"]
@@ -183,6 +186,7 @@ class BearingElement(Element):
         self.n_r = n
 
         self.w = np.array(w, dtype=np.float64)
+        self.tag = tag
         self.color = "#355d7a"
 
     def __repr__(self):
@@ -193,7 +197,7 @@ class BearingElement(Element):
             f" kyx={self.kyx}, kyy={self.kyy},\n"
             f" cxx={self.cxx}, cxy={self.cxy},\n"
             f" cyx={self.cyx}, cyy={self.cyy},\n"
-            f" w={self.w})"
+            f" w={self.w}, tag={self.tag!r})"
         )
 
     def __eq__(self, other):
@@ -237,6 +241,7 @@ class BearingElement(Element):
             "cxy": self.cxy.coefficient,
             "cyx": self.cyx.coefficient,
             "w": w,
+            "tag": self.tag,
         }
         self.dump_data(data, file_name)
 
@@ -721,6 +726,7 @@ class SealElement(BearingElement):
         cyx=0,
         w=None,
         seal_leakage=None,
+        tag=None,
     ):
         super().__init__(
             n=n,
@@ -733,6 +739,7 @@ class SealElement(BearingElement):
             cxy=cxy,
             cyx=cyx,
             cyy=cyy,
+            tag=tag,
         )
 
         self.seal_leakage = seal_leakage

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -24,6 +24,9 @@ class DiskElement(Element):
          Diametral moment of inertia.
      Ip : float
          Polar moment of inertia
+     tag : str, optional
+         A tag to name the element
+         Default is None
      References
      ----------
      .. [1] 'Dynamics of Rotating Machinery' by MI Friswell, JET Penny, SD Garvey
@@ -35,7 +38,7 @@ class DiskElement(Element):
      0.32956362
      """
 
-    def __init__(self, n, m, Id, Ip):
+    def __init__(self, n, m, Id, Ip, tag=None):
         self.n = int(n)
         self.n_l = n
         self.n_r = n
@@ -43,6 +46,7 @@ class DiskElement(Element):
         self.m = m
         self.Id = Id
         self.Ip = Ip
+        self.tag = tag
         self.color = "#bc625b"
 
     def __eq__(self, other):
@@ -70,7 +74,7 @@ class DiskElement(Element):
             f"{self.__class__.__name__}"
             f"(Id={self.Id:{0}.{5}}, Ip={self.Ip:{0}.{5}}, "
             f"m={self.m:{0}.{5}}, color={self.color!r}, "
-            f"n={self.n})"
+            f"n={self.n}, tag={self.tag!r})"
         )
 
     def save(self, file_name):
@@ -80,6 +84,7 @@ class DiskElement(Element):
             "m": self.m,
             "Id": self.Id,
             "Ip": self.Ip,
+            "tag": self.tag,
         }
         self.dump_data(data, file_name)
 
@@ -240,6 +245,7 @@ class DiskElement(Element):
                 IP=[self.Ip],
                 ID=[self.Id],
                 mass=[self.m],
+                tag=[self.tag],
             )
         )
         source_c = ColumnDataSource(
@@ -252,6 +258,7 @@ class DiskElement(Element):
                 IP=[self.Ip],
                 ID=[self.Id],
                 mass=[self.m],
+                tag=[self.tag],
             )
         )
 
@@ -299,13 +306,15 @@ class DiskElement(Element):
             ("Polar Moment of Inertia :", "@IP"),
             ("Diametral Moment of Inertia :", "@ID"),
             ("Disk mass :", "@mass"),
+            ("Tag :", "@tag")
         ]
         hover.mode = "mouse"
 
         return hover
 
+
     @classmethod
-    def from_geometry(cls, n, material, width, i_d, o_d):
+    def from_geometry(cls, n, material, width, i_d, o_d, tag=None):
         """A disk element.
         This class will create a disk element from input data of geometry.
         Parameters
@@ -328,6 +337,9 @@ class DiskElement(Element):
             Diametral moment of inertia.
         Ip : float
             Polar moment of inertia
+        tag : str, optional
+            A tag to name the element
+            Default is None
         References
         ----------
         .. [1] 'Dynamics of Rotating Machinery' by MI Friswell, JET Penny, SD Garvey
@@ -348,7 +360,9 @@ class DiskElement(Element):
         # fmt: on
         Ip = 0.03125 * material.rho * np.pi * width * (o_d ** 4 - i_d ** 4)
 
-        return cls(n, m, Id, Ip)
+        tag = tag
+
+        return cls(n, m, Id, Ip, tag)
 
     @classmethod
     def from_table(cls, file, sheet_name=0):

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -189,6 +189,12 @@ class Rotor(object):
             if disk.tag is None:
                 disk.tag = "Disk " + str(i)
 
+        for i, brg in enumerate(bearing_seal_elements):
+            if brg.__class__.__name__ == "BearingElement" and brg.tag is None:
+                brg.tag = "Bearing " + str(i)
+            if brg.__class__.__name__ == "SealElement" and brg.tag is None:
+                brg.tag = "Seal " + str(i)
+
         self.shaft_elements = shaft_elements
         self.bearing_seal_elements = bearing_seal_elements
         self.disk_elements = disk_elements

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -185,6 +185,10 @@ class Rotor(object):
         if bearing_seal_elements is None:
             bearing_seal_elements = []
 
+        for i, disk in enumerate(disk_elements):
+            if disk.tag is None:
+                disk.tag = "Disk " + str(i)
+
         self.shaft_elements = shaft_elements
         self.bearing_seal_elements = bearing_seal_elements
         self.disk_elements = disk_elements
@@ -212,6 +216,7 @@ class Rotor(object):
             "rho",
             "volume",
             "m",
+            "tag",
         ]
 
         df_shaft = pd.DataFrame([el.summary() for el in self.shaft_elements])


### PR DESCRIPTION
Disk, bearing and seal elements now get an attribute called "Tag".
This allows the user to name the elements to help refer to the actual equipment (impellers, blades, labyrinth seal...)

If the user do not input a tag, it's named after:
- Disk 1, 2, 3... 
- Bearing 1, 2, 3...
- Seal 1, 2, 3...

As bearings and seals are input in the same list of objects, this situation below may happens:
```

def rotor_example():
    i_d = 0
    o_d = 0.05
    n = 6
    L = [0.25 for _ in range(n)]

    shaft_elem = [
        ShaftElement(
            l, i_d, o_d, steel, shear_effects=True, rotary_inertia=True, gyroscopic=True
        )
        for l in L
    ]

    disk0 = DiskElement.from_geometry(
        n=1, material=steel, width=0.07, i_d=0.05, o_d=0.28
    )
    disk1 = DiskElement.from_geometry(
        n=3, material=steel, width=0.07, i_d=0.05, o_d=0.28, tag="disk_test"
    )
    disk2 = DiskElement.from_geometry(
        n=5, material=steel, width=0.07, i_d=0.05, o_d=0.28, tag="disk_test2"
    )

    stfx = 1e8
    stfy = 1e8
    bearing0 = BearingElement(0, kxx=stfx, kyy=stfy, cxx=1000, tag="brg")
    bearing1 = BearingElement(6, kxx=stfx, kyy=stfy, cxx=1000)
    seal0 = SealElement(2, kxx=1e2, kyy=1e2, cxx=500, cyy=500, tag="seal")
    seal1 = SealElement(4, kxx=1e2, kyy=1e2, cxx=500, cyy=500)

    return Rotor(shaft_elem, [disk0, disk1, disk2], [bearing0, seal0, seal1, bearing1])

>>> rotor = rotor_example()
>>> rotor.df_bearings["tag"]
0    brg
1    seal
2    Seal 2
3    Bearing 3
Name: tag, dtype: object
```
The counting for bearings and seals is not independent. I don't see it as big deal, but I'm open to suggestions.
