### PR TITLE
Remove setup_requires for pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,8 +136,6 @@ setup(
     # },
     install_requires=REQUIRED,
     extras_require=EXTRAS,
-    setup_requires=["pytest-runner"],
-    tests_requires=["pytest"],
     include_package_data=True,
     license="MIT",
     classifiers=[


### PR DESCRIPTION
We do not need this requirement since we have changed appveyor script
see commit 745b79c7c9a4992e785b114e3f1554d4886df403:
```
  - "%PYTHON%\\python.exe setup.py test"
  + "%PYTHON%\\python.exe pytest ross"
```