### PR TITLE
Remove unit conversion factor

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1423,7 +1423,7 @@ class StaticResults:
         """
         source = ColumnDataSource(
             data=dict(
-                x=self.nodes_pos, y0=self.disp_y * 1000, y1=[0] * len(self.nodes_pos)
+                x=self.nodes_pos, y0=self.disp_y, y1=[0] * len(self.nodes_pos)
             )
         )
 


### PR DESCRIPTION
Remove a conversion factor (meters to milimeters) from the plot_deformation() ColumnDataSource.
So the x and y axis units get to be the same.

Related to Issue #312 