### PR TITLE
Change math rendering mode from imgmath to mathjax

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
-    "sphinx.ext.imgmath",
+    "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.coverage",
     "numpydoc",


### PR DESCRIPTION
As explained on the sphinx docs
(https://www.sphinx-doc.org/en/1.8/usage/extensions/math.html), math
can be rendering using different methods. We were using the imgmath
method, which requires latex installed on the machine. Since our
documentation is built on Travis CI, we would need to install latex
there, but it seems that this is not a simple task as explained here:
https://tex.stackexchange.com/questions/398830/how-to-build-my-latex-automatically-using-travis-ci
The other option is to use mathjax, and the math gets rendered online
by the javascript package. We are adopting this method now.

With this modification the page is rendered like this:
![image](https://user-images.githubusercontent.com/18506378/69175483-a0824500-0ae2-11ea-98f8-aa421394b06e.png)


Closes #384.