### PR TITLE
Change ross to uppercase letters - ROSS

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,8 +24,8 @@ sys.path.append(os.path.abspath("../../ross"))
 # -- Project information -----------------------------------------------------
 
 project = "ross"
-copyright = "2019, Team Ross"
-author = "Team Ross"
+copyright = "2019, Team ROSS"
+author = "Team ROSS"
 
 import ross
 
@@ -121,7 +121,7 @@ colors = {
 # theme further.
 html_theme_options = {
     # Navigation bar title. (Default: ``project`` value)
-    "navbar_title": "ross",
+    "navbar_title": "ROSS",
     # Tab name for entire site. (Default: "Site")
     "navbar_site_name": "Site",
     # A list of tuples containing pages or urls to link to.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@
 
 .. |ross-logo| image:: ross-logo.svg
 
-|ross-logo| ross: rotordynamic open-source software
+|ross-logo| ROSS: Rotordynamic Open-Source Software
 ===================================================
 
 Ross is a library written in Python for rotordynamic analysis. The source is

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Installation
 Install Python
 --------------
 
-The first step is to install Python. Since ross requires several packages to be installed besides Python, such as
+The first step is to install Python. Since ROSS requires several packages to be installed besides Python, such as
 numpy, scipy and bokeh we recommend installing `Anaconda <https://www.anaconda.com/distribution/>`_ (version 3.6 or higher) which is a
 scientific Python distribution that aims to simplify package management and deployment. It contains Python and a large
 number of packages that are commonly used.
@@ -14,7 +14,7 @@ Alternatively, you may refer to the `Python website
 <http://www.python.org/>`_.
 Ross’s code is tested in Python 3.6 and higher.
 
-Install ross
+Install ROSS
 ------------
 
 Using the terminal (or the Anaconda prompt if on Windows) you can install the latest release version with::


### PR DESCRIPTION
The team decided that we should use capital letters on texts for the package
title, since it is an acronym. In the code the package name remains
ross to comply with pep 8 requirements for packages and modules (all
lowercase letters).