### PR TITLE
Change imported index

### DIFF
--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -514,7 +514,7 @@ class DiskElement(Element):
         >>> file_path = os.path.dirname(os.path.realpath(__file__)) + '/tests/data/shaft_si.xls'
         >>> list_of_disks = DiskElement.from_table(file_path, sheet_name="More")
         >>> list_of_disks[0]
-        DiskElement(Id=0.0, Ip=0.0, m=15.12, color='#b2182b', n=4, tag=None)
+        DiskElement(Id=0.0, Ip=0.0, m=15.12, color='#b2182b', n=3, tag=None)
         """
         parameters = read_table_file(file, "disk", sheet_name=sheet_name)
         list_of_disks = []

--- a/ross/tests/test_fluid_flow.py
+++ b/ross/tests/test_fluid_flow.py
@@ -1,3 +1,4 @@
+import pytest
 import math
 import numpy as np
 
@@ -5,29 +6,53 @@ from ross.fluid_flow import fluid_flow as flow
 from bokeh.plotting import figure
 import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
-from ross.fluid_flow.fluid_flow_coefficients import calculate_analytical_damping_matrix,\
-    calculate_analytical_stiffness_matrix, calculate_oil_film_force, calculate_stiffness_matrix,\
-    find_equilibrium_position
-from ross.fluid_flow.fluid_flow_graphics import plot_shape, plot_eccentricity, plot_pressure_theta,\
-    plot_pressure_z, matplot_shape, matplot_eccentricity, matplot_pressure_theta, matplot_pressure_z
+from ross.fluid_flow.fluid_flow_coefficients import (
+    calculate_analytical_damping_matrix,
+    calculate_analytical_stiffness_matrix,
+    calculate_oil_film_force,
+    calculate_stiffness_matrix,
+    find_equilibrium_position,
+)
+from ross.fluid_flow.fluid_flow_graphics import (
+    plot_shape,
+    plot_eccentricity,
+    plot_pressure_theta,
+    plot_pressure_z,
+    matplot_shape,
+    matplot_eccentricity,
+    matplot_pressure_theta,
+    matplot_pressure_z,
+)
 
 
+@pytest.fixture
 def fluid_flow_short_eccentricity():
     nz = 16
     ntheta = 528
     nradius = 11
-    omega = 100.*2*np.pi/60
-    p_in = 0.
-    p_out = 0.
+    omega = 100.0 * 2 * np.pi / 60
+    p_in = 0.0
+    p_out = 0.0
     radius_rotor = 0.1999996
     radius_stator = 0.1999996 + 0.000194564
     length = (1 / 10) * (2 * radius_stator)
     eccentricity = 0.0001
     visc = 0.015
-    rho = 860.
-    return flow.FluidFlow(nz, ntheta, nradius, length, omega, p_in,
-                          p_out, radius_rotor, radius_stator,
-                          visc, rho, eccentricity=eccentricity)
+    rho = 860.0
+    return flow.FluidFlow(
+        nz,
+        ntheta,
+        nradius,
+        length,
+        omega,
+        p_in,
+        p_out,
+        radius_rotor,
+        radius_stator,
+        visc,
+        rho,
+        eccentricity=eccentricity,
+    )
 
 
 def fluid_flow_short_friswell(set_load=True):
@@ -36,22 +61,44 @@ def fluid_flow_short_friswell(set_load=True):
     nradius = 11
     length = 0.03
     omega = 157.1
-    p_in = 0.
-    p_out = 0.
+    p_in = 0.0
+    p_out = 0.0
     radius_rotor = 0.0499
     radius_stator = 0.05
     load = 525
     visc = 0.1
-    rho = 860.
-    eccentricity = (radius_stator - radius_rotor)*0.2663
+    rho = 860.0
+    eccentricity = (radius_stator - radius_rotor) * 0.2663
     if set_load:
-        return flow.FluidFlow(nz, ntheta, nradius, length, omega, p_in,
-                              p_out, radius_rotor, radius_stator,
-                              visc, rho, load=load)
+        return flow.FluidFlow(
+            nz,
+            ntheta,
+            nradius,
+            length,
+            omega,
+            p_in,
+            p_out,
+            radius_rotor,
+            radius_stator,
+            visc,
+            rho,
+            load=load,
+        )
     else:
-        return flow.FluidFlow(nz, ntheta, nradius, length, omega, p_in,
-                              p_out, radius_rotor, radius_stator,
-                              visc, rho, eccentricity=eccentricity)
+        return flow.FluidFlow(
+            nz,
+            ntheta,
+            nradius,
+            length,
+            omega,
+            p_in,
+            p_out,
+            radius_rotor,
+            radius_stator,
+            visc,
+            rho,
+            eccentricity=eccentricity,
+        )
 
 
 def test_sommerfeld_number():
@@ -81,28 +128,28 @@ def test_stiffness_matrix():
     Taken from example 5.5.1, page 181 (Dynamics of rotating machine, FRISSWELL)
     """
     bearing = fluid_flow_short_friswell()
-    kxx, kxy, kyx, kyy = calculate_analytical_stiffness_matrix(bearing.load,
-                                                               bearing.eccentricity_ratio,
-                                                               bearing.radial_clearance)
-    assert math.isclose(kxx/10**6, 12.81, rel_tol=0.01)
-    assert math.isclose(kxy/10**6, 16.39, rel_tol=0.01)
-    assert math.isclose(kyx/10**6, -25.06, rel_tol=0.01)
-    assert math.isclose(kyy/10**6, 8.815, rel_tol=0.01)
+    kxx, kxy, kyx, kyy = calculate_analytical_stiffness_matrix(
+        bearing.load, bearing.eccentricity_ratio, bearing.radial_clearance
+    )
+    assert math.isclose(kxx / 10 ** 6, 12.81, rel_tol=0.01)
+    assert math.isclose(kxy / 10 ** 6, 16.39, rel_tol=0.01)
+    assert math.isclose(kyx / 10 ** 6, -25.06, rel_tol=0.01)
+    assert math.isclose(kyy / 10 ** 6, 8.815, rel_tol=0.01)
 
 
-def test_stiffness_matrix_numerical():
+def test_stiffness_matrix_numerical(fluid_flow_short_eccentricity):
     """
     This function instantiate a bearing using the fluid flow class and test if it matches the
     expected results for the stiffness matrix based on Friswell's book formulas, given the
     eccentricity ratio.
     Taken from chapter 5, page 179 (Dynamics of rotating machine, FRISSWELL)
     """
-    bearing = fluid_flow_short_eccentricity()
+    bearing = fluid_flow_short_eccentricity
     bearing.calculate_pressure_matrix_numerical()
     kxx, kxy, kyx, kyy = calculate_stiffness_matrix(bearing)
-    k_xx, k_xy, k_yx, k_yy = calculate_analytical_stiffness_matrix(bearing.load,
-                                                                   bearing.eccentricity_ratio,
-                                                                   bearing.radial_clearance)
+    k_xx, k_xy, k_yx, k_yy = calculate_analytical_stiffness_matrix(
+        bearing.load, bearing.eccentricity_ratio, bearing.radial_clearance
+    )
     assert_allclose(kxx, k_xx, rtol=0.03)
     assert_allclose(kxy, k_xy, rtol=0.006)
     assert_allclose(kyx, k_yx, rtol=0.02)
@@ -116,14 +163,16 @@ def test_damping_matrix():
     Taken from example 5.5.1, page 181 (Dynamics of rotating machine, FRISSWELL)
     """
     bearing = fluid_flow_short_friswell()
-    cxx, cxy, cyx, cyy = calculate_analytical_damping_matrix(bearing.load,
-                                                             bearing.eccentricity_ratio,
-                                                             bearing.radial_clearance,
-                                                             bearing.omega)
-    assert math.isclose(cxx/10**3, 232.9, rel_tol=0.01)
-    assert math.isclose(cxy/10**3, -81.92, rel_tol=0.01)
-    assert math.isclose(cyx/10**3, -81.92, rel_tol=0.01)
-    assert math.isclose(cyy/10**3, 294.9, rel_tol=0.01)
+    cxx, cxy, cyx, cyy = calculate_analytical_damping_matrix(
+        bearing.load,
+        bearing.eccentricity_ratio,
+        bearing.radial_clearance,
+        bearing.omega,
+    )
+    assert math.isclose(cxx / 10 ** 3, 232.9, rel_tol=0.01)
+    assert math.isclose(cxy / 10 ** 3, -81.92, rel_tol=0.01)
+    assert math.isclose(cyx / 10 ** 3, -81.92, rel_tol=0.01)
+    assert math.isclose(cyy / 10 ** 3, 294.9, rel_tol=0.01)
 
 
 def fluid_flow_short_numerical():
@@ -131,45 +180,71 @@ def fluid_flow_short_numerical():
     ntheta = 132
     nradius = 11
     length = 0.01
-    omega = 100. * 2 * np.pi / 60
-    p_in = 0.
-    p_out = 0.
+    omega = 100.0 * 2 * np.pi / 60
+    p_in = 0.0
+    p_out = 0.0
     radius_rotor = 0.08
     radius_stator = 0.1
     visc = 0.015
-    rho = 860.
+    rho = 860.0
     attitude_angle = None
     eccentricity = 0.001
-    return flow.FluidFlow(nz, ntheta, nradius, length,
-                          omega, p_in, p_out, radius_rotor,
-                          radius_stator, visc, rho, attitude_angle=attitude_angle, eccentricity=eccentricity)
+    return flow.FluidFlow(
+        nz,
+        ntheta,
+        nradius,
+        length,
+        omega,
+        p_in,
+        p_out,
+        radius_rotor,
+        radius_stator,
+        visc,
+        rho,
+        attitude_angle=attitude_angle,
+        eccentricity=eccentricity,
+    )
 
 
 def fluid_flow_long_numerical():
     nz = 8
     ntheta = 132
     nradius = 11
-    omega = 100. * 2 * np.pi / 60
-    p_in = 0.
-    p_out = 0.
+    omega = 100.0 * 2 * np.pi / 60
+    p_in = 0.0
+    p_out = 0.0
     radius_rotor = 1
     h = 0.000194564
     radius_stator = radius_rotor + h
     length = 8 * 2 * radius_stator
     visc = 0.015
-    rho = 860.
+    rho = 860.0
     eccentricity = 0.0001
-    return flow.FluidFlow(nz, ntheta, nradius, length,
-                          omega, p_in, p_out, radius_rotor,
-                          radius_stator, visc, rho, eccentricity=eccentricity)
+    return flow.FluidFlow(
+        nz,
+        ntheta,
+        nradius,
+        length,
+        omega,
+        p_in,
+        p_out,
+        radius_rotor,
+        radius_stator,
+        visc,
+        rho,
+        eccentricity=eccentricity,
+    )
 
 
 def test_numerical_abs_error():
     bearing = fluid_flow_short_numerical()
     bearing.calculate_pressure_matrix_analytical()
     bearing.calculate_pressure_matrix_numerical()
-    error = np.linalg.norm(bearing.p_mat_analytical[:][int(bearing.nz / 2)] -
-                           bearing.p_mat_numerical[:][int(bearing.nz / 2)], ord=np.inf)
+    error = np.linalg.norm(
+        bearing.p_mat_analytical[:][int(bearing.nz / 2)]
+        - bearing.p_mat_numerical[:][int(bearing.nz / 2)],
+        ord=np.inf,
+    )
     assert math.isclose(error, 0, abs_tol=0.001)
 
 
@@ -177,8 +252,11 @@ def test_numerical_abs_error2():
     bearing = fluid_flow_short_numerical()
     bearing.calculate_pressure_matrix_analytical(method=1)
     bearing.calculate_pressure_matrix_numerical()
-    error = np.linalg.norm(bearing.p_mat_analytical[:][int(bearing.nz / 2)] -
-                           bearing.p_mat_numerical[:][int(bearing.nz / 2)], ord=np.inf)
+    error = np.linalg.norm(
+        bearing.p_mat_analytical[:][int(bearing.nz / 2)]
+        - bearing.p_mat_numerical[:][int(bearing.nz / 2)],
+        ord=np.inf,
+    )
     assert math.isclose(error, 0, abs_tol=0.001)
 
 
@@ -186,8 +264,10 @@ def test_long_bearing():
     bearing = fluid_flow_long_numerical()
     bearing.calculate_pressure_matrix_analytical()
     bearing.calculate_pressure_matrix_numerical()
-    error = (max(bearing.p_mat_analytical[int(bearing.nz / 2)]) -
-             max(bearing.p_mat_numerical[int(bearing.nz / 2)])) / max(bearing.p_mat_numerical[int(bearing.nz / 2)])
+    error = (
+        max(bearing.p_mat_analytical[int(bearing.nz / 2)])
+        - max(bearing.p_mat_numerical[int(bearing.nz / 2)])
+    ) / max(bearing.p_mat_numerical[int(bearing.nz / 2)])
     assert math.isclose(error, 0, abs_tol=0.007)
 
 
@@ -195,8 +275,9 @@ def test_oil_film_force_short():
     bearing = fluid_flow_short_numerical()
     bearing.calculate_pressure_matrix_numerical()
     n, t, force_x, force_y = calculate_oil_film_force(bearing)
-    n_numerical, t_numerical, force_x_numerical, force_y_numerical = \
-        calculate_oil_film_force(bearing, force_type='numerical')
+    n_numerical, t_numerical, force_x_numerical, force_y_numerical = calculate_oil_film_force(
+        bearing, force_type="numerical"
+    )
     assert_allclose(n, n_numerical, rtol=0.08)
     assert_allclose(t, t_numerical, rtol=0.7)
     assert_allclose(force_x_numerical, 0, atol=1e-06)
@@ -207,8 +288,9 @@ def test_oil_film_force_long():
     bearing = fluid_flow_long_numerical()
     bearing.calculate_pressure_matrix_numerical()
     n, t, force_x, force_y = calculate_oil_film_force(bearing)
-    n_numerical, t_numerical, force_x_numerical, force_y_numerical = \
-        calculate_oil_film_force(bearing, force_type='numerical')
+    n_numerical, t_numerical, force_x_numerical, force_y_numerical = calculate_oil_film_force(
+        bearing, force_type="numerical"
+    )
     assert_allclose(n, n_numerical, rtol=0.2)
     assert_allclose(t, t_numerical, rtol=0.4)
 
@@ -236,6 +318,8 @@ def test_matplotlib_plots():
 def test_find_equilibrium_position():
     bearing = fluid_flow_short_friswell()
     eccentricity = find_equilibrium_position(bearing, print_along=False)
-    assert_allclose(eccentricity, (bearing.radius_stator - bearing.radius_rotor)*0.2663, rtol=0.0002)
-
-
+    assert_allclose(
+        eccentricity,
+        (bearing.radius_stator - bearing.radius_rotor) * 0.2663,
+        rtol=0.0002,
+    )

--- a/ross/tests/test_shaft_element.py
+++ b/ross/tests/test_shaft_element.py
@@ -141,7 +141,7 @@ def test_from_table():
             shaft_file, sheet_type="Model", sheet_name="Model"
         )
         el0 = shaft[0]
-        assert el0.n == 1
+        assert el0.n == 0
         assert_allclose(el0.i_d, 0.1409954)
         assert_allclose(el0.o_d, 0.151003)
 
@@ -151,8 +151,8 @@ def test_from_table():
         assert_allclose(mat0.G_s, 82737087518.02, rtol=2e-06)
 
         # test if node is the same for elements in different layers
-        assert shaft[8].n == 9
-        assert shaft[9].n == 9
+        assert shaft[8].n == 8
+        assert shaft[9].n == 8
         assert_allclose(shaft[8].material.E, 206842718795.05, rtol=3e-06)
         assert_allclose(shaft[9].material.E, 6894.75, atol=0.008)
 

--- a/ross/utils.py
+++ b/ross/utils.py
@@ -117,7 +117,11 @@ def read_table_file(file, element, sheet_name=0, n=0, sheet_type="Model"):
                     if row[i].lower() == header_key_word:
                         header_index = index
                         header_found = True
-                if "inches" in row[i].lower() or "lbm" in row[i].lower() or 'lb' in row[i].lower():
+                if (
+                    "inches" in row[i].lower()
+                    or "lbm" in row[i].lower()
+                    or "lb" in row[i].lower()
+                ):
                     convert_to_metric = True
                 if "rpm" in row[i].lower():
                     convert_to_rad_per_sec = True
@@ -246,6 +250,14 @@ def read_table_file(file, element, sheet_name=0, n=0, sheet_type="Model"):
             for i in range(0, df.shape[0]):
                 new_material[i] = "shaft_mat_" + str(int(new_material[i]))
             parameters["material"] = new_material
+
+    # change xltrc index to python index (0 based)
+    if element in ("shaft", "disk"):
+        new_n = parameters["n"]
+        for i in range(0, df.shape[0]):
+            new_n[i] -= 1
+        parameters["n"] = new_n
+
     if convert_to_metric:
         for i in range(0, df.shape[0]):
             if element == "bearing":


### PR DESCRIPTION
As per #368, we had an inconsistency between imported shaft and disks.
PR #372 changed the shaft index, removing the lines that would change the index from 1 to 0 based. The problem is that the imported shaft and disks would be 1 indexed, and python (and ross) are 0 based, so I believe it is better to apply the 0 index to both, shaft and disks imported.

Closes #367 