### PR TITLE
Update the syntax of the legend attribute from bokeh figures

### DIFF
--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -422,7 +422,7 @@ class Report:
                     line_width=0.8,
                     fill_alpha=0.2,
                     fill_color=bokeh_colors[8],
-                    legend="Separation Margin",
+                    legend_label="Separation Margin",
                     name="SM2",
                 )
                 hover = HoverTool(names=["SM2"])
@@ -457,7 +457,7 @@ class Report:
                     line_width=0.8,
                     fill_alpha=0.2,
                     fill_color=bokeh_colors[8],
-                    legend="Separation Margin",
+                    legend_label="Separation Margin",
                     name="SM2",
                 )
                 hover = HoverTool(names=["SM2"])
@@ -491,7 +491,7 @@ class Report:
             line_width=0.8,
             fill_alpha=0.2,
             fill_color="green",
-            legend="Operation Speed Range",
+            legend_label="Operation Speed Range",
         )
 
         source = ColumnDataSource(dict(x=freq_range, y=mag[dof]))
@@ -509,7 +509,7 @@ class Report:
             line_dash="dotdash",
             line_width=2.0,
             line_color=bokeh_colors[1],
-            legend="Av1 - Mechanical test vibration limit",
+            legend_label="Av1 - Mechanical test vibration limit",
         )
         mag_plot.add_layout(
             Label(
@@ -649,7 +649,7 @@ class Report:
             y=vn,
             line_width=4,
             line_color="red",
-            legend="Mode = %s, Speed = %.1f RPM" % (mode, rpm_speed),
+            legend_label="Mode = %s, Speed = %.1f RPM" % (mode, rpm_speed),
         )
         plot.line(
             x=nodes_pos,

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -681,8 +681,8 @@ class BearingElement(Element):
             ypos + 1.5 * mean,
         ]
         yu_top = [-y for y in yl_top]
-        bk_ax.line(x=x_top, y=yl_top, legend="Bearing", **kwargs)
-        bk_ax.line(x=x_top, y=yu_top, legend="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yl_top, legend_label="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yu_top, legend_label="Bearing", **kwargs)
 
         # plot ground
         if self.n_link is None:
@@ -1111,7 +1111,7 @@ class SealElement(BearingElement):
             line_width=1,
             fill_alpha=0.8,
             fill_color=bokeh_colors[6],
-            legend="Seal",
+            legend_label="Seal",
         )
         # bokeh plot - lower seal visual representation
         bk_ax.quad(
@@ -1358,8 +1358,8 @@ class BallBearingElement(BearingElement):
             ypos + 1.5 * mean,
         ]
         yu_top = [-y for y in yl_top]
-        bk_ax.line(x=x_top, y=yl_top, legend="Bearing", **kwargs)
-        bk_ax.line(x=x_top, y=yu_top, legend="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yl_top, legend_label="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yu_top, legend_label="Bearing", **kwargs)
 
         # plot ground
         if self.n_link is None:
@@ -1649,8 +1649,8 @@ class RollerBearingElement(BearingElement):
             ypos + 1.5 * mean,
         ]
         yu_top = [-y for y in yl_top]
-        bk_ax.line(x=x_top, y=yl_top, legend="Bearing", **kwargs)
-        bk_ax.line(x=x_top, y=yu_top, legend="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yl_top, legend_label="Bearing", **kwargs)
+        bk_ax.line(x=x_top, y=yu_top, legend_label="Bearing", **kwargs)
 
         # plot ground
         if self.n_link is None:

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -393,7 +393,7 @@ class DiskElement(Element):
             alpha=1,
             line_width=2,
             color=self.color,
-            legend="Disk",
+            legend_label="Disk",
             name="ub_disk",
         )
         bk_ax.patches(

--- a/ross/fluid_flow/fluid_flow_graphics.py
+++ b/ross/fluid_flow/fluid_flow_graphics.py
@@ -79,9 +79,9 @@ def plot_pressure_z(fluid_flow_object, theta=0):
         x_axis_label="Points along Z",
     )
     if fluid_flow_object.numerical_pressure_matrix_available:
-        p.line(fluid_flow_object.z_list, y_n, legend="Numerical pressure", color="blue", line_width=2)
+        p.line(fluid_flow_object.z_list, y_n, legend_label="Numerical pressure", color="blue", line_width=2)
     if fluid_flow_object.analytical_pressure_matrix_available:
-        p.line(fluid_flow_object.z_list, y_a, legend="Analytical pressure", color="red", line_width=2)
+        p.line(fluid_flow_object.z_list, y_a, legend_label="Analytical pressure", color="red", line_width=2)
     return p
 
 
@@ -159,7 +159,7 @@ def plot_pressure_theta(fluid_flow_object, z=0):
         p.line(
             fluid_flow_object.gama[z],
             fluid_flow_object.p_mat_numerical[z],
-            legend="Numerical pressure",
+            legend_label="Numerical pressure",
             line_width=2,
             color="blue",
         )
@@ -167,7 +167,7 @@ def plot_pressure_theta(fluid_flow_object, z=0):
         p.line(
             fluid_flow_object.gama[z],
             fluid_flow_object.p_mat_analytical[z],
-            legend="Analytical pressure",
+            legend_label="Analytical pressure",
             line_width=2,
             color="red",
         )

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -2,10 +2,13 @@
 
 This module defines the PointMass class which will be used to link elements.
 """
-import numpy as np
-from ross.element import Element
+import toml
+import bokeh.palettes as bp
+from bokeh.models import ColumnDataSource, HoverTool
+import matplotlib.patches as mpatches
 
 __all__ = ["PointMass"]
+bokeh_colors = bp.RdGy[11]
 
 
 class PointMass(Element):
@@ -185,7 +188,7 @@ class PointMass(Element):
             line_color=bokeh_colors[0],
             fill_alpha=1.0,
             fill_color=bokeh_colors[7],
-            legend="Point Mass",
+            legend_label="Point Mass",
         )
 
         for k, v in default_values.items():

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -2,6 +2,9 @@
 
 This module defines the PointMass class which will be used to link elements.
 """
+import numpy as np
+from ross.element import Element
+
 import toml
 import bokeh.palettes as bp
 from bokeh.models import ColumnDataSource, HoverTool

--- a/ross/results.py
+++ b/ross/results.py
@@ -770,7 +770,7 @@ class CampbellResults:
                             color=bokeh_colors[9],
                             muted_color=bokeh_colors[9],
                             muted_alpha=0.2,
-                            legend="Crit. Speed",
+                            legend_label="Crit. Speed",
                             name="critspeed",
                         )
                         hover = HoverTool(names=["critspeed"])
@@ -801,7 +801,7 @@ class CampbellResults:
                         muted_color=color_mapper,
                         muted_alpha=0.2,
                         source=source,
-                        legend=legend,
+                        legend_label=legend,
                     )
 
         harm_color = bp.Category20[20]
@@ -813,15 +813,15 @@ class CampbellResults:
                 color=harm_color[j],
                 line_dash="dotdash",
                 line_alpha=1.0,
-                legend=str(harm) + "x speed",
+                legend_label=str(harm) + "x speed",
                 muted_color=harm_color[j],
                 muted_alpha=0.2,
             )
 
         # turn legend glyphs black
-        camp.scatter(0, 0, color="black", size=0, marker="^", legend="Foward")
-        camp.scatter(0, 0, color="black", size=0, marker="o", legend="Mixed")
-        camp.scatter(0, 0, color="black", size=0, marker="v", legend="Backward")
+        camp.scatter(0, 0, color="black", size=0, marker="^", legend_label="Foward")
+        camp.scatter(0, 0, color="black", size=0, marker="o", legend_label="Mixed")
+        camp.scatter(0, 0, color="black", size=0, marker="v", legend_label="Backward")
 
         color_bar = ColorBar(
             color_mapper=color_mapper["transform"],

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1750,7 +1750,7 @@ class Rotor(object):
             size=5,
             fill_alpha=0.5,
             fill_color=bokeh_colors[0],
-            legend="Kxx",
+            legend_label="Kxx",
         )
         bk_ax.square(
             bearing0.kyy.interpolated(bearing0.frequency),
@@ -1758,7 +1758,7 @@ class Rotor(object):
             size=5,
             fill_alpha=0.5,
             fill_color=bokeh_colors[0],
-            legend="Kyy",
+            legend_label="Kyy",
         )
         for j in range(rotor_wn.T.shape[1]):
             bk_ax.line(

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -773,7 +773,7 @@ class ShaftElement(Element):
             line_width=1,
             fill_alpha=0.5,
             fill_color=bk_color,
-            legend=legend,
+            legend_label=legend,
             name="u_shaft",
         )
         bk_ax.quad(
@@ -1826,7 +1826,7 @@ class ShaftTaperedElement(Element):
             line_width=1,
             fill_alpha=0.5,
             fill_color=bk_color,
-            legend=legend,
+            legend_label=legend,
             name="u_shaft",
         )
         bk_ax.patches(
@@ -1837,7 +1837,7 @@ class ShaftTaperedElement(Element):
             line_width=1,
             fill_alpha=0.5,
             fill_color=bk_color,
-            legend=legend,
+            legend_label=legend,
             name="l_shaft",
         )
 


### PR DESCRIPTION
Bokeh library has updated to 1.4.0 version lately, and as you have noticed, several warnings about "legend" attribute getting deprecated has appeared. 
This PR update legend to legend_label according to the new sintaxe shown [here](https://docs.bokeh.org/en/latest/docs/user_guide/annotations.html).