### PR TITLE
Allow user choose material in "Rotor.from_section()"

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2443,13 +2443,17 @@ class Rotor(object):
                 for i, leng in enumerate(leng_data):
                     le = leng / nel_r
                     for j in range(nel_r):
+                        idl = (idr_data[i] - idl_data[i]) * j * le / leng + idl_data[i]
+                        odl = (odr_data[i] - odl_data[i]) * j * le / leng + odl_data[i]
+                        idr = (idr_data[i] - idl_data[i]) * (j + 1) * le / leng + idl_data[i]
+                        odr = (odr_data[i] - odl_data[i]) * (j + 1) * le / leng + odl_data[i]
                         shaft_elements.append(
                             ShaftElement(
-                                L=le,
-                                idl=idl_data[i],
-                                odl=odl_data[i],
-                                idr=idr_data[i],
-                                odr=odr_data[i],
+                                le,
+                                idl,
+                                odl,
+                                idr,
+                                odr,
                                 material=material_data[i],
                                 shear_effects=True,
                                 rotary_inertia=True,
@@ -2460,13 +2464,17 @@ class Rotor(object):
                 for i, leng in enumerate(leng_data):
                     le = leng / nel_r
                     for j in range(nel_r):
+                        idl = (idr_data[i] - idl_data[i]) * j * le / leng + idl_data[i]
+                        odl = (odr_data[i] - odl_data[i]) * j * le / leng + odl_data[i]
+                        idr = (idr_data[i] - idl_data[i]) * (j + 1) * le / leng + idl_data[i]
+                        odr = (odr_data[i] - odl_data[i]) * (j + 1) * le / leng + odl_data[i]
                         shaft_elements.append(
                             ShaftElement(
-                                L=le,
-                                idl=idl_data[i],
-                                odl=odl_data[i],
-                                idr=idr_data[i],
-                                odr=odr_data[i],
+                                le,
+                                idl,
+                                odl,
+                                idr,
+                                odr,
                                 material=material_data,
                                 shear_effects=True,
                                 rotary_inertia=True,

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2487,11 +2487,15 @@ class Rotor(object):
             for DiskEl in disk_data:
                 aux_DiskEl = deepcopy(DiskEl)
                 aux_DiskEl.n = nel_r * DiskEl.n
+                aux_DiskEl.n_l = nel_r * DiskEl.n_l
+                aux_DiskEl.n_r = nel_r * DiskEl.n_r
                 disk_elements.append(aux_DiskEl)
 
             for Brg_SealEl in brg_seal_data:
                 aux_Brg_SealEl = deepcopy(Brg_SealEl)
                 aux_Brg_SealEl.n = nel_r * Brg_SealEl.n
+                aux_Brg_SealEl.n_l = nel_r * Brg_SealEl.n_l
+                aux_Brg_SealEl.n_r = nel_r * Brg_SealEl.n_r
                 bearing_seal_elements.append(aux_Brg_SealEl)
 
             regions.append(disk_elements)

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -994,7 +994,7 @@ def test_from_section():
 
     with pytest.raises(ValueError) as excinfo:
         Rotor.from_section(
-            leng_data=leng_data_error,
+            leng_data=leng_data,
             idl_data=idl_data,
             odl_data=odl_data,
             odr_data=odr_data_error,

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -942,10 +942,14 @@ def test_from_section():
     #  Rotor built from classmethod from_section
     #  2 disks and 2 bearings
     leng_data = [0.5, 1.0, 2.0, 1.0, 0.5]
-    leng_data2 = [0.5, 1.0, 2.0, 1.0]
-    o_ds_data = [0.1, 0.2, 0.3, 0.2, 0.1]
-    o_ds_data2 = [0.1, 0.2, 0.3, 0.2]
-    i_ds_data = [0, 0, 0, 0, 0]
+    leng_data_error = [0.5, 1.0, 2.0, 1.0]
+
+    odl_data = [0.1, 0.2, 0.3, 0.2, 0.1]
+    odr_data_error = [0.1, 0.2, 0.3, 0.2]
+
+    idl_data = [0, 0, 0, 0, 0]
+    material = steel
+    material_error = [steel, steel]
     disk_data = [
         DiskElement.from_geometry(n=2, material=steel, width=0.07, i_d=0.05, o_d=0.28),
         DiskElement.from_geometry(n=3, material=steel, width=0.07, i_d=0.05, o_d=0.35),
@@ -957,8 +961,9 @@ def test_from_section():
 
     rotor1 = Rotor.from_section(
         leng_data=leng_data,
-        o_ds_data=o_ds_data,
-        i_ds_data=i_ds_data,
+        idl_data=idl_data,
+        odl_data=odl_data,
+        material_data=material,
         disk_data=disk_data,
         brg_seal_data=brg_seal_data,
         nel_r=4,
@@ -977,25 +982,52 @@ def test_from_section():
 
     with pytest.raises(ValueError) as excinfo:
         Rotor.from_section(
-            leng_data=leng_data2,
-            o_ds_data=o_ds_data,
-            i_ds_data=i_ds_data,
+            leng_data=leng_data_error,
+            idl_data=idl_data,
+            odl_data=odl_data,
+            material_data=material,
             disk_data=disk_data,
             brg_seal_data=brg_seal_data,
             nel_r=4,
         )
-    assert "The matrices lenght do not match." == str(excinfo.value)
+    assert "The lists size do not match (leng_data, odl_data and idl_data)." == str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        Rotor.from_section(
+            leng_data=leng_data_error,
+            idl_data=idl_data,
+            odl_data=odl_data,
+            odr_data=odr_data_error,
+            material_data=material,
+            disk_data=disk_data,
+            brg_seal_data=brg_seal_data,
+            nel_r=4,
+        )
+    assert "The lists size do not match (leng_data, odr_data and idr_data)." == str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         Rotor.from_section(
             leng_data=leng_data,
-            o_ds_data=o_ds_data2,
-            i_ds_data=i_ds_data,
+            idl_data=idl_data,
+            odl_data=odl_data,
+            material_data=None,
             disk_data=disk_data,
             brg_seal_data=brg_seal_data,
             nel_r=4,
         )
-    assert "The matrices lenght do not match." == str(excinfo.value)
+    assert "Please define a material or a list of materials" == str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        Rotor.from_section(
+            leng_data=leng_data,
+            idl_data=idl_data,
+            odl_data=odl_data,
+            material_data=material_error,
+            disk_data=disk_data,
+            brg_seal_data=brg_seal_data,
+            nel_r=4,
+        )
+    assert "material_data size does not match size of other lists" == str(excinfo.value)
 
 
 @pytest.fixture

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1017,7 +1017,7 @@ def test_from_section():
         )
     assert "Please define a material or a list of materials" == str(excinfo.value)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(IndexError) as excinfo:
         Rotor.from_section(
             leng_data=leng_data,
             idl_data=idl_data,

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1005,7 +1005,7 @@ def test_from_section():
         )
     assert "The lists size do not match (leng_data, odr_data and idr_data)." == str(excinfo.value)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(AttributeError) as excinfo:
         Rotor.from_section(
             leng_data=leng_data,
             idl_data=idl_data,


### PR DESCRIPTION
As requested in Issue #401, the user will be able to define a material when using `.from_section()` classmethod.
In addition, more modifications have been done regarding the new ShaftElement API.
Now, the user has the option to instantiate tapered sections.