### PR TITLE
Add Stability Level 1 analysis

### DIFF
--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.signal import argrelextrema
 
 from ross.rotor_assembly import Rotor, rotor_example
+from ross.bearing_seal_element import BearingElement
 import ross as rs
 
 import bokeh.palettes as bp
@@ -32,6 +33,11 @@ class Report:
             String defining the unit for rotor speed.
             Default is "rpm".
 
+        Attributes
+        ----------
+        rotor_type : str
+            Defines if the rotor is between bearings or overhung
+
         Return
         ------
 
@@ -49,6 +55,32 @@ class Report:
         if speed_units == "rpm":
             minspeed = minspeed * np.pi / 30
             maxspeed = maxspeed * np.pi / 30
+
+        # check if rotor is between bearings, single or double overhung
+        # fmt: off
+        if(
+            all(i > min(rotor.df_bearings["n"]) for i in rotor.df_disks["n"]) and
+            all(i < max(rotor.df_bearings["n"]) for i in rotor.df_disks["n"])
+        ):
+            rotor_type = "between_bearings"
+        elif(
+            any(i < min(rotor.df_bearings["n"]) for i in rotor.df_disks["n"]) and
+            all(i < max(rotor.df_bearings["n"]) for i in rotor.df_disks["n"])
+        ):
+            rotor_type = "left_overhung"
+        elif(
+            all(i > min(rotor.df_bearings["n"]) for i in rotor.df_disks["n"]) and
+            any(i > max(rotor.df_bearings["n"]) for i in rotor.df_disks["n"])
+        ):
+            rotor_type = "right_overhung"
+        elif(
+            any(i < min(rotor.df_bearings["n"]) for i in rotor.df_disks["n"]) and
+            any(i > max(rotor.df_bearings["n"]) for i in rotor.df_disks["n"])
+        ):
+            rotor_type = "double_overhung"
+        # fmt: on
+
+        self.rotor_type = rotor_type
 
         self.maxspeed = maxspeed
         self.minspeed = minspeed

--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -73,7 +73,7 @@ class Report:
         ...                 maxspeed=1000,
         ...                 speed_units="rad/s")
         >>> report.rotor_type
-        "between_bearings"
+        'between_bearings'
         """
         self.rotor = rotor
         self.speed_units = speed_units

--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -624,13 +624,14 @@ class Report:
         plot.title.text_font_size = "14pt"
 
         nodes_pos = np.array(nodes_pos)
+        rpm_speed = (30 / np.pi) * modal.wn[mode]
 
         plot.line(
             x=zn,
             y=vn,
             line_width=4,
             line_color="red",
-            legend="Mode = %s, Speed = %.1f RPM" % (mode+1, 9.55*self.rotor.wn[mode]),
+            legend="Mode = %s, Speed = %.1f RPM" % (mode, rpm_speed),
         )
         plot.line(
             x=nodes_pos,
@@ -786,7 +787,7 @@ class Report:
         Q0 = cross_coupled_stiff[-1]
 
         # CSR - Critical Speed Ratio
-        CSR = self.maxspeed / self.rotor.wn[0]
+        CSR = self.maxspeed / self.rotor.run_modal(speed=self.maxspeed).wn[0]
 
         # RHO_mean - Average gas density
         RHO_mean = (RHOd + RHOs) / 2


### PR DESCRIPTION
- This analysis consider a anticipated cross coupling QA based on conditions at the normal operating point and the cross-coupling required to produce a zero log decrement, Q0.

- Add attribute "rotor_type" 
    - This attribute is necessary to distinguish overhung and between bearings rotors.
    - The unbalance forces and and the respective nodes where they are introduced depends on this information.

- Improve unbalance force method.
    - With this improvement, the unbalance forces are calculated according to the rotor_type and 
consideres the disks and shaft wheight (if overhung).

- Change mode_shape to find nodes according to rotor_type
    - The method .mode_shapes() was capturing the maximum points from the rotor's mode shapes without checking if it was overhung or between bearings.
    - For rotors where the disk is cantilevered beyond the bearings, unbalance shall be added at the disk. So, the method now checks the rotor_type to define the nodes correctly.

- Add machine_type and disk_nodes attribute 
    - Machine_type will be useful to help the code to distinguish between compressors, turbines, etc. Because each machine type has their own conditions to be calculated.
    - Disk_nodes is useful to collect the disk of interest. if we are working with a overhung rotor, disk_nodes will collect the disk which are overhung only, for example.

This Level 1 analysis does not have the screening criteria yet.
The next step is to implement the Level 2 analysis. Once I get to work on it, I'll add the screening criteria. I still need to organize some ideas for the next step.