### PR TITLE
Fix modes shape plot

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -95,6 +95,7 @@ class CampbellResults:
         Returns the bokeh axes object with the plot
         if plot_type == "bokeh"
     """
+
     def __init__(self, speed_range, wd, log_dec, whirl_values):
         self.speed_range = speed_range
         self.wd = wd
@@ -444,6 +445,7 @@ class FrequencyResponseResults:
         Returns the bokeh axes object with the plot
         if plot_type == "bokeh"
     """
+
     def __init__(self, freq_resp, speed_range, magnitude, phase):
         self.freq_resp = freq_resp
         self.speed_range = speed_range
@@ -824,6 +826,7 @@ class ForcedResponseResults:
         Bokeh colum with magnitude and phase plot
         if plot_type == "bokeh"
     """
+
     def __init__(self, forced_resp, speed_range, magnitude, phase):
         self.forced_resp = forced_resp
         self.speed_range = speed_range
@@ -1155,7 +1158,7 @@ class ModeShapeResults:
         ndof,
         nodes,
         nodes_pos,
-        elements_length,
+        shaft_elements_length,
         w,
         wd,
         log_dec,
@@ -1165,7 +1168,7 @@ class ModeShapeResults:
         self.ndof = ndof
         self.nodes = nodes
         self.nodes_pos = nodes_pos
-        self.elements_length = elements_length
+        self.shaft_elements_length = shaft_elements_length
         self.w = w
         self.wd = wd
         self.log_dec = log_dec
@@ -1203,7 +1206,7 @@ class ModeShapeResults:
         evec0 = self.modes[:, mode]
         nodes = self.nodes
         nodes_pos = self.nodes_pos
-        elements_length = self.elements_length
+        shaft_elements_length = self.shaft_elements_length
 
         modex = evec0[0::4]
         modey = evec0[1::4]
@@ -1251,7 +1254,7 @@ class ModeShapeResults:
         N3 = 3 * zeta ** 2 - 2 * zeta ** 3
         N4 = -zeta ** 2 + zeta ** 3
 
-        for Le, n in zip(elements_length, nodes):
+        for Le, n in zip(shaft_elements_length, nodes):
             node_pos = nodes_pos[n]
             Nx = np.hstack((N1, Le * N2, N3, Le * N4))
             Ny = np.hstack((N1, -Le * N2, N3, -Le * N4))
@@ -1378,6 +1381,7 @@ class StaticResults:
     grid_plots : bokeh.gridplot
         Bokeh column with Static Analysis plots
     """
+
     def __init__(
         self,
         disp_y,
@@ -1718,6 +1722,7 @@ class ConvergenceResults:
     plot : bokeh.gridplot
         Bokeh column with Convergence Analysis plots
     """
+
     def __init__(self, el_num, eigv_arr, error_arr):
         self.el_num = el_num
         self.eigv_arr = eigv_arr
@@ -1811,6 +1816,7 @@ class TimeResponseResults:
         Bokeh axes with time response plot
         if plot_type == "bokeh"
     """
+
     def __init__(self, t, yout, xout, dof):
         self.t = t
         self.yout = yout

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -309,12 +309,10 @@ class Rotor(object):
         nodes_o_d.append(df_shaft["o_d"].iloc[-1])
         self.nodes_o_d = nodes_o_d
 
-        nodes_le = list(df_shaft.groupby("n_l")["L"].min())
-        nodes_le.append(df_shaft["L"].iloc[-1])
-        self.nodes_le = nodes_le
+        shaft_elements_length = list(df_shaft.groupby("n_l")["L"].min())
+        self.shaft_elements_length = shaft_elements_length
 
         self.nodes = list(range(len(self.nodes_pos)))
-        self.elements_length = [sh_el.L for sh_el in self.shaft_elements]
         self.L = nodes_pos[-1]
 
         # rotor mass can also be calculated with self.M()[::4, ::4].sum()
@@ -1847,7 +1845,7 @@ class Rotor(object):
             ndof=self.ndof,
             nodes=self.nodes,
             nodes_pos=self.nodes_pos,
-            elements_length=self.elements_length,
+            shaft_elements_length=self.shaft_elements_length,
             w=self.w,
             wd=self.wd,
             log_dec=self.log_dec,

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -279,7 +279,7 @@ class ShaftElement(Element):
         >>> shaft2 = ShaftElement.load("ShaftElement.toml")
         >>> shaft2
         [ShaftElement(L=0.25, i_d=0.0, o_d=0.05, material='Steel', n=None)]
-        """ 
+        """
         shaft_elements = []
         with open("ShaftElement.toml", "r") as f:
             shaft_elements_dict = toml.load(f)
@@ -671,7 +671,7 @@ class ShaftElement(Element):
             bk_color = "yellow"
             legend = "Shaft - Slenderness Ratio < 1.6"
         else:
-            bk_color = bokeh_colors[2]
+            bk_color = self.material.color
             legend = "Shaft"
 
         source_u = ColumnDataSource(
@@ -1708,7 +1708,7 @@ class ShaftTaperedElement(Element):
             bk_color = "yellow"
             legend = "Shaft - Slenderness Ratio < 1.6"
         else:
-            bk_color = bokeh_colors[2]
+            bk_color = self.material.color
             legend = "Shaft"
 
         # bokeh plot - plot the shaft

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -316,8 +316,8 @@ def test_rotor_attributes(rotor1, rotor3, rotor3_odd):
     assert rotor1.nodes_pos[0] == 0
     assert rotor1.nodes_pos[1] == 0.25
     assert rotor1.nodes_pos[-1] == 0.5
-    assert len(rotor3.elements_length) == 6
-    assert len(rotor3_odd.elements_length) == 7
+    assert len(rotor3.shaft_elements_length) == 6
+    assert len(rotor3_odd.shaft_elements_length) == 7
 
 
 def test_evects_sorted_rotor3(rotor3):


### PR DESCRIPTION
This is related to #100. On that issue the problem was related to
the length of BearingElement being considered on the list. The problem
with that fix is that the list comprehension was not considering the
case where we have a shaft with different layers. In this case the
length for elements on different layers would be inserted on the list,
causing the plot to be wrong.