### PR TITLE
Adapt convergence analysis to ShaftTaperedElement

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -34,7 +34,7 @@ from ross.results import (
     ConvergenceResults,
     TimeResponseResults,
 )
-from ross.shaft_element import ShaftElement
+from ross.shaft_element import ShaftElement, ShaftTaperedElement
 
 __all__ = ["Rotor", "rotor_example"]
 

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -13,7 +13,7 @@ from ross.materials import Material
 from ross.materials import steel
 from ross.utils import read_table_file
 
-__all__ = ["ShaftElement"]
+__all__ = ["ShaftElement", "ShaftTaperedElement"]
 
 bokeh_colors = bp.RdGy[11]
 


### PR DESCRIPTION
Now the convergence analysis uses the class ShaftTaperedElement to generate shaft elements since it's more generic.
This should solve issue #280.