### PR TITLE
Fix links not working for more than one support

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -251,17 +251,17 @@ class BearingElement(Element):
         --------
         >>> bearing = bearing_example()
         >>> bearing # doctest: +ELLIPSIS
-        BearingElement(n=0,
+        BearingElement(n=0, n_link=None,
          kxx=[...
         """
         return (
             f"{self.__class__.__name__}"
-            f"(n={self.n},\n"
+            f"(n={self.n}, n_link={self.n_link},\n"
             f" kxx={self.kxx}, kxy={self.kxy},\n"
             f" kyx={self.kyx}, kyy={self.kyy},\n"
             f" cxx={self.cxx}, cxy={self.cxy},\n"
             f" cyx={self.cyx}, cyy={self.cyy},\n"
-            f" frequency={self.frequency}, tag={self.tag!r}, n_link={self.n_link})"
+            f" frequency={self.frequency}, tag={self.tag!r})"
         )
 
     def __eq__(self, other):

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -806,7 +806,7 @@ class BearingElement(Element):
         >>> import os
         >>> file_path = os.path.dirname(os.path.realpath(__file__)) + '/tests/data/bearing_seal_si.xls'
         >>> BearingElement.from_table(0, file_path) # doctest: +ELLIPSIS
-        BearingElement(n=0,
+        BearingElement(n=0, n_link=None,
          kxx=[...
         """
         parameters = read_table_file(file, "bearing", sheet_name, n)
@@ -914,7 +914,7 @@ class BearingElement(Element):
         >>> BearingElement.from_fluid_flow(0, nz, ntheta, nradius, length, omega, p_in,
         ...                                p_out, radius_rotor, radius_stator,
         ...                                visc, rho, eccentricity=eccentricity) # doctest: +ELLIPSIS
-        BearingElement(n=0,
+        BearingElement(n=0, n_link=None,
          kxx=[...
         """
         fluid_flow = flow.FluidFlow(

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -237,6 +237,7 @@ class BearingElement(Element):
         self.tag = tag
         self.color = "#355d7a"
         self.scale_factor = scale_factor
+        self.dof_global_index = None
 
     def __repr__(self):
         """This function returns a string representation of a bearing element.
@@ -260,7 +261,7 @@ class BearingElement(Element):
             f" kyx={self.kyx}, kyy={self.kyy},\n"
             f" cxx={self.cxx}, cxy={self.cxy},\n"
             f" cyx={self.cyx}, cyy={self.cyy},\n"
-            f" frequency={self.frequency}, tag={self.tag!r})"
+            f" frequency={self.frequency}, tag={self.tag!r}, n_link={self.n_link})"
         )
 
     def __eq__(self, other):

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -47,6 +47,7 @@ class DiskElement(Element):
         self.Ip = Ip
         self.tag = tag
         self.color = bokeh_colors[9]
+        self.dof_global_index = None
 
     def __eq__(self, other):
         """This function allows disk elements to be compared.

--- a/ross/element.py
+++ b/ross/element.py
@@ -283,33 +283,3 @@ class Element(ABC):
         local_index = dof_tuple(**dof_mapping)
 
         return local_index
-
-    def dof_global_index(self):
-        """Get the global index for a element specific degree of freedom.
-
-        Returns
-        -------
-        global_index: namedtupple
-            A named tuple containing the global index.
-
-        Examples
-        --------
-        >>> # Example using BearingElement
-        >>> from ross.bearing_seal_element import bearing_example
-        >>> bearing = bearing_example()
-        >>> bearing.dof_global_index()
-        GlobalIndex(x_0=0, y_0=1)
-        """
-        dof_mapping = self.dof_mapping()
-        global_dof_mapping = {}
-        for k, v in dof_mapping.items():
-            dof_letter, dof_number = k.split("_")
-            global_dof_mapping[dof_letter + "_" + str(int(dof_number) + self.n)] = v
-        dof_tuple = namedtuple("GlobalIndex", global_dof_mapping)
-
-        for k, v in global_dof_mapping.items():
-            global_dof_mapping[k] = 4 * self.n + v
-
-        global_index = dof_tuple(**global_dof_mapping)
-
-        return global_index

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -58,6 +58,7 @@ class PointMass(Element):
         self.mx = mx
         self.my = my
         self.tag = tag
+        self.dof_global_index = None
 
     def __hash__(self):
         return hash(self.tag)

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -39,12 +39,12 @@ class PointMass(Element):
     --------
     >>> p0 = PointMass(n=0, m=2)
     >>> p0.M()
-    array([[2, 0],
-           [0, 2]])
+    array([[2., 0.],
+           [0., 2.]])
     >>> p1 = PointMass(n=0, mx=2, my=3)
     >>> p1.M()
-    array([[2, 0],
-           [0, 3]])
+    array([[2., 0.],
+           [0., 3.]])
     """
 
     def __init__(self, n=None, m=None, mx=None, my=None, tag=None):
@@ -52,11 +52,11 @@ class PointMass(Element):
         self.m = m
 
         if mx is None and my is None:
-            mx = m
-            my = m
+            mx = float(m)
+            my = float(m)
 
-        self.mx = mx
-        self.my = my
+        self.mx = float(mx)
+        self.my = float(my)
         self.tag = tag
         self.dof_global_index = None
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1052,7 +1052,8 @@ class Rotor(object):
         array([[[1.00000000e-06, 1.00261725e-06, 1.01076952e-06, ...
         """
         if speed_range is None:
-            speed_range = np.linspace(0, max(self.evalues.imag) * 1.5, 1000)
+            modal = self.run_modal(0)
+            speed_range = np.linspace(0, max(modal.evalues.imag) * 1.5, 1000)
 
         freq_resp = np.empty((self.ndof, self.ndof, len(speed_range)), dtype=np.complex)
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -368,8 +368,8 @@ class Rotor(object):
         )
 
         # global indexes for dofs
+        n_last = self.shaft_elements[-1].n
         for elm in self.elements:
-            n_last = self.shaft_elements[-1].n
             dof_mapping = elm.dof_mapping()
             global_dof_mapping = {}
             for k, v in dof_mapping.items():
@@ -386,13 +386,7 @@ class Rotor(object):
 
             elm.dof_global_index = dof_tuple(**global_dof_mapping)
 
-            bearing_class_list = [
-                    "BearingElement",
-                    "SealElement",
-                    "BallBearingElement",
-                    "RollerBearingElement",
-            ]
-            if elm.__class__.__name__ in bearing_class_list:
+            if isinstance(elm, BearingElement):
                 if elm.n_link is not None:
                     dof_global_index = elm.dof_global_index._asdict()
                     if elm.n_link <= n_last + 1:

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -380,24 +380,19 @@ class Rotor(object):
             if elm.n <= n_last + 1:
                 for k, v in global_dof_mapping.items():
                     global_dof_mapping[k] = 4 * elm.n + v
+                if hasattr(elm, "n_link") and elm.n_link is not None:
+                    global_dof_mapping[f"x_{elm.n_link}"] = 4 * elm.n_link
+                    global_dof_mapping[f"y_{elm.n_link}"] = 4 * elm.n_link + 1
             else:
                 for k, v in global_dof_mapping.items():
                     global_dof_mapping[k] = 2 * n_last + 2 * elm.n + 4 + v
+                if hasattr(elm, "n_link") and elm.n_link is not None:
+                    global_dof_mapping[f"x_{elm.n_link}"] = 2 * n_last + 2 * elm.n_link + 4 
+                    global_dof_mapping[f"y_{elm.n_link}"] = 2 * n_last + 2 * elm.n_link + 5
 
+            dof_tuple = namedtuple("GlobalIndex", global_dof_mapping)
             elm.dof_global_index = dof_tuple(**global_dof_mapping)
-
-            if isinstance(elm, BearingElement):
-                if elm.n_link is not None:
-                    dof_global_index = elm.dof_global_index._asdict()
-                    if elm.n_link <= n_last + 1:
-                        dof_global_index[f"x_{elm.n_link}"] = 4 * elm.n_link
-                        dof_global_index[f"y_{elm.n_link}"] = 4 * elm.n_link + 1
-                    else:
-                        dof_global_index[f"x_{elm.n_link}"] = 2 * n_last + 2 * elm.n_link + 4 
-                        dof_global_index[f"y_{elm.n_link}"] = 2 * n_last + 2 * elm.n_link + 5
-
-                    dof_tuple = namedtuple("GlobalIndex", dof_global_index)
-                    elm.dof_global_index = dof_tuple(**dof_global_index)
+            df.at[df.loc[df.tag == elm.tag].index[0], "dof_global_index"] = elm.dof_global_index
 
         #  values for static analysis will be calculated by def static
         self.Vx = None

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -380,14 +380,16 @@ class Rotor(object):
             if elm.n <= n_last + 1:
                 for k, v in global_dof_mapping.items():
                     global_dof_mapping[k] = 4 * elm.n + v
-                if hasattr(elm, "n_link") and elm.n_link is not None:
-                    global_dof_mapping[f"x_{elm.n_link}"] = 4 * elm.n_link
-                    global_dof_mapping[f"y_{elm.n_link}"] = 4 * elm.n_link + 1
             else:
                 for k, v in global_dof_mapping.items():
-                    global_dof_mapping[k] = 2 * n_last + 2 * elm.n + 4 + v
-                if hasattr(elm, "n_link") and elm.n_link is not None:
-                    global_dof_mapping[f"x_{elm.n_link}"] = 2 * n_last + 2 * elm.n_link + 4 
+                    global_dof_mapping[k] = 2 * n_last + 2 * elm.n + 4 + v                
+
+            if hasattr(elm, "n_link") and elm.n_link is not None:
+                if elm.n_link <= n_last + 1:                
+                    global_dof_mapping[f"x_{elm.n_link}"] = 4 * elm.n_link
+                    global_dof_mapping[f"y_{elm.n_link}"] = 4 * elm.n_link + 1
+                else:
+                    global_dof_mapping[f"x_{elm.n_link}"] = 2 * n_last + 2 * elm.n_link + 4
                     global_dof_mapping[f"y_{elm.n_link}"] = 2 * n_last + 2 * elm.n_link + 5
 
             dof_tuple = namedtuple("GlobalIndex", global_dof_mapping)

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -293,6 +293,7 @@ class ShaftElement(Element):
             self.kappa = kappa
 
         self.phi = phi
+        self.dof_global_index = None
 
     def __eq__(self, other):
         """

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -97,9 +97,6 @@ def test_index(bearing1):
     assert bearing1.dof_local_index().x_0 == 0
     assert bearing1.dof_local_index()[1] == 1
     assert bearing1.dof_local_index().y_0 == 1
-    assert bearing1.dof_global_index().x_4 == 16
-    assert bearing1.dof_global_index().y_4 == 17
-    assert bearing1.dof_global_index()[-1] == 17
 
 
 def test_bearing1_interpol_kxx(bearing1):
@@ -231,16 +228,6 @@ def test_from_table():
     assert bearing.n == 0
     assert_allclose(bearing.frequency[2], 523.5987755985)
     assert_allclose(bearing.kxx.coefficient[2], 53565700)
-
-
-def test_bearing_link_global_index():
-    b0 = BearingElement(n=0, n_link=3, kxx=1, cxx=1)
-    idx = b0.dof_global_index()
-    assert idx.x_0 == 0
-    assert idx.y_0 == 1
-    print(idx)
-    assert idx.x_3 == 12
-    assert idx.y_3 == 13
 
 
 def test_bearing_link_matrices():

--- a/ross/tests/test_disk_element.py
+++ b/ross/tests/test_disk_element.py
@@ -17,10 +17,6 @@ def test_index(disk):
     assert disk.dof_local_index().y_0 == 1
     assert disk.dof_local_index().alpha_0 == 2
     assert disk.dof_local_index().beta_0 == 3
-    assert disk.dof_global_index().x_0 == 0
-    assert disk.dof_global_index().y_0 == 1
-    assert disk.dof_global_index().alpha_0 == 2
-    assert disk.dof_global_index().beta_0 == 3
 
 
 def test_mass_matrix_disk(disk):

--- a/ross/tests/test_point_mass.py
+++ b/ross/tests/test_point_mass.py
@@ -9,9 +9,20 @@ def test_point_mass():
                    [0, 10.0]])
     # fmt: on
 
-    p = PointMass(n=0, m=10.0)
+    p = PointMass(n=0, m=10.0, tag="pointmass")
 
+    assert p.tag == 'pointmass'
     assert_allclose(m0, p.M())
     assert_allclose(np.zeros((2, 2)), p.K())
     assert_allclose(np.zeros((2, 2)), p.C())
     assert_allclose(np.zeros((2, 2)), p.G())
+
+
+def test_local_index():
+    n = 0
+    mx = 1.0
+    my = 2.0
+    p = PointMass(n=n, mx=mx, my=my)
+
+    assert p.dof_local_index().x_0 == 0
+    assert p.dof_local_index().y_0 == 1

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -10,7 +10,7 @@ from ross.materials import steel
 from ross.rotor_assembly import *
 from ross.rotor_assembly import MAC_modes
 from ross.shaft_element import *
-from ross.point_mass import PointMass
+from ross.point_mass import *
 
 test_dir = os.path.dirname(__file__)
 
@@ -1237,7 +1237,7 @@ def test_save_load():
     assert a == b
 
 
-def test_rotor_link():
+def test_global_index():
     i_d = 0
     o_d = 0.05
     n = 6
@@ -1260,19 +1260,53 @@ def test_rotor_link():
     stfx = 1e6
     stfy = 0.8e6
     bearing0 = BearingElement(0, n_link=7, kxx=stfx, kyy=stfy, cxx=0)
-    support = BearingElement(7, kxx=stfx, kyy=stfy, cxx=0)
-    bearing1 = BearingElement(6, kxx=stfx, kyy=stfy, cxx=0)
+    support0 = BearingElement(7, kxx=stfx, kyy=stfy, cxx=0, tag="Support0")
+    bearing1 = BearingElement(6, n_link=8, kxx=stfx, kyy=stfy, cxx=0)
+    support1 = BearingElement(8, kxx=stfx, kyy=stfy, cxx=0, tag="Support1")
 
-    point_mass = PointMass(7, m=1.0)
+    point_mass0 = PointMass(7, m=1.0)
+    point_mass1 = PointMass(8, m=1.0)
 
     rotor = Rotor(
-        shaft_elem, [disk0, disk1], [bearing0, support, bearing1], [point_mass]
+            shaft_elem,
+            [disk0, disk1],
+            [bearing0, bearing1, support0, support1],
+            [point_mass0, point_mass1]
     )
 
-    modal = rotor.run_modal(1000 / 9.5492965964254)
+    shaft = rotor.shaft_elements
+    disks = rotor.disk_elements
+    bearings = rotor.bearing_seal_elements
+    pointmass = rotor.point_mass_elements
 
-    wn_expected = np.array(
-        [82.43809938, 87.5639844, 239.36021417, 261.15187937, 646.59858922, 688.428424]
-    )
+    assert shaft[0].dof_global_index.x_0 == 0
+    assert shaft[0].dof_global_index.y_0 == 1
+    assert shaft[0].dof_global_index.alpha_0 == 2
+    assert shaft[0].dof_global_index.beta_0 == 3
+    assert shaft[0].dof_global_index.x_1 == 4
+    assert shaft[0].dof_global_index.y_1 == 5
+    assert shaft[0].dof_global_index.alpha_1 == 6
+    assert shaft[0].dof_global_index.beta_1 == 7
 
-    assert_allclose(modal.wn, wn_expected)
+    assert disks[0].dof_global_index.x_2 == 8
+    assert disks[0].dof_global_index.y_2 == 9
+    assert disks[0].dof_global_index.alpha_2 == 10
+    assert disks[0].dof_global_index.beta_2 == 11
+
+    assert bearings[0].dof_global_index.x_0 == 0
+    assert bearings[0].dof_global_index.y_0 == 1
+    assert bearings[0].dof_global_index.x_7 == 28
+    assert bearings[0].dof_global_index.y_7 == 29
+    assert bearings[1].dof_global_index.x_6 == 24
+    assert bearings[1].dof_global_index.y_6 == 25
+    assert bearings[1].dof_global_index.x_8 == 30
+    assert bearings[1].dof_global_index.y_8 == 31
+    assert bearings[2].dof_global_index.x_7 == 28
+    assert bearings[2].dof_global_index.y_7 == 29
+    assert bearings[3].dof_global_index.x_8 == 30
+    assert bearings[3].dof_global_index.y_8 == 31
+
+    assert pointmass[0].dof_global_index.x_7 == 28
+    assert pointmass[0].dof_global_index.y_7 == 29
+    assert pointmass[1].dof_global_index.x_8 == 30
+    assert pointmass[1].dof_global_index.y_8 == 31

--- a/ross/tests/test_shaft_element.py
+++ b/ross/tests/test_shaft_element.py
@@ -28,10 +28,6 @@ def test_index(eb):
     assert eb.dof_local_index().y_0 == 1
     assert eb.dof_local_index().alpha_0 == 2
     assert eb.dof_local_index().beta_0 == 3
-    assert eb.dof_global_index().x_3 == 12
-    assert eb.dof_global_index().y_3 == 13
-    assert eb.dof_global_index().alpha_3 == 14
-    assert eb.dof_global_index().beta_3 == 15
 
 
 def test_parameters_eb(eb):
@@ -195,14 +191,6 @@ def test_tapered_index(tap_tim):
     assert tap_tim.dof_local_index().y_1 == 5
     assert tap_tim.dof_local_index().alpha_1 == 6
     assert tap_tim.dof_local_index().beta_1 == 7
-    assert tap_tim.dof_global_index().x_3 == 12
-    assert tap_tim.dof_global_index().y_3 == 13
-    assert tap_tim.dof_global_index().alpha_3 == 14
-    assert tap_tim.dof_global_index().beta_3 == 15
-    assert tap_tim.dof_global_index().x_4 == 16
-    assert tap_tim.dof_global_index().y_4 == 17
-    assert tap_tim.dof_global_index().alpha_4 == 18
-    assert tap_tim.dof_global_index().beta_4 == 19
 
 
 def test_parameters_tap_tim(tap_tim):


### PR DESCRIPTION
Related to Issue #382.

We were having problems to define de global indexes for the elements using this method intenally to a element class.
It makes more sense to use .dof_global_index() when build the rotor model.
The routine to calculate the elements' global indexes have been moved to rotor_assembly (`.__init__()` method).
Now, each element has an attribute that keeps those index, instead of calling a function to this job.