### PR TITLE
Fix shaft element index

### DIFF
--- a/ross/tests/test_shaft_element.py
+++ b/ross/tests/test_shaft_element.py
@@ -141,7 +141,7 @@ def test_from_table():
             shaft_file, sheet_type="Model", sheet_name="Model"
         )
         el0 = shaft[0]
-        assert el0.n == 0
+        assert el0.n == 1
         assert_allclose(el0.i_d, 0.1409954)
         assert_allclose(el0.o_d, 0.151003)
 
@@ -151,8 +151,8 @@ def test_from_table():
         assert_allclose(mat0.G_s, 82737087518.02, rtol=2e-06)
 
         # test if node is the same for elements in different layers
-        assert shaft[8].n == 8
-        assert shaft[9].n == 8
+        assert shaft[8].n == 9
+        assert shaft[9].n == 9
         assert_allclose(shaft[8].material.E, 206842718795.05, rtol=3e-06)
         assert_allclose(shaft[9].material.E, 6894.75, atol=0.008)
 

--- a/ross/utils.py
+++ b/ross/utils.py
@@ -241,10 +241,6 @@ def read_table_file(file, element, sheet_name=0, n=0, sheet_type="Model"):
                 else:
                     continue
     if element == "shaft":
-        new_n = parameters["n"]
-        for i in range(0, df.shape[0]):
-            new_n[i] -= 1
-        parameters["n"] = new_n
         if sheet_type == "Model":
             new_material = parameters["material"]
             for i in range(0, df.shape[0]):


### PR DESCRIPTION
When loading a shaft element from an excel file, at some point the index was being reduced in 1.

I created this solution so that indexes would start on 0, as in every example they would start on 1. I was afraid indexes starting on 1 would create bugs in other parts of the code, but I didn't implement the same solution to disk elements. I also did not consider that the user could start their index on 0, which would cause it to start on -1.

This PR removes this index modification.

Close #368 