### PR TITLE
Visual improvements to graphs

### DIFF
--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -524,9 +524,8 @@ class Report:
                 y_offset=20,
             )
         )
-        mag_plot.width = 1280
-        mag_plot.height = 720
-        mag_plot.title.text_font_size = "14pt"
+        mag_plot.width = 640
+        mag_plot.height = 480
 
         return mag_plot
 
@@ -562,8 +561,7 @@ class Report:
         df_bearings = self.rotor.df_bearings
         df_disks = self.rotor.df_disks
 
-        # TODO: Add mcs speed to evaluate mode shapes
-        modal = self.rotor.run_modal(speed=0)
+        modal = self.rotor.run_modal(speed=self.maxspeed)
         xn, yn, zn, xc, yc, zc_pos, nn = modal.calc_mode_shape(mode=mode)
 
         # reduce 3D view to 2D view
@@ -638,9 +636,10 @@ class Report:
             x_axis_label="Rotor lenght",
             y_axis_label="Non dimensional rotor deformation",
         )
-        plot.xaxis.axis_label_text_font_size = "12pt"
-        plot.yaxis.axis_label_text_font_size = "12pt"
         plot.title.text_font_size = "14pt"
+        plot.xaxis.axis_label_text_font_size = "20pt"
+        plot.yaxis.axis_label_text_font_size = "20pt"
+        plot.axis.major_label_text_font_size = "16pt"
 
         nodes_pos = np.array(nodes_pos)
         rpm_speed = (30 / np.pi) * modal.wn[mode]
@@ -728,15 +727,18 @@ class Report:
             Adopted unit system.
             Default is "m"
 
+        Attributes
+        ----------
+        condition: str
+            not required: Stability Level 1 satisfies the analysis;
+            required: Stability Level 2 is required.
+
         Return
         ------
         fig1: bokeh.figure
             Applied Cross-Coupled Stiffness vs. Log Decrement plot;
         fig2: bokeh.figure
             CSR vs. Mean Gas Density plot.
-        condition: str
-            not required: Stability Level 1 satisfies the analysis;
-            required: Stability Level 2 is required.
 
         Example
         -------
@@ -893,9 +895,10 @@ class Report:
             x_range=(0, max(cross_coupled_Qa)),
             y_range=DataRange1d(start=0),
         )
-        fig1.title.text_font_size = "11pt"
-        fig1.xaxis.axis_label_text_font_size = "11pt"
-        fig1.yaxis.axis_label_text_font_size = "11pt"
+        fig1.title.text_font_size = "14pt"
+        fig1.xaxis.axis_label_text_font_size = "20pt"
+        fig1.yaxis.axis_label_text_font_size = "20pt"
+        fig1.axis.major_label_text_font_size = "16pt"
 
         fig1.line(
             cross_coupled_Qa, log_dec, line_width=3, line_color=bokeh_colors[0]
@@ -933,9 +936,10 @@ class Report:
             y_range=DataRange1d(start=0),
             x_range=DataRange1d(start=0),
         )
-        fig2.title.text_font_size = "11pt"
-        fig2.xaxis.axis_label_text_font_size = "11pt"
-        fig2.yaxis.axis_label_text_font_size = "11pt"
+        fig2.title.text_font_size = "14pt"
+        fig2.xaxis.axis_label_text_font_size = "20pt"
+        fig2.yaxis.axis_label_text_font_size = "20pt"
+        fig2.axis.major_label_text_font_size = "16pt"
         fig2.extra_x_ranges = {"x_range2": Range1d(f * min(RHO), f * max(RHO))}
 
         fig2.add_layout(
@@ -1010,7 +1014,7 @@ class Report:
         self.RHO_gas = RHO_mean
         self.condition = condition
 
-        return fig1, fig2, condition
+        return fig1, fig2
 
     def stability_level_2(self):
         """Stability analysis level 2.
@@ -1199,10 +1203,7 @@ class Report:
             "CSR",
             "Gas Density (kg/m³)",
         ]
-        stab_lvl2_titles = [
-            "Components",
-            "Log. Dec.",
-        ]
+        stab_lvl2_titles = ["Components", "Log. Dec."]
 
         stab_lvl1_formatters = [
             None,
@@ -1216,10 +1217,7 @@ class Report:
             NumberFormatter(format="0.000"),
             NumberFormatter(format="0.000"),
         ]
-        stab_lvl2_formatters = [
-            None,
-            NumberFormatter(format="0.0000"),
-        ]
+        stab_lvl2_formatters = [None, NumberFormatter(format="0.0000")]
 
         stab_lvl1_columns = [
             TableColumn(field=str(field), title=title, formatter=form)

--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -723,8 +723,8 @@ class Report:
             Suction gas density in the first stage, kg/m3 (lbm/in.3).
         RHOd: float
             Discharge gas density in the last stage, kg/m3 (lbm/in.3),
-        unit: str
-            Adopted unit system.
+        unit: str, optional
+            Adopted unit system. Options are "m" (meter) and "in" (inch)
             Default is "m"
 
         Attributes
@@ -824,7 +824,7 @@ class Report:
                     bearing_seal_elements=bearings,
                     rated_w=self.rotor.rated_w,
                 )
-                modal = aux_rotor.run_modal(speed=oper_speed)
+                modal = aux_rotor.run_modal(speed=oper_speed * np.pi / 30)
                 non_backward = modal.whirl_direction() != "Backward"
                 log_dec[i] = modal.log_dec[non_backward][0]
 
@@ -845,7 +845,7 @@ class Report:
                     bearing_seal_elements=bearings,
                     rated_w=self.rotor.rated_w,
                 )
-                modal = aux_rotor.run_modal(speed=oper_speed)
+                modal = aux_rotor.run_modal(speed=oper_speed * np.pi / 30)
                 non_backward = modal.whirl_direction() != "Backward"
                 log_dec[i] = modal.log_dec[non_backward][0]
 

--- a/ross/results.py
+++ b/ross/results.py
@@ -840,7 +840,7 @@ class CampbellResults:
         camp.legend.click_policy = "mute"
         camp.legend.location = "top_left"
         camp.legend.label_text_font_size = "16pt"
-        camp.add_layout(color_bar, "right"))
+        camp.add_layout(color_bar, "right")
 
         return camp
 

--- a/ross/results.py
+++ b/ross/results.py
@@ -493,8 +493,8 @@ class ModalResults:
         ax.set_xlim(zn_cl0 - 0.1, zn_cl1 + 0.1)
 
         ax.set_title(
-            f"$speed$ = {self.speed:.1f} rad/s\n$"
-            f"\omega_n$ = {self.wn[mode]:.1f} rad/s\n"
+            f"$mode$ {mode + 1} - $speed$ = {self.speed:.1f} rad/s\n"
+            f"$\omega_n$ = {self.wn[mode]:.1f} rad/s\n"
             f"$log dec$ = {self.log_dec[mode]:.1f}\n"
             f"$whirl\_direction$ = {self.whirl_direction()[mode]}",
             fontsize=18,

--- a/ross/results.py
+++ b/ross/results.py
@@ -494,9 +494,13 @@ class ModalResults:
 
         ax.set_title(
             f"$speed$ = {self.speed:.1f} rad/s\n$"
-            f"\omega_d$ = {self.wd[mode]:.1f} rad/s\n"
-            f"$log dec$ = {self.log_dec[mode]:.1f}"
+            f"\omega_n$ = {self.wn[mode]:.1f} rad/s\n"
+            f"$log dec$ = {self.log_dec[mode]:.1f}\n"
+            f"$whirl\_direction$ = {self.whirl_direction()[mode]}",
+            fontsize=18,
         )
+        ax.tick_params(axis='both', which='major', labelsize=18)
+        ax.tick_params(axis='both', which='minor', labelsize=18)
 
         return fig, ax
 
@@ -710,8 +714,10 @@ class CampbellResults:
             x_axis_label="Rotor speed (rad/s)",
             y_axis_label="Damped natural frequencies (rad/s)",
         )
-        camp.xaxis.axis_label_text_font_size = "14pt"
-        camp.yaxis.axis_label_text_font_size = "14pt"
+        camp.xaxis.axis_label_text_font_size = "20pt"
+        camp.yaxis.axis_label_text_font_size = "20pt"
+        camp.axis.major_label_text_font_size = "16pt"
+        camp.title.text_font_size = "14pt"
         hover = False
 
         color_mapper = linear_cmap(
@@ -823,16 +829,18 @@ class CampbellResults:
             location=(0, 0),
             title="log dec",
             title_text_font_style="bold italic",
+            title_text_font_size="16pt",
             title_text_align="center",
             major_label_text_align="left",
+            major_label_text_font_size="16pt",
         )
         if hover:
             camp.add_tools(hover)
         camp.legend.background_fill_alpha = 0.1
         camp.legend.click_policy = "mute"
         camp.legend.location = "top_left"
-        camp.legend.label_text_font_size = "8pt"
-        camp.add_layout(color_bar, "right")
+        camp.legend.label_text_font_size = "16pt"
+        camp.add_layout(color_bar, "right"))
 
         return camp
 
@@ -990,8 +998,10 @@ class FrequencyResponseResults:
             x_axis_label="Frequency (rad/s)",
             y_axis_label=y_axis_label,
         )
-        mag_plot.xaxis.axis_label_text_font_size = "14pt"
-        mag_plot.yaxis.axis_label_text_font_size = "14pt"
+        mag_plot.xaxis.axis_label_text_font_size = "20pt"
+        mag_plot.yaxis.axis_label_text_font_size = "20pt"
+        mag_plot.axis.major_label_text_font_size = "16pt"
+        mag_plot.title.text_font_size = "14pt"
 
         source = ColumnDataSource(dict(x=frequency_range, y=mag[inp, out, :]))
         mag_plot.line(
@@ -1077,8 +1087,10 @@ class FrequencyResponseResults:
             x_axis_label="Frequency (rad/s)",
             y_axis_label="Phase",
         )
-        phase_plot.xaxis.axis_label_text_font_size = "14pt"
-        phase_plot.yaxis.axis_label_text_font_size = "14pt"
+        phase_plot.xaxis.axis_label_text_font_size = "20pt"
+        phase_plot.yaxis.axis_label_text_font_size = "20pt"
+        phase_plot.axis.major_label_text_font_size = "16pt"
+        phase_plot.title.text_font_size = "14pt"
 
         source = ColumnDataSource(dict(x=frequency_range, y=phase[inp, out, :]))
         phase_plot.line(
@@ -1372,8 +1384,10 @@ class ForcedResponseResults:
             x_range=[0, max(frequency_range)],
             y_axis_label=y_axis_label,
         )
-        mag_plot.xaxis.axis_label_text_font_size = "14pt"
-        mag_plot.yaxis.axis_label_text_font_size = "14pt"
+        mag_plot.xaxis.axis_label_text_font_size = "20pt"
+        mag_plot.yaxis.axis_label_text_font_size = "20pt"
+        mag_plot.axis.major_label_text_font_size = "16pt"
+        mag_plot.title.text_font_size = "14pt"
 
         source = ColumnDataSource(dict(x=frequency_range, y=mag[dof]))
         mag_plot.line(
@@ -1465,8 +1479,10 @@ class ForcedResponseResults:
             line_alpha=1.0,
             line_width=3,
         )
-        phase_plot.xaxis.axis_label_text_font_size = "14pt"
-        phase_plot.yaxis.axis_label_text_font_size = "14pt"
+        phase_plot.xaxis.axis_label_text_font_size = "20pt"
+        phase_plot.yaxis.axis_label_text_font_size = "20pt"
+        phase_plot.axis.major_label_text_font_size = "16pt"
+        phase_plot.title.text_font_size = "14pt"
 
         return phase_plot
 
@@ -1655,8 +1671,9 @@ class StaticResults:
             x_axis_label="Shaft lenght",
             y_axis_label="Lateral displacement",
         )
-        fig.xaxis.axis_label_text_font_size = "14pt"
-        fig.yaxis.axis_label_text_font_size = "14pt"
+        fig.xaxis.axis_label_text_font_size = "20pt"
+        fig.yaxis.axis_label_text_font_size = "20pt"
+        fig.axis.major_label_text_font_size = "16pt"
         fig.title.text_font_size = "14pt"
 
         interpolated = interpolate.interp1d(
@@ -1741,7 +1758,8 @@ class StaticResults:
             y_range=[-3 * y_start, 3 * y_start],
         )
         fig.yaxis.visible = False
-        fig.xaxis.axis_label_text_font_size = "14pt"
+        fig.xaxis.axis_label_text_font_size = "20pt"
+        fig.axis.major_label_text_font_size = "16pt"
         fig.title.text_font_size = "14pt"
 
         fig.line("x", "y1", source=source, line_width=5, line_color=bokeh_colors[0])
@@ -1884,8 +1902,9 @@ class StaticResults:
             y_axis_label="Force",
             x_range=[-0.1 * shaft_end, 1.1 * shaft_end],
         )
-        fig.xaxis.axis_label_text_font_size = "14pt"
-        fig.yaxis.axis_label_text_font_size = "14pt"
+        fig.xaxis.axis_label_text_font_size = "20pt"
+        fig.yaxis.axis_label_text_font_size = "20pt"
+        fig.axis.major_label_text_font_size = "16pt"
         fig.title.text_font_size = "14pt"
 
         fig.line("x", "y", source=source_SF, line_width=4, line_color=bokeh_colors[0])
@@ -1929,8 +1948,9 @@ class StaticResults:
             y_axis_label="Bending Moment",
             x_range=[-0.1 * shaft_end, 1.1 * shaft_end],
         )
-        fig.xaxis.axis_label_text_font_size = "14pt"
-        fig.yaxis.axis_label_text_font_size = "14pt"
+        fig.xaxis.axis_label_text_font_size = "20pt"
+        fig.yaxis.axis_label_text_font_size = "20pt"
+        fig.axis.major_label_text_font_size = "16pt"
         fig.title.text_font_size = "14pt"
 
         i = 0
@@ -2266,8 +2286,10 @@ class ConvergenceResults:
             x_axis_label="Numer of Elements",
             y_axis_label="Frequency (rad/s)",
         )
-        freq_arr.xaxis.axis_label_text_font_size = "14pt"
-        freq_arr.yaxis.axis_label_text_font_size = "14pt"
+        freq_arr.xaxis.axis_label_text_font_size = "20pt"
+        freq_arr.yaxis.axis_label_text_font_size = "20pt"
+        freq_arr.axis.major_label_text_font_size = "16pt"
+        freq_arr.title.text_font_size = "14pt"
 
         freq_arr.line("x0", "y0", source=source, line_width=3, line_color="crimson")
         freq_arr.circle("x0", "y0", source=source, size=8, fill_color="crimson")
@@ -2282,8 +2304,10 @@ class ConvergenceResults:
             x_axis_label="Number of Elements",
             y_axis_label="Relative Error (%)",
         )
-        rel_error.xaxis.axis_label_text_font_size = "14pt"
-        rel_error.yaxis.axis_label_text_font_size = "14pt"
+        rel_error.xaxis.axis_label_text_font_size = "20pt"
+        rel_error.yaxis.axis_label_text_font_size = "20pt"
+        rel_error.axis.major_label_text_font_size = "16pt"
+        rel_error.title.text_font_size = "14pt"
 
         rel_error.line(
             "x0", "y1", source=source, line_width=3, line_color="darkslategray"
@@ -2409,10 +2433,11 @@ class TimeResponseResults:
             x_axis_label="Time (s)",
             y_axis_label="Amplitude (%s)" % amp,
         )
-        bk_ax.xaxis.axis_label_text_font_size = "14pt"
-        bk_ax.yaxis.axis_label_text_font_size = "14pt"
+        bk_ax.xaxis.axis_label_text_font_size = "20pt"
+        bk_ax.yaxis.axis_label_text_font_size = "20pt"
+        bk_ax.axis.major_label_text_font_size = "16pt"
+        bk_ax.title.text_font_size = "14pt"
 
-        # bokeh plot - plot shaft centerline
         bk_ax.line(
             self.t, self.yout[:, self.dof], line_width=3, line_color=bokeh_colors[0]
         )

--- a/ross/tests/test_api_report.py
+++ b/ross/tests/test_api_report.py
@@ -236,7 +236,7 @@ def test_stability_level1(report0, report1, report2):
     assert_allclose(report2.crit_speed, 38.263712414670984, atol=1e-4)
     assert_allclose(report2.MCS, 1000.0736613927509, atol=1e-4)
     assert_allclose(report2.RHO_gas, 34.05, atol=1e-4)
-    assert report2.condition == 'required"
+    assert report2.condition == 'required'
 
 
 def test_stability_level2(report0, report1, report2):

--- a/ross/tests/test_api_report.py
+++ b/ross/tests/test_api_report.py
@@ -15,8 +15,8 @@ def report0():
     # rotor type: between bearings
     i_d = 0.0
     o_d = 0.05
-    n = 6
-    L = [0.25 for _ in range(n)]
+    n = 50
+    L = [0.03 for _ in range(n)]
 
     shaft_elem = [
         ShaftElement(
@@ -26,16 +26,16 @@ def report0():
     ]
 
     disk0 = DiskElement.from_geometry(
-        n=2, material=steel, width=0.07, i_d=0.05, o_d=0.28
+        n=15, material=steel, width=0.07, i_d=0.05, o_d=0.28
     )
     disk1 = DiskElement.from_geometry(
-        n=4, material=steel, width=0.07, i_d=0.05, o_d=0.35
+        n=35, material=steel, width=0.07, i_d=0.05, o_d=0.35
     )
 
     stfx = 1e6
     stfy = 0.8e6
-    bearing0 = BearingElement(0, kxx=stfx, kyy=stfy, cxx=0, scale_factor=0.5)
-    bearing1 = BearingElement(6, kxx=stfx, kyy=stfy, cxx=0, scale_factor=0.5)
+    bearing0 = BearingElement(0, kxx=stfx, kyy=stfy, cxx=1000)
+    bearing1 = BearingElement(50, kxx=stfx, kyy=stfy, cxx=1000)
 
     rotor = Rotor(shaft_elem, [disk0, disk1], [bearing0, bearing1])
 
@@ -52,8 +52,8 @@ def report1():
     # rotor type: single overhung
     i_d = 0.0
     o_d = 0.05
-    n = 6
-    L = [0.25 for _ in range(n)]
+    n = 50
+    L = [0.03 for _ in range(n)]
 
     shaft_elem = [
         ShaftElement(
@@ -68,8 +68,8 @@ def report1():
 
     stfx = 1e6
     stfy = 0.8e6
-    bearing0 = BearingElement(2, kxx=stfx, kyy=stfy, cxx=0, scale_factor=0.5)
-    bearing1 = BearingElement(6, kxx=stfx, kyy=stfy, cxx=0, scale_factor=0.5)
+    bearing0 = BearingElement(15, kxx=stfx, kyy=stfy, cxx=1000)
+    bearing1 = BearingElement(50, kxx=stfx, kyy=stfy, cxx=1000)
 
     rotor = Rotor(shaft_elem, [disk0], [bearing0, bearing1])
 
@@ -86,8 +86,8 @@ def report2():
     # rotor type: single double overhung
     i_d = 0.0
     o_d = 0.05
-    n = 6
-    L = [0.25 for _ in range(n)]
+    n = 50
+    L = [0.03 for _ in range(n)]
 
     shaft_elem = [
         ShaftElement(
@@ -100,13 +100,13 @@ def report2():
         n=0, material=steel, width=0.07, i_d=0.05, o_d=0.28
     )
     disk1 = DiskElement.from_geometry(
-        n=6, material=steel, width=0.07, i_d=0.05, o_d=0.35
+        n=50, material=steel, width=0.07, i_d=0.05, o_d=0.35
     )
 
     stfx = 1e6
     stfy = 0.8e6
-    bearing0 = BearingElement(2, kxx=stfx, kyy=stfy, cxx=0, scale_factor=0.5)
-    bearing1 = BearingElement(4, kxx=stfx, kyy=stfy, cxx=0, scale_factor=0.5)
+    bearing0 = BearingElement(15, kxx=stfx, kyy=stfy, cxx=1000)
+    bearing1 = BearingElement(35, kxx=stfx, kyy=stfy, cxx=1000)
 
     rotor = Rotor(shaft_elem, [disk0, disk1], [bearing0, bearing1])
 
@@ -120,7 +120,7 @@ def report2():
 
 def test_initial_attributes(report0, report1, report2):
     assert report0.rotor_type == 'between_bearings'
-    assert report0.disk_nodes == [2, 4]
+    assert report0.disk_nodes == [15, 35]
     assert report0.machine_type == 'compressor'
     assert report0.tag == 'Rotor 0'
     assert_allclose(report0.maxspeed, 1000.0, atol=1e-2)
@@ -132,7 +132,7 @@ def test_initial_attributes(report0, report1, report2):
     assert_allclose(report1.maxspeed, 1000.0, atol=1e-2)
     assert_allclose(report1.minspeed, 400.0, atol=1e-2)
     assert report2.rotor_type == 'double_overhung'
-    assert report2.disk_nodes == [0, 6]
+    assert report2.disk_nodes == [0, 50]
     assert report2.machine_type == 'compressor'
     assert report2.tag == 'Rotor 0'
     assert_allclose(report2.maxspeed, 1000.0736613927509, atol=1e-8)
@@ -143,12 +143,12 @@ def test_report_static_forces(report0, report1, report2):
     F_0 = report0.static_forces()
     F_1 = report1.static_forces()
     F_2 = report2.static_forces()
-    assert_allclose(F_0[0], 50.40534339, atol=1e-6)
-    assert_allclose(F_0[1], 56.7174833, atol=1e-6)
-    assert_allclose(F_1[0], 66.13980523, atol=1e-6)
-    assert_allclose(F_1[1], -10.54402692, atol=1e-6)
-    assert_allclose(F_2[0], 25.15678377, atol=1e-6)
-    assert_allclose(F_2[1], 81.96604293, atol=1e-6)
+    assert_allclose(F_0[0], 49.77310967, atol=1e-6)
+    assert_allclose(F_0[1], 57.34971702, atol=1e-6)
+    assert_allclose(F_1[0], 62.98883394, atol=1e-6)
+    assert_allclose(F_1[1], -7.39305563, atol=1e-6)
+    assert_allclose(F_2[0], 29.88833937, atol=1e-6)
+    assert_allclose(F_2[1], 77.22429001, atol=1e-6)
 
 
 def test_unbalance_forces(report0, report1, report2):
@@ -156,25 +156,25 @@ def test_unbalance_forces(report0, report1, report2):
     assert_allclose(Uforce_00, [71.23351373], atol=1e-6)
 
     Uforce_02 = report0.unbalance_forces(mode=2)
-    assert_allclose(Uforce_02, [33.51806362, 37.71545011], atol=1e-6)
+    assert_allclose(Uforce_02, [33.09764688, 38.13586685], atol=1e-6)
 
     Uforce_10 = report1.unbalance_forces(mode=0)
-    assert_allclose(Uforce_10, [26.769833052956542], atol=1e-6)
+    assert_allclose(Uforce_10, [26.25997031], atol=1e-6)
 
     Uforce_12 = report1.unbalance_forces(mode=2)
-    assert_allclose(Uforce_12, [26.769833052956542], atol=1e-6)
+    assert_allclose(Uforce_12, [26.25997031], atol=1e-6)
 
     Uforce_20 = report2.unbalance_forces(mode=0)
-    assert_allclose(Uforce_20, np.array([26.7678613, 39.35850396]), atol=1e-6)
+    assert_allclose(Uforce_20, np.array([26.25803611, 38.84867878]), atol=1e-6)
 
     Uforce_22 = report2.unbalance_forces(mode=2)
-    assert_allclose(Uforce_22, np.array([26.7678613, 39.35850396]), atol=1e-6)
+    assert_allclose(Uforce_22, np.array([26.25803611, 38.84867878]), atol=1e-6)
 
 
 def test_report_mode_shape(report0, report1, report2):
     n1, n2 = report0.mode_shape(mode=0)
     nodes = [int(node) for sub_nodes in [n1, n2] for node in sub_nodes]
-    assert nodes == [3]
+    assert nodes == [26]
 
     n1, n2 = report1.mode_shape(mode=0)
     nodes = [int(node) for sub_nodes in [n1, n2] for node in sub_nodes]
@@ -186,8 +186,94 @@ def test_report_mode_shape(report0, report1, report2):
 
     n1, n2 = report2.mode_shape(mode=0)
     nodes = [int(node) for sub_nodes in [n1, n2] for node in sub_nodes]
-    assert nodes == [0, 6]
+    assert nodes == [0, 50]
 
     n1, n2 = report2.mode_shape(mode=3)
     nodes = [int(node) for sub_nodes in [n1, n2] for node in sub_nodes]
-    assert nodes == [0, 6]
+    assert nodes == [0, 50]
+
+
+def test_stability_level1(report0, report1, report2):
+    D = [0.28, 0.35]
+    H = [0.07, 0.07]
+    HP = [6000, 8000]
+    RHO_ratio = [1.11, 1.14]
+    RHOd = 30.45
+    RHOs = 37.65
+    oper_speed = 1000.0
+
+    report0.stability_level_1(D, H, HP, oper_speed, RHO_ratio, RHOs, RHOd)
+
+    assert_allclose(report0.Q0, 81599.87755102041, atol=1e-4)
+    assert_allclose(report0.Qa, 20399.969387755104, atol=1e-4)
+    assert_allclose(report0.log_dec_a, 0.30527030743121375, atol=1e-4)
+    assert_allclose(report0.CSR, 12.096802976513656, atol=1e-4)
+    assert_allclose(report0.Qratio, 4.0, atol=1e-4)
+    assert_allclose(report0.crit_speed, 82.66646997074625, atol=1e-4)
+    assert_allclose(report0.MCS, 1000.0, atol=1e-4)
+    assert_allclose(report0.RHO_gas, 34.05, atol=1e-4)
+    assert report0.condition == 'required'
+
+    report1.stability_level_1(D, H, HP, oper_speed, RHO_ratio, RHOs, RHOd)
+
+    assert_allclose(report1.Q0, 79730.98330241187, atol=1e-4)
+    assert_allclose(report1.Qa, 4385.204081632653, atol=1e-4)
+    assert_allclose(report1.log_dec_a, 0.8370720236581191, atol=1e-4)
+    assert_allclose(report1.CSR, 14.043968256888528, atol=1e-4)
+    assert_allclose(report1.Qratio, 18.181818181818183, atol=1e-4)
+    assert_allclose(report1.crit_speed, 71.20494590334201, atol=1e-4)
+    assert_allclose(report1.MCS, 1000.0, atol=1e-4)
+    assert_allclose(report1.RHO_gas, 34.05, atol=1e-4)
+    assert report1.condition == 'not required'
+
+    report2.stability_level_1(D, H, HP, oper_speed, RHO_ratio, RHOs, RHOd)
+
+    assert_allclose(report2.Q0, 61199.90816326531, atol=1e-4)
+    assert_allclose(report2.Qa, 20399.969387755104, atol=1e-4)
+    assert_allclose(report2.log_dec_a, 0.6761496778932745, atol=1e-4)
+    assert_allclose(report2.CSR, 26.13634690107343, atol=1e-4)
+    assert_allclose(report2.Qratio, 3.0, atol=1e-4)
+    assert_allclose(report2.crit_speed, 38.263712414670984, atol=1e-4)
+    assert_allclose(report2.MCS, 1000.0736613927509, atol=1e-4)
+    assert_allclose(report2.RHO_gas, 34.05, atol=1e-4)
+    assert report2.condition == 'required"
+
+
+def test_stability_level2(report0, report1, report2):
+    df0 = report0.stability_level_2()
+    df1 = report1.stability_level_2()
+    df2 = report2.stability_level_2()
+
+    assert_allclose(
+        df0["log_dec"].tolist(),
+        [
+            0.17669652215696618,
+            0.15801304519741688,
+            0.14761936907792816,
+            0.3153250139555406,
+            0.1476193691000094,
+        ],
+        atol=1e-6,
+    )
+    assert_allclose(
+        df1["log_dec"].tolist(),
+        [
+            0.14898201611278591,
+            0.14898201641839076,
+            0.8368485552898145,
+            0.14898201644744202,
+        ],
+        atol=1e-6,
+    )
+    assert_allclose(
+        df2["log_dec"].tolist(),
+        [
+            0.18583253961189522,
+            0.1234528382387709,
+            0.13263883296849005,
+            0.6795260384463433,
+            0.13263883219846548,
+        ],
+        atol=1e-6,
+    )
+

--- a/ross/tests/test_api_report.py
+++ b/ross/tests/test_api_report.py
@@ -242,7 +242,6 @@ def test_stability_level1(report0, report1, report2):
 def test_stability_level2(report0, report1, report2):
     df0 = report0.stability_level_2()
     df1 = report1.stability_level_2()
-    df2 = report2.stability_level_2()
 
     assert_allclose(
         df0["log_dec"].tolist(),
@@ -265,15 +264,3 @@ def test_stability_level2(report0, report1, report2):
         ],
         atol=1e-6,
     )
-    assert_allclose(
-        df2["log_dec"].tolist(),
-        [
-            0.18583253961189522,
-            0.1234528382387709,
-            0.13263883296849005,
-            0.6795260384463433,
-            0.13263883219846548,
-        ],
-        atol=1e-6,
-    )
-


### PR DESCRIPTION
The labels, ticks and titles font size from bokeh figure were small when putting it presentations. So I've increased the font size of all graphs.

- Add new tab to the `.summary()` with stability level 2 data;
- Change stability level 2 labels for better user understanding when using `.summary()`. The labels include explicitly all the components considered in a certain analysis (Shaft + Bearing + Disk + Seal...);
- Increases labels, titiles and tick font sizes (results.py and api_report.py);
- Add mcs speed to evaluate mode shapes (api_report.py);
- Fix `.unbalance_response()` plot size to match results.py file;
- In `.stability_level_1()` remove condition from returning and add it as attribute;
- `.run_modal().plot_mode()` add legend informing the whirl direction.