### PR TITLE
Add .save() and .load() to point mass element

### DIFF
--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -101,6 +101,61 @@ class PointMass(Element):
             f" my={self.my:{0}.{5}}, tag={self.tag!r})"
         )
 
+    def save(self, file_name):
+        """Saves a point mass element in a toml format. It works as an
+        auxiliary function of the save function in the Rotor class.
+        Parameters
+        ----------
+        file_name: string
+            The name of the file the point mass element will be saved in.
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> pointmass = point_mass_example()
+        >>> pointmass.save('PointMass.toml')
+        """
+        data = self.load_data(file_name)
+        data["PointMass"][str(self.n)] = {
+            "n": self.n,
+            "mx": self.mx,
+            "my": self.my,
+            "tag": self.tag,
+        }
+        self.dump_data(data, file_name)
+
+    @staticmethod
+    def load(file_name="PointMass"):
+        """Loads a list of point mass elements saved in a toml format.
+        Parameters
+        ----------
+        file_name: string
+            The name of the file of the point mass element to be loaded.
+
+        Returns
+        -------
+        A list of point mass elements.
+
+        Examples
+        --------
+        >>> pointmass = point_mass_example()
+        >>> pointmass.save('PointMass.toml')
+        >>> list_of_point_mass = PointMass.load('PointMass.toml')
+        >>> pointmass == list_of_point_mass[0]
+        True
+        """
+        pm_elements = []
+        with open("PointMass.toml", "r") as f:
+            pm_elements_dict = toml.load(f)
+            for element in pm_elements_dict["PointMass"]:
+                pm_elements.append(
+                    PointMass(**pm_elements_dict["PointMass"][element])
+                )
+        return pm_elements
+
     def M(self):
         """Mass matrix."""
         mx = self.mx

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -5,7 +5,13 @@ This module defines the PointMass class which will be used to link elements.
 import numpy as np
 from ross.element import Element
 
+import toml
+import bokeh.palettes as bp
+from bokeh.models import ColumnDataSource, HoverTool
+import matplotlib.patches as mpatches
+
 __all__ = ["PointMass"]
+bokeh_colors = bp.RdGy[11]
 
 
 class PointMass(Element):

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2278,13 +2278,35 @@ class Rotor(object):
         except FileNotFoundError:
             return "A rotor with this name does not exist, check the rotors folder."
 
-        os.chdir(rotor_path / "elements")
-        shaft_elements = ShaftElement.load()
-        os.chdir(rotor_path / "elements")
-        disk_elements = DiskElement.load()
-        bearing_elements = BearingElement.load()
+        shaft_elements = []
+        disk_elements = []
+        bearing_elements = []
         seal_elements = []
-        point_mass_elements = PointMass.load()
+        point_mass_elements = []
+
+        try:
+            os.chdir(rotor_path / "elements")
+            shaft_elements = ShaftElement.load()
+        except FileNotFoundError:
+            pass
+
+        try:
+            os.chdir(rotor_path / "elements")
+            disk_elements = DiskElement.load()
+        except FileNotFoundError:
+            pass
+
+        try:
+            os.chdir(rotor_path / "elements")
+            bearing_elements = BearingElement.load()
+        except FileNotFoundError:
+            pass
+
+        try:
+            os.chdir(rotor_path / "elements")
+            point_mass_elements = PointMass.load()
+        except FileNotFoundError:
+            pass
 
         os.chdir(rotor_path)
         with open("properties.toml", "r") as f:

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2284,6 +2284,7 @@ class Rotor(object):
         disk_elements = DiskElement.load()
         bearing_elements = BearingElement.load()
         seal_elements = []
+        point_mass_elements = PointMass.load()
 
         os.chdir(rotor_path)
         with open("properties.toml", "r") as f:
@@ -2294,6 +2295,7 @@ class Rotor(object):
             shaft_elements=shaft_elements,
             bearing_seal_elements=bearing_elements + seal_elements,
             disk_elements=disk_elements,
+            point_mass_elements=point_mass_elements,
             **parameters,
         )
 


### PR DESCRIPTION
In PR #318, I should have added these methods too.
So, I'm adding them now.
Now, the code will save and load the point mass elements. 