### PR TITLE
Add BallBearing and RollerBearing Element

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -1143,8 +1143,9 @@ class BallBearingElement(BearingElement):
     >>> tag = "ballbearing"
     >>> bearing = BallBearingElement(n=n, n_balls=n_balls, d_balls=d_balls,
     ...                              fs=fs, alpha=alpha, tag=tag)
-    >>> bearing # doctest: +ELLIPSIS
-    BallBearingElement(n=0, kxx=['4.64e+07'], kxy=['0.00e+00']...
+    >>> bearing.K(0)
+    array([[4.64168838e+07, 0.00000000e+00],
+           [0.00000000e+00, 1.00906269e+08]])
     """
     def __init__(
         self,
@@ -1453,10 +1454,11 @@ class RollerBearingElement(BearingElement):
     >>> fs = 500.0
     >>> alpha = np.pi / 6
     >>> tag = "rollerbearing"
-    >>> brg = RollerBearingElement(n=n, n_rollers=n_rollers, l_rollers=l_rollers,
+    >>> bearing = RollerBearingElement(n=n, n_rollers=n_rollers, l_rollers=l_rollers,
     ...                            fs=fs, alpha=alpha, tag=tag)
-    >>> brg # doctest: +ELLIPSIS
-    RollerBearingElement(n=0, kxx=['2.73e+08'], kxy=['0.00e+00']...
+    >>> bearing.K(0)
+    array([[2.72821927e+08, 0.00000000e+00],
+           [0.00000000e+00, 5.56779444e+08]])
     """
     def __init__(
         self,

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -1105,6 +1105,633 @@ class SealElement(BearingElement):
         )
 
 
+class BallBearingElement(BearingElement):
+    """A bearing element for ball bearings.
+    This class will create a bearing element based on some geometric and
+    constructive parameters of ball bearings. The main difference is that
+    cross-coupling stiffness and damping are not modeled in this case.    
+
+    Parameters
+    ----------
+    n: int
+        Node which the bearing will be located in
+    n_balls: float
+        Number of steel spheres in the bearing
+    d_balls: float
+        Diameter of the steel sphere
+    fs: float,optional
+        Static bearing loading force
+    alpha: float, optional
+        Contact angle between the steel sphere and the inner / outer raceway
+        (defaults to cxx)
+    cxx: float, optional
+        Direct stiffness in the x direction.
+        Default is None)
+    cyy: float, optional
+        Direct damping in the y direction.
+        Defaults is None
+    tag : str, optional
+        A tag to name the element
+        Default is None
+    Examples
+    --------
+    >>> n = 0
+    >>> n_balls= 8
+    >>> d_balls = 0.03
+    >>> fs = 500.0
+    >>> alpha = np.pi / 6
+    >>> tag = "ballbearing"
+    >>> bearing = BallBearingElement(n=n, n_balls=n_balls, d_balls=d_balls,
+    ...                              fs=fs, alpha=alpha, tag=tag)
+    >>> bearing # doctest: +ELLIPSIS
+    BallBearingElement(n=0, kxx=['4.64e+07'], kxy=['0.00e+00']...
+    """
+    def __init__(
+        self,
+        n,
+        n_balls,
+        d_balls,
+        fs,
+        alpha,
+        cxx=None,
+        cyy=None,
+        tag=None,
+    ):
+
+        Kb = 13.0e6
+        kyy = (
+            Kb * n_balls ** (2./3) * d_balls ** (1./3) *
+            fs ** (1./3) * (np.cos(alpha)) ** (5./3)
+        )
+
+        nb = [8, 12, 16]
+        ratio = [0.46, 0.64, 0.73]
+        dict_ratio = dict(zip(nb, ratio))
+
+        if n_balls in dict_ratio.keys():
+            kxx = dict_ratio[n_balls] * kyy
+        else:
+            f = interpolate.interp1d(nb, ratio, kind="quadratic")
+            kxx = f(n_balls)
+
+        if cxx is None:
+            cxx = 1.25e-5 * kxx
+        if cyy is None:
+            cyy = 1.25e-5 * kyy
+
+        super().__init__(
+            n=n,
+            w=None,
+            kxx=kxx,
+            kxy=0.0,
+            kyx=0.0,
+            kyy=kyy,
+            cxx=cxx,
+            cxy=0.0,
+            cyx=0.0,
+            cyy=cyy,
+            tag=tag,
+        )
+
+        self.color = "#77ACA2"
+
+    def patch(self, position, mean, ax, **kwargs):
+        """Bearing element patch.
+        Patch that will be used to draw the bearing element.
+
+        Parameters
+        ----------
+        position : tuple
+            Position (z, y) in which the patch will be drawn.
+        mean : float
+            Mean value of shaft element outer diameters
+        ax : matplotlib axes, optional
+            Axes in which the plot will be drawn.
+
+        Returns
+        -------
+        """
+        default_values = dict(lw=1.0, alpha=1.0, c="k")
+        for k, v in default_values.items():
+            kwargs.setdefault(k, v)
+
+        # geometric factors
+        zpos, ypos = position
+        coils = 6  # number of points to generate spring
+        step = mean / 5  # spring step
+        a = 2.2  # range(1.8 to 2.8)
+        b = 1.4  # range(1.2 to 1.5)
+        c = mean / 2.9  # defines width
+        d = (coils / a) * step  # modifies damper width
+        n = 5  # number of ground lines
+
+        zs0 = zpos - c
+        zs1 = zpos + c
+        ys0 = ypos + mean / 2
+
+        # plot bottom base
+        x_bot = [zpos, zpos, zs0, zs1]
+        yl_bot = [ypos, ys0, ys0, ys0]
+        yu_bot = [-y for y in yl_bot]
+        ax.add_line(mlines.Line2D(x_bot, yl_bot, **kwargs))
+        ax.add_line(mlines.Line2D(x_bot, yu_bot, **kwargs))
+
+        # plot top base
+        x_top = [zpos, zpos, zs0, zs1]
+        yl_top = [
+            b * ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+        ]
+        yu_top = [-y for y in yl_top]
+
+        ax.add_line(mlines.Line2D(x_top, yl_top, **kwargs))
+        ax.add_line(mlines.Line2D(x_top, yu_top, **kwargs))
+
+        # plot ground
+        zl_g = [zs0 - step, zs1 + step]
+        yl_g = [yl_top[0], yl_top[0]]
+        yu_g = [-y for y in yl_g]
+        ax.add_line(mlines.Line2D(zl_g, yl_g, **kwargs))
+        ax.add_line(mlines.Line2D(zl_g, yu_g, **kwargs))
+
+        step2 = (zl_g[1] - zl_g[0]) / n
+        for i in range(n + 1):
+            zl_g2 = [(zs0 - step) + step2 * (i), (zs0 - step) + step2 * (i + 1)]
+            yl_g2 = [yl_g[0], 1.1 * yl_g[0]]
+            yu_g2 = [-y for y in yl_g2]
+            ax.add_line(mlines.Line2D(zl_g2, yl_g2, **kwargs))
+            ax.add_line(mlines.Line2D(zl_g2, yu_g2, **kwargs))
+
+        # plot spring
+        z_spring = np.array([zs0, zs0, zs0, zs0])
+        yl_spring = np.array(
+            [ys0, ys0 + step, ys0 + coils * step, ys0 + (coils + 1) * step]
+        )
+
+        for i in range(coils):
+            z_spring = np.insert(z_spring, i + 2, zs0 - (-1) ** i * step)
+            yl_spring = np.insert(yl_spring, i + 2, ys0 + (i + 1) * step)
+        yu_spring = [-y for y in yl_spring]
+
+        ax.add_line(mlines.Line2D(z_spring, yl_spring, **kwargs))
+        ax.add_line(mlines.Line2D(z_spring, yu_spring, **kwargs))
+
+        # plot damper
+        z_damper1 = [zs1, zs1]
+        yl_damper1 = [ys0, ys0 + d]
+        yu_damper1 = [-y for y in yl_damper1]
+
+        ax.add_line(mlines.Line2D(z_damper1, yl_damper1, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper1, yu_damper1, **kwargs))
+
+        z_damper2 = [zs1 - step, zs1 - step, zs1 + step, zs1 + step]
+        yl_damper2 = [ys0 + 2 * d, ys0 + d, ys0 + d, ys0 + 2 * d]
+        yu_damper2 = [-y for y in yl_damper2]
+
+        ax.add_line(mlines.Line2D(z_damper2, yl_damper2, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper2, yu_damper2, **kwargs))
+
+        z_damper3 = [zs1 - step, zs1 + step, zs1, zs1]
+        yl_damper3 = [
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + (coils + 1) * step,
+        ]
+        yu_damper3 = [-y for y in yl_damper3]
+
+        ax.add_line(mlines.Line2D(z_damper3, yl_damper3, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper3, yu_damper3, **kwargs))
+
+    def bokeh_patch(self, position, mean, bk_ax, **kwargs):
+        """Bearing element patch.
+        Patch that will be used to draw the bearing element.
+
+        Parameters
+        ----------
+        position : tuple
+            Position (z, y) in which the patch will be drawn.
+        mean : float
+            Mean value of shaft element outer diameters
+        bk_ax : bokeh plotting axes, optional
+            Axes in which the plot will be drawn.
+
+        Returns
+        -------
+        """
+        default_values = dict(line_width=3, line_alpha=1, color=bokeh_colors[1])
+        for k, v in default_values.items():
+            kwargs.setdefault(k, v)
+
+        # geometric factors
+        zpos, ypos = position
+        coils = 6  # number of points to generate spring
+        step = mean / 5  # spring step
+        a = 2.2  # range(1.8 to 2.8)
+        b = 1.4  # range(1.2 to 1.5)
+        c = mean / 2.9  # defines width
+        d = (coils / a) * step  # modifies damper width
+        n = 5  # number of ground lines
+
+        zs0 = zpos - c
+        zs1 = zpos + c
+        ys0 = ypos + mean / 2
+
+        # plot bottom base
+        x_bot = [zpos, zpos, zs0, zs1]
+        yl_bot = [ypos, ys0, ys0, ys0]
+        yu_bot = [-y for y in yl_bot]
+        bk_ax.line(x=x_bot, y=yl_bot, **kwargs)
+        bk_ax.line(x=x_bot, y=yu_bot, **kwargs)
+
+        # plot top base
+        x_top = [zpos, zpos, zs0, zs1]
+        yl_top = [
+            b * ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+        ]
+        yu_top = [-y for y in yl_top]
+
+        bk_ax.line(x=x_top, y=yl_top, legend="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yu_top, legend="Bearing", **kwargs)
+
+        # plot ground
+        if self.n_link is None:
+            zl_g = [zs0 - step, zs1 + step]
+            yl_g = [yl_top[0], yl_top[0]]
+            yu_g = [-y for y in yl_g]
+            bk_ax.line(x=zl_g, y=yl_g, **kwargs)
+            bk_ax.line(x=zl_g, y=yu_g, **kwargs)
+
+            step2 = (zl_g[1] - zl_g[0]) / n
+            for i in range(n + 1):
+                zl_g2 = [(zs0 - step) + step2 * (i), (zs0 - step) + step2 * (i + 1)]
+                yl_g2 = [yl_g[0], 1.1 * yl_g[0]]
+                yu_g2 = [-y for y in yl_g2]
+                bk_ax.line(x=zl_g2, y=yl_g2, **kwargs)
+                bk_ax.line(x=zl_g2, y=yu_g2, **kwargs)
+
+        # plot spring
+        z_spring = np.array([zs0, zs0, zs0, zs0])
+        yl_spring = np.array(
+            [ys0, ys0 + step, ys0 + coils * step, ys0 + (coils + 1) * step]
+        )
+
+        for i in range(coils):
+            z_spring = np.insert(z_spring, i + 2, zs0 - (-1) ** i * step)
+            yl_spring = np.insert(yl_spring, i + 2, ys0 + (i + 1) * step)
+        yu_spring = [-y for y in yl_spring]
+
+        bk_ax.line(x=z_spring, y=yl_spring, **kwargs)
+        bk_ax.line(x=z_spring, y=yu_spring, **kwargs)
+
+        # plot damper
+        z_damper1 = [zs1, zs1]
+        yl_damper1 = [ys0, ys0 + d]
+        yu_damper1 = [-y for y in yl_damper1]
+
+        bk_ax.line(x=z_damper1, y=yl_damper1, **kwargs)
+        bk_ax.line(x=z_damper1, y=yu_damper1, **kwargs)
+
+        z_damper2 = [zs1 - step, zs1 - step, zs1 + step, zs1 + step]
+        yl_damper2 = [ys0 + 2 * d, ys0 + d, ys0 + d, ys0 + 2 * d]
+        yu_damper2 = [-y for y in yl_damper2]
+
+        bk_ax.line(x=z_damper2, y=yl_damper2, **kwargs)
+        bk_ax.line(x=z_damper2, y=yu_damper2, **kwargs)
+
+        z_damper3 = [zs1 - step, zs1 + step, zs1, zs1]
+        yl_damper3 = [
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + (coils + 1) * step,
+        ]
+        yu_damper3 = [-y for y in yl_damper3]
+
+        bk_ax.line(x=z_damper3, y=yl_damper3, **kwargs)
+        bk_ax.line(x=z_damper3, y=yu_damper3, **kwargs)
+
+
+class RollerBearingElement(BearingElement):
+    """A bearing element for roller bearings.
+    This class will create a bearing element based on some geometric and
+    constructive parameters of roller bearings. The main difference is that
+    cross-coupling stiffness and damping are not modeled in this case.    
+
+    Parameters
+    ----------
+    n: int
+        Node which the bearing will be located in
+    n_rollers: float
+        Number of steel spheres in the bearing
+    l_rollers: float
+        Diameter of the steel sphere
+    fs: float,optional
+        Static bearing loading force
+    alpha: float, optional
+        Contact angle between the steel sphere and the inner / outer raceway
+        (defaults to cxx)
+    cxx: float, optional
+        Direct stiffness in the x direction.
+        Default is None)
+    cyy: float, optional
+        Direct damping in the y direction.
+        Defaults is None
+    tag : str, optional
+        A tag to name the element
+        Default is None
+    Examples
+    --------
+    >>> n = 0
+    >>> n_rollers= 8
+    >>> l_rollers = 0.03
+    >>> fs = 500.0
+    >>> alpha = np.pi / 6
+    >>> tag = "rollerbearing"
+    >>> brg = RollerBearingElement(n=n, n_rollers=n_rollers, l_rollers=l_rollers,
+    ...                            fs=fs, alpha=alpha, tag=tag)
+    >>> brg # doctest: +ELLIPSIS
+    RollerBearingElement(n=0, kxx=['2.73e+08'], kxy=['0.00e+00']...
+    """
+    def __init__(
+        self,
+        n,
+        n_rollers,
+        l_rollers,
+        fs,
+        alpha,
+        cxx=None,
+        cyy=None,
+        tag=None,
+    ):
+
+        Kb = 1.0e9
+        kyy = (
+            Kb * n_rollers ** 0.9 * l_rollers ** 0.8 *
+            fs ** 0.1 * (np.cos(alpha)) ** 1.9
+        )
+
+        nr = [8, 12, 16]
+        ratio = [0.49, 0.66, 0.74]
+        dict_ratio = dict(zip(nr, ratio))
+
+        if n_rollers in dict_ratio.keys():
+            kxx = dict_ratio[n_rollers] * kyy
+        else:
+            f = interpolate.interp1d(nr, ratio, kind="quadratic")
+            kxx = f(n_rollers)
+
+        if cxx is None:
+            cxx = 1.25e-5 * kxx
+        if cyy is None:
+            cyy = 1.25e-5 * kyy
+
+        super().__init__(
+            n=n,
+            w=None,
+            kxx=kxx,
+            kxy=0.0,
+            kyx=0.0,
+            kyy=kyy,
+            cxx=cxx,
+            cxy=0.0,
+            cyx=0.0,
+            cyy=cyy,
+            tag=tag,
+        )
+
+        self.color = "#77ACA2"
+
+    def patch(self, position, mean, ax, **kwargs):
+        """Bearing element patch.
+        Patch that will be used to draw the bearing element.
+
+        Parameters
+        ----------
+        position : tuple
+            Position (z, y) in which the patch will be drawn.
+        mean : float
+            Mean value of shaft element outer diameters
+        ax : matplotlib axes, optional
+            Axes in which the plot will be drawn.
+
+        Returns
+        -------
+
+        Examples
+        --------
+        """
+        default_values = dict(lw=1.0, alpha=1.0, c="k")
+        for k, v in default_values.items():
+            kwargs.setdefault(k, v)
+
+        # geometric factors
+        zpos, ypos = position
+        coils = 6  # number of points to generate spring
+        step = mean / 5  # spring step
+        a = 2.2  # range(1.8 to 2.8)
+        b = 1.4  # range(1.2 to 1.5)
+        c = mean / 2.9  # defines width
+        d = (coils / a) * step  # modifies damper width
+        n = 5  # number of ground lines
+
+        zs0 = zpos - c
+        zs1 = zpos + c
+        ys0 = ypos + mean / 2
+
+        # plot bottom base
+        x_bot = [zpos, zpos, zs0, zs1]
+        yl_bot = [ypos, ys0, ys0, ys0]
+        yu_bot = [-y for y in yl_bot]
+        ax.add_line(mlines.Line2D(x_bot, yl_bot, **kwargs))
+        ax.add_line(mlines.Line2D(x_bot, yu_bot, **kwargs))
+
+        # plot top base
+        x_top = [zpos, zpos, zs0, zs1]
+        yl_top = [
+            b * ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+        ]
+        yu_top = [-y for y in yl_top]
+
+        ax.add_line(mlines.Line2D(x_top, yl_top, **kwargs))
+        ax.add_line(mlines.Line2D(x_top, yu_top, **kwargs))
+
+        # plot ground
+        zl_g = [zs0 - step, zs1 + step]
+        yl_g = [yl_top[0], yl_top[0]]
+        yu_g = [-y for y in yl_g]
+        ax.add_line(mlines.Line2D(zl_g, yl_g, **kwargs))
+        ax.add_line(mlines.Line2D(zl_g, yu_g, **kwargs))
+
+        step2 = (zl_g[1] - zl_g[0]) / n
+        for i in range(n + 1):
+            zl_g2 = [(zs0 - step) + step2 * (i), (zs0 - step) + step2 * (i + 1)]
+            yl_g2 = [yl_g[0], 1.1 * yl_g[0]]
+            yu_g2 = [-y for y in yl_g2]
+            ax.add_line(mlines.Line2D(zl_g2, yl_g2, **kwargs))
+            ax.add_line(mlines.Line2D(zl_g2, yu_g2, **kwargs))
+
+        # plot spring
+        z_spring = np.array([zs0, zs0, zs0, zs0])
+        yl_spring = np.array(
+            [ys0, ys0 + step, ys0 + coils * step, ys0 + (coils + 1) * step]
+        )
+
+        for i in range(coils):
+            z_spring = np.insert(z_spring, i + 2, zs0 - (-1) ** i * step)
+            yl_spring = np.insert(yl_spring, i + 2, ys0 + (i + 1) * step)
+        yu_spring = [-y for y in yl_spring]
+
+        ax.add_line(mlines.Line2D(z_spring, yl_spring, **kwargs))
+        ax.add_line(mlines.Line2D(z_spring, yu_spring, **kwargs))
+
+        # plot damper
+        z_damper1 = [zs1, zs1]
+        yl_damper1 = [ys0, ys0 + d]
+        yu_damper1 = [-y for y in yl_damper1]
+
+        ax.add_line(mlines.Line2D(z_damper1, yl_damper1, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper1, yu_damper1, **kwargs))
+
+        z_damper2 = [zs1 - step, zs1 - step, zs1 + step, zs1 + step]
+        yl_damper2 = [ys0 + 2 * d, ys0 + d, ys0 + d, ys0 + 2 * d]
+        yu_damper2 = [-y for y in yl_damper2]
+
+        ax.add_line(mlines.Line2D(z_damper2, yl_damper2, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper2, yu_damper2, **kwargs))
+
+        z_damper3 = [zs1 - step, zs1 + step, zs1, zs1]
+        yl_damper3 = [
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + (coils + 1) * step,
+        ]
+        yu_damper3 = [-y for y in yl_damper3]
+
+        ax.add_line(mlines.Line2D(z_damper3, yl_damper3, **kwargs))
+        ax.add_line(mlines.Line2D(z_damper3, yu_damper3, **kwargs))
+
+    def bokeh_patch(self, position, mean, bk_ax, **kwargs):
+        """Bearing element patch.
+        Patch that will be used to draw the bearing element.
+
+        Parameters
+        ----------
+        position : tuple
+            Position (z, y) in which the patch will be drawn.
+        mean : float
+            Mean value of shaft element outer diameters
+        bk_ax : bokeh plotting axes, optional
+            Axes in which the plot will be drawn.
+
+        Returns
+        -------
+        """
+        default_values = dict(line_width=3, line_alpha=1, color=bokeh_colors[1])
+        for k, v in default_values.items():
+            kwargs.setdefault(k, v)
+
+        # geometric factors
+        zpos, ypos = position
+        coils = 6  # number of points to generate spring
+        step = mean / 5  # spring step
+        a = 2.2  # range(1.8 to 2.8)
+        b = 1.4  # range(1.2 to 1.5)
+        c = mean / 2.9  # defines width
+        d = (coils / a) * step  # modifies damper width
+        n = 5  # number of ground lines
+
+        zs0 = zpos - c
+        zs1 = zpos + c
+        ys0 = ypos + mean / 2
+
+        # plot bottom base
+        x_bot = [zpos, zpos, zs0, zs1]
+        yl_bot = [ypos, ys0, ys0, ys0]
+        yu_bot = [-y for y in yl_bot]
+        bk_ax.line(x=x_bot, y=yl_bot, **kwargs)
+        bk_ax.line(x=x_bot, y=yu_bot, **kwargs)
+
+        # plot top base
+        x_top = [zpos, zpos, zs0, zs1]
+        yl_top = [
+            b * ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+            ys0 + (coils + 1) * step,
+        ]
+        yu_top = [-y for y in yl_top]
+
+        bk_ax.line(x=x_top, y=yl_top, legend="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yu_top, legend="Bearing", **kwargs)
+
+        # plot ground
+        if self.n_link is None:
+            zl_g = [zs0 - step, zs1 + step]
+            yl_g = [yl_top[0], yl_top[0]]
+            yu_g = [-y for y in yl_g]
+            bk_ax.line(x=zl_g, y=yl_g, **kwargs)
+            bk_ax.line(x=zl_g, y=yu_g, **kwargs)
+
+            step2 = (zl_g[1] - zl_g[0]) / n
+            for i in range(n + 1):
+                zl_g2 = [(zs0 - step) + step2 * (i), (zs0 - step) + step2 * (i + 1)]
+                yl_g2 = [yl_g[0], 1.1 * yl_g[0]]
+                yu_g2 = [-y for y in yl_g2]
+                bk_ax.line(x=zl_g2, y=yl_g2, **kwargs)
+                bk_ax.line(x=zl_g2, y=yu_g2, **kwargs)
+
+        # plot spring
+        z_spring = np.array([zs0, zs0, zs0, zs0])
+        yl_spring = np.array(
+            [ys0, ys0 + step, ys0 + coils * step, ys0 + (coils + 1) * step]
+        )
+
+        for i in range(coils):
+            z_spring = np.insert(z_spring, i + 2, zs0 - (-1) ** i * step)
+            yl_spring = np.insert(yl_spring, i + 2, ys0 + (i + 1) * step)
+        yu_spring = [-y for y in yl_spring]
+
+        bk_ax.line(x=z_spring, y=yl_spring, **kwargs)
+        bk_ax.line(x=z_spring, y=yu_spring, **kwargs)
+
+        # plot damper
+        z_damper1 = [zs1, zs1]
+        yl_damper1 = [ys0, ys0 + d]
+        yu_damper1 = [-y for y in yl_damper1]
+
+        bk_ax.line(x=z_damper1, y=yl_damper1, **kwargs)
+        bk_ax.line(x=z_damper1, y=yu_damper1, **kwargs)
+
+        z_damper2 = [zs1 - step, zs1 - step, zs1 + step, zs1 + step]
+        yl_damper2 = [ys0 + 2 * d, ys0 + d, ys0 + d, ys0 + 2 * d]
+        yu_damper2 = [-y for y in yl_damper2]
+
+        bk_ax.line(x=z_damper2, y=yl_damper2, **kwargs)
+        bk_ax.line(x=z_damper2, y=yu_damper2, **kwargs)
+
+        z_damper3 = [zs1 - step, zs1 + step, zs1, zs1]
+        yl_damper3 = [
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + 1.5 * d,
+            ys0 + (coils + 1) * step,
+        ]
+        yu_damper3 = [-y for y in yl_damper3]
+
+        bk_ax.line(x=z_damper3, y=yl_damper3, **kwargs)
+        bk_ax.line(x=z_damper3, y=yu_damper3, **kwargs)
+
+
 def bearing_example():
     """This function returns an instance of a simple bearing.
     The purpose is to make available a simple model

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -4,7 +4,11 @@ import os
 from numpy.testing import assert_allclose
 import math
 
-from ross.bearing_seal_element import BearingElement
+from ross.bearing_seal_element import (
+        BearingElement,
+        BallBearingElement,
+        RollerBearingElement
+)
 
 
 @pytest.fixture
@@ -228,3 +232,61 @@ def test_bearing_link_matrices():
 
     assert_allclose(b0.K(0), M)
     assert_allclose(b0.C(0), M)
+
+
+def test_ball_bearing_element():
+    n = 0
+    n_balls = 8
+    d_balls = 0.03
+    fs = 500.0
+    alpha = np.pi / 6
+    tag = "ballbearing"
+    ballbearing = BallBearingElement(
+            n=n,
+            n_balls=n_balls,
+            d_balls=d_balls,
+            fs=fs,
+            alpha=alpha,
+            tag=tag
+    )
+
+    M = np.zeros((2, 2))
+    K = np.array([[4.64168838e+07, 0.00000000e+00],
+                  [0.00000000e+00, 1.00906269e+08]])
+    C = np.array([[ 580.2110481 ,    0.        ],
+                  [   0.        , 1261.32836543]])
+    G = np.zeros((2, 2))
+
+    assert_allclose(ballbearing.M(), M)
+    assert_allclose(ballbearing.K(0), K)
+    assert_allclose(ballbearing.C(0), C)
+    assert_allclose(ballbearing.G(), G)
+
+
+def test_roller_bearing_element():
+    n = 0
+    n_rollers = 8
+    l_rollers = 0.03
+    fs = 500.0
+    alpha = np.pi / 6
+    tag = "rollerbearing"
+    rollerbearing = RollerBearingElement(
+            n=n,
+            n_rollers=n_rollers,
+            l_rollers=l_rollers,
+            fs=fs,
+            alpha=alpha,
+            tag=tag
+    )
+
+    M = np.zeros((2, 2))
+    K = np.array([[2.72821927e+08, 0.00000000e+00],
+                  [0.00000000e+00, 5.56779444e+08]])
+    C = np.array([[3410.27409251,    0.        ],
+                  [   0.        , 6959.74304593]])
+    G = np.zeros((2, 2))
+
+    assert_allclose(rollerbearing.M(), M)
+    assert_allclose(rollerbearing.K(0), K)
+    assert_allclose(rollerbearing.C(0), C)
+    assert_allclose(rollerbearing.G(), G)


### PR DESCRIPTION
This PR adds two new classes:
- BallBearingElement
- RollerBearingElement

These classes create a bearing element for ball and roller bearings models. They are instantiated based os some geometric and constructive parameters like: number of rotating elements, size (diameter for ballbearing; length for rollerbearing) of the rotating elements, contact angle, and static loading force. 

The direct stiffness coefficientes are calculated using these parameters.

I also left an opened option to instantiate the direct damping coefficients. But if it's set as None, they are calculated based on the stiffness coefficient as the literature suggests.
However the cross-coupling coefficients are set to zero, and the coefficients are not dependent on speed.

```
    def __init__(
        self,
        n,
        n_balls,
        d_balls,
        fs,
        alpha,
        cxx=None,
        cyy=None,
        tag=None,
    ):

        Kb = 13.0e6
        kyy = (
            Kb * n_balls ** (2./3) * d_balls ** (1./3) *
            fs ** (1./3) * (np.cos(alpha)) ** (5./3)
        )

        nb = [8, 12, 16]
        ratio = [0.46, 0.64, 0.73]
        dict_ratio = dict(zip(nb, ratio))

        if n_balls in dict_ratio.keys():
            kxx = dict_ratio[n_balls] * kyy
        else:
            f = interpolate.interp1d(nb, ratio, kind="quadratic")
            kxx = f(n_balls)

        if cxx is None:
            cxx = 1.25e-5 * kxx
        if cyy is None:
            cyy = 1.25e-5 * kyy

        super().__init__(
            n=n,
            w=None,
            kxx=kxx,
            kxy=0.0,
            kyx=0.0,
            kyy=kyy,
            cxx=cxx,
            cxy=0.0,
            cyx=0.0,
            cyy=cyy,
            tag=tag,
        )
```