### PR TITLE
Add method to plot orbit

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -2473,3 +2473,133 @@ class TimeResponseResults:
             return self._plot_bokeh(**kwargs)
         else:
             raise ValueError(f"{plot_type} is not a valid plot type.")
+
+
+class OrbitResponseResults:
+    """Class used to store results and provide plots for Orbit Response
+    Analysis.
+
+    This class takes the results from orbit response analysis and creates a
+    plot given a force and a time.
+
+    Parameters
+    ----------
+    t : array
+        Time values for the output.
+    yout : array
+        System response.
+    xout : array
+        Time evolution of the state vector.
+    node : int
+        Rotor node
+
+    Returns
+    -------
+    ax : matplotlib.axes
+        Matplotlib axes with time response plot.
+        if plot_type == "matplotlib"
+    bk_ax : bokeh axes
+        Bokeh axes with time response plot
+        if plot_type == "bokeh"
+    """
+
+    def __init__(self, t, yout, xout, node):
+        self.t = t
+        self.yout = yout
+        self.xout = xout
+        self.node = node
+
+    def _plot_matplotlib(self, ax=None):
+        """Plot orbit response.
+
+        This function will take a rotor object and plot its orbit response
+        using Matplotlib
+
+        Parameters
+        ----------
+        ax : matplotlib.axes
+            Matplotlib axes where time response will be plotted.
+            if None, creates a new one
+
+        Returns
+        -------
+        ax : matplotlib.axes
+            Matplotlib axes with orbit response plot.
+        """
+        if ax is None:
+            ax = plt.gca()
+
+        ax.plot(self.yout[:, 4 * self.node], self.yout[:, 4 * self.node + 1])
+
+        ax.set_xlabel("Amplitude - direction x (m)")
+        ax.set_ylabel("Amplitude - direction y (m)")
+        ax.set_title("Orbit for node %s" % (self.node))
+
+        return ax
+
+    def _plot_bokeh(self):
+        """Plot orbit response.
+
+        This function will take a rotor object and plot its orbit response
+        using Bokeh
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        bk_ax : bokeh axes
+            Bokeh axes with orbit response plot
+            if plot_type == "bokeh"
+        """
+        # bokeh plot - create a new plot
+        bk_ax = figure(
+            tools="pan, box_zoom, wheel_zoom, reset, save",
+            width=640,
+            height=480,
+            title="Response for node %s" % (self.node),
+            x_axis_label="Amplitude - direction x (m)",
+            y_axis_label="Amplitude - direction y (m)"
+        )
+        bk_ax.xaxis.axis_label_text_font_size = "20pt"
+        bk_ax.yaxis.axis_label_text_font_size = "20pt"
+        bk_ax.title.text_font_size = "14pt"
+
+        bk_ax.line(
+            self.yout[:, 4 * self.node],
+            self.yout[:, 4 * self.node + 1],
+            line_width=3,
+            line_color=bokeh_colors[0],
+        )
+
+        return bk_ax
+
+    def plot(self, plot_type="bokeh", **kwargs):
+        """Plot orbit response.
+
+        This function will take a rotor object and plot its orbit response
+
+        Parameters
+        ----------
+        plot_type: str
+            Matplotlib or bokeh.
+            The default is bokeh
+        kwargs : optional
+            Additional key word arguments can be passed to change
+            the plot (e.g. linestyle='--')
+
+        Returns
+        -------
+        ax : matplotlib.axes
+            Matplotlib axes with time response plot.
+            if plot_type == "matplotlib"
+        bk_ax : bokeh axes
+            Bokeh axes with time response plot
+            if plot_type == "bokeh"
+        """
+        if plot_type == "matplotlib":
+            return self._plot_matplotlib(**kwargs)
+        elif plot_type == "bokeh":
+            return self._plot_bokeh(**kwargs)
+        else:
+            raise ValueError(f"{plot_type} is not a valid plot type.")

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -34,6 +34,7 @@ from ross.results import (
     StaticResults,
     SummaryResults,
     TimeResponseResults,
+    OrbitResponseResults
 )
 from ross.shaft_element import ShaftElement, ShaftTaperedElement
 
@@ -906,9 +907,6 @@ class Rotor(object):
         idx = self._index(evalues)
 
         return evalues[idx], evectors[:, idx]
-
-    def orbit(self):
-        pass
 
     def _lti(self, speed, frequency=None):
         """Continuous-time linear time invariant system.
@@ -1909,6 +1907,51 @@ class Rotor(object):
         t_, yout, xout = self.time_response(speed, F, t)
 
         results = TimeResponseResults(t, yout, xout, dof)
+
+        return results
+
+    def run_orbit_response(self, speed, F, t, node):
+        """Calculates the orbit for a given node.
+
+        This function will take a rotor object and plot the orbit for a single
+        node.
+
+        Parameters
+        ----------
+        speed: float
+            Rotor speed
+        F: array
+            Force array (needs to have the same number of rows as time array).
+            Each column corresponds to a dof and each row to a time.
+        t: array
+            Time array.
+        node : int
+            Node to be observed.
+
+        Returns
+        -------
+        results : array
+            Array containing the time array, the system response, and the
+            time evolution of the state vector.
+            It will be returned if plot=False.
+
+        Examples
+        --------
+        >>> rotor = rotor_example()
+        >>> speed = 500.0
+        >>> size = 1000
+        >>> node = 3
+        >>> t = np.linspace(0, 10, size)
+        >>> F = np.zeros((size, rotor.ndof))
+        >>> F[:, 4 * node] = 10 * np.cos(2 * t)
+        >>> F[:, 4 * node + 1] = 10 * np.sin(2 * t)
+        >>> response = rotor.run_orbit_response(speed, F, t, node)
+        >>> response.yout[:, 4 * node] # doctest: +ELLIPSIS
+        array([ 0.00000000e+00,  6.94968863e-06,  2.13014440e-05, ...
+        """
+        t_, yout, xout = self.time_response(speed, F, t)
+
+        results = OrbitResponseResults(t, yout, xout, node)
 
         return results
 


### PR DESCRIPTION
- Add `.run_orbit_response()` method to rotor_assembly.py.
    - `.run_orbit_response()` calculates the orbit for a rotor's given node, speed and forces.

- Add class `OrbitResponseResults` to results.py.
    - Class used to store results and provide plots for orbit response.

Example using this new method:
```
>>> rotor = rotor_example()
>>> speed = 500.0                                           # pick a rotor speed
>>> size = 10000                                            # time array's size
>>> node = 3                                                # node of interest
>>> t = np.linspace(0, 10, size)                            # create time array
>>> F = np.zeros((size, rotor.ndof))                        # create force vectors
>>> F[:, 4 * node] = 10 * np.cos(2 * t)                     # introduce a periodic force in a single dof
>>> F[:, 4 * node + 1] = 10 * np.sin(2 * t)                 # introduce a periodic force in a single dof
>>> response = rotor.run_orbit_response(speed, F, t, node)  # run orbit response
>>> show(response.plot())                                   # plot orbit response
```