### PR TITLE
Add units

### DIFF
--- a/ross/materials.py
+++ b/ross/materials.py
@@ -31,7 +31,7 @@ class Material:
     G_s : float
         Shear modulus (N/m**2).
     rho : float
-        Density (N/m**3).
+        Density (kg/m**3).
     color : str
         Can be used on plots.
 

--- a/ross/new_units.txt
+++ b/ross/new_units.txt
@@ -1,0 +1,2 @@
+RPM = rpm * 1
+hour = 60 * minute = h = hr

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -11,6 +11,7 @@ import ross
 from ross.element import Element
 from ross.materials import Material, steel
 from ross.utils import read_table_file
+from ross.units import check_units
 
 __all__ = ["ShaftElement"]
 bokeh_colors = bp.RdGy[11]
@@ -31,16 +32,16 @@ class ShaftElement(Element):
 
     Parameters
     ----------
-    L : float
+    L : float, pint.Quantity
         Element length.
-    idl : float
+    idl : float, pint.Quantity
         Inner diameter of the element at the left position..
-    odl : float
+    odl : float, pint.Quantity
         Outer diameter of the element at the left position.
-    idr : float, optional
+    idr : float, pint.Quantity, optional
         Inner diameter of the element at the right position
         Default is equal to idl value (cylindrical element)
-    odr : float, optional
+    odr : float, pint.Quantity, optional
         Outer diameter of the element at the right position.
         Default is equal to odl value (cylindrical element)
     material : ross.material
@@ -122,6 +123,7 @@ class ShaftElement(Element):
     >>> Timoshenko_Element.phi
     0.1571268472906404
     """
+    @check_units
     def __init__(
         self,
         L,
@@ -139,6 +141,14 @@ class ShaftElement(Element):
         shear_method_calc="cowper",
         tag=None,
     ):
+
+        # After changing units to defined unit (see units.py), we go back to using only the magnitude
+        # This could be modified later if we apply pint to all arguments and have consistency throughout the package
+        L = L.m
+        idl = idl.m
+        odl = odl.m
+        idr = idr.m
+        odr = odr.m
 
         if idr is None:
             idr = idl

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -123,6 +123,7 @@ class ShaftElement(Element):
     >>> Timoshenko_Element.phi
     0.1571268472906404
     """
+
     @check_units
     def __init__(
         self,
@@ -142,6 +143,11 @@ class ShaftElement(Element):
         tag=None,
     ):
 
+        if idr is None:
+            idr = idl
+        if odr is None:
+            odr = odl
+
         # After changing units to defined unit (see units.py), we go back to using only the magnitude
         # This could be modified later if we apply pint to all arguments and have consistency throughout the package
         L = L.m
@@ -149,11 +155,6 @@ class ShaftElement(Element):
         odl = odl.m
         idr = idr.m
         odr = odr.m
-
-        if idr is None:
-            idr = idl
-        if odr is None:
-            odr = odl
 
         if material is None:
             raise AttributeError("Material is not defined.")
@@ -400,9 +401,7 @@ class ShaftElement(Element):
             shaft_elements_dict = toml.load(f)
             for element in shaft_elements_dict["ShaftElement"]:
                 shaft_elements.append(
-                    ShaftElement(
-                        **shaft_elements_dict["ShaftElement"][element]
-                    )
+                    ShaftElement(**shaft_elements_dict["ShaftElement"][element])
                 )
         return shaft_elements
 
@@ -1187,19 +1186,18 @@ class ShaftElement(Element):
 
         elements = [
             cls(
-                    le,
-                    (s_idr - s_idl) * i * le / L + s_idl,
-                    (s_odr - s_odl) * i * le / L + s_odl,
-                    (s_idr - s_idl) * (i + 1) * le / L + s_idl,
-                    (s_odr - s_odl) * (i + 1) * le / L + s_odl,
-                    material,
-                    n,
-                    shear_effects,
-                    rotary_inertia,
-                    gyroscopic
+                le,
+                (s_idr - s_idl) * i * le / L + s_idl,
+                (s_odr - s_odl) * i * le / L + s_odl,
+                (s_idr - s_idl) * (i + 1) * le / L + s_idl,
+                (s_odr - s_odl) * (i + 1) * le / L + s_odl,
+                material,
+                n,
+                shear_effects,
+                rotary_inertia,
+                gyroscopic,
             )
             for i in range(ne)
         ]
 
         return elements
-

--- a/ross/tests/test_units.py
+++ b/ross/tests/test_units.py
@@ -1,0 +1,157 @@
+import pytest
+from numpy.testing import assert_allclose
+from ross.units import check_units, Q_, units
+
+
+def test_new_units_loaded():
+    speed = Q_(1, "RPM")
+    assert speed.magnitude == 1
+
+
+@pytest.fixture
+def auxiliary_function():
+    @check_units
+    def func(E, G_s, rho, L, idl, idr, odl, odr, speed, frequency):
+        return E, G_s, rho, L, idl, idr, odl, odr, speed, frequency
+
+    return func
+
+
+def test_units(auxiliary_function):
+    results = auxiliary_function(
+        E=1, G_s=1, rho=1, L=1, idl=1, idr=1, odl=1, odr=1, speed=1, frequency=1
+    )
+    # check if all available units are tested
+    assert len(results) == len(units)
+
+    E, G_s, rho, L, idl, idr, odl, odr, speed, frequency = results
+
+    assert E.magnitude == 1
+    assert E.units == "newton/meter**2"
+
+    assert G_s.magnitude == 1
+    assert G_s.units == "newton/meter**2"
+
+    assert rho.magnitude == 1
+    assert rho.units == "kilogram/meter**3"
+
+    assert L.magnitude == 1
+    assert L.units == "meter"
+
+    assert idl.magnitude == 1
+    assert idl.units == "meter"
+
+    assert idr.magnitude == 1
+    assert idr.units == "meter"
+
+    assert odl.magnitude == 1
+    assert odl.units == "meter"
+
+    assert odr.magnitude == 1
+    assert odr.units == "meter"
+
+    assert speed.magnitude == 1
+    assert speed.units == "radian/second"
+
+    assert frequency.magnitude == 1
+    assert frequency.units == "radian/second"
+
+
+def test_unit_Q_(auxiliary_function):
+    results = auxiliary_function(
+        E=Q_(1, "N/m**2"),
+        G_s=Q_(1, "N/m**2"),
+        rho=Q_(1, "kg/m**3"),
+        L=Q_(1, "meter"),
+        idl=Q_(1, "meter"),
+        idr=Q_(1, "meter"),
+        odl=Q_(1, "meter"),
+        odr=Q_(1, "meter"),
+        speed=Q_(1, "radian/second"),
+        frequency=Q_(1, "radian/second"),
+    )
+
+    # check if all available units are tested
+    assert len(results) == len(units)
+
+    E, G_s, rho, L, idl, idr, odl, odr, speed, frequency = results
+
+    assert E.magnitude == 1
+    assert E.units == "newton/meter**2"
+
+    assert G_s.magnitude == 1
+    assert G_s.units == "newton/meter**2"
+
+    assert rho.magnitude == 1
+    assert rho.units == "kilogram/meter**3"
+
+    assert L.magnitude == 1
+    assert L.units == "meter"
+
+    assert idl.magnitude == 1
+    assert idl.units == "meter"
+
+    assert idr.magnitude == 1
+    assert idr.units == "meter"
+
+    assert odl.magnitude == 1
+    assert odl.units == "meter"
+
+    assert odr.magnitude == 1
+    assert odr.units == "meter"
+
+    assert speed.magnitude == 1
+    assert speed.units == "radian/second"
+
+    assert frequency.magnitude == 1
+    assert frequency.units == "radian/second"
+
+
+def test_unit_Q_conversion(auxiliary_function):
+    results = auxiliary_function(
+        E=Q_(1, "lbf/in**2"),
+        G_s=Q_(1, "lbf/in**2"),
+        rho=Q_(1, "lb/foot**3"),
+        L=Q_(1, "inches"),
+        idl=Q_(1, "inches"),
+        idr=Q_(1, "inches"),
+        odl=Q_(1, "inches"),
+        odr=Q_(1, "inches"),
+        speed=Q_(1, "RPM"),
+        frequency=Q_(1, "RPM"),
+    )
+
+    # check if all available units are tested
+    assert len(results) == len(units)
+
+    E, G_s, rho, L, idl, idr, odl, odr, speed, frequency = results
+
+    assert E.magnitude == 6894.7572931683635
+    assert E.units == "newton/meter**2"
+
+    assert G_s.magnitude == 6894.7572931683635
+    assert G_s.units == "newton/meter**2"
+
+    assert_allclose(rho.magnitude, 16.01846337396014)
+    assert rho.units == "kilogram/meter**3"
+
+    assert L.magnitude == 0.0254
+    assert L.units == "meter"
+
+    assert idl.magnitude == 0.0254
+    assert idl.units == "meter"
+
+    assert idr.magnitude == 0.0254
+    assert idr.units == "meter"
+
+    assert odl.magnitude == 0.0254
+    assert odl.units == "meter"
+
+    assert odr.magnitude == 0.0254
+    assert odr.units == "meter"
+
+    assert speed.magnitude == 0.10471975511965977
+    assert speed.units == "radian/second"
+
+    assert frequency.magnitude == 0.10471975511965977
+    assert frequency.units == "radian/second"

--- a/ross/units.py
+++ b/ross/units.py
@@ -16,12 +16,14 @@ __all__ = ["Q_", "check_units"]
 units = {
     "E": "N/m**2",
     "G_s": "N/m**2",
-    "rho": "N/m**3",
+    "rho": "kg/m**3",
     "L": "meter",
     "idl": "meter",
     "idr": "meter",
     "odl": "meter",
     "odr": "meter",
+    "speed": "radian/second",
+    "frequency": "radian/second",
 }
 
 

--- a/ross/units.py
+++ b/ross/units.py
@@ -1,0 +1,82 @@
+"""
+This module deals with units conversion in the ROSS library. 
+"""
+import inspect
+from pint import UnitRegistry
+from functools import wraps
+from pathlib import Path
+
+new_units_path = Path(__file__).parent / "new_units.txt"
+ureg = UnitRegistry()
+ureg.load_definitions(str(new_units_path))
+Q_ = ureg.Quantity
+
+__all__ = ["Q_", "check_units"]
+
+units = {
+    "E": "N/m**2",
+    "G_s": "N/m**2",
+    "rho": "N/m**3",
+    "L": "meter",
+    "idl": "meter",
+    "idr": "meter",
+    "odl": "meter",
+    "odr": "meter",
+}
+
+
+def check_units(func):
+    """Wrapper to check and convert units to base_units.
+
+    If we use the check_units decorator in a function the arguments are checked, and if they are in the units
+    dictionary, they are converted to the 'default' unit given in the dictionary.
+
+    For example:
+    >>> units = {
+    ... "L": "meter",
+    ... }
+
+    >>> @check_units
+    ... def foo(L=None):
+    ...     print(L)
+    ...
+
+    If we call the function with the argument as a float:
+    >>> foo(L=0.5)
+    0.5 meter
+
+    the L argument will be available inside the function as a pint.Quantity object
+    (with the magnitude and units attributes).
+
+    If we call the function with a pint.Quantity object the value is automatically converted to the default:
+    >>> foo(L=Q_(0.5, 'inches'))
+    0.0127 meter
+    """
+
+    @wraps(func)
+    def inner(*args, **kwargs):
+        base_unit_args = []
+        args_names = inspect.getfullargspec(func)[0]
+
+        for arg_name, arg_value in zip(args_names, args):
+            if arg_name in units:
+                try:
+                    base_unit_args.append(arg_value.to(units[arg_name]))
+                except AttributeError:
+                    base_unit_args.append(Q_(arg_value, units[arg_name]))
+            else:
+                base_unit_args.append(arg_value)
+
+        base_unit_kwargs = {}
+        for k, v in kwargs.items():
+            if k in units and v is not None:
+                try:
+                    base_unit_kwargs[k] = v.to(units[k])
+                except AttributeError:
+                    base_unit_kwargs[k] = Q_(v, units[k])
+            else:
+                base_unit_kwargs[k] = v
+
+        return func(*base_unit_args, **base_unit_kwargs)
+
+    return inner

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ REQUIRED = [
     "bokeh",
     "coverage",
     "xlrd",
+    "pint",
 ]
 
 # What packages are optional?


### PR DESCRIPTION
If we use the check_units decorator in a function the arguments are checked, and if they are in the units
dictionary, they are converted to the 'default' unit given in the dictionary.

For example:
```python
>>> units = {
... "L": "meter",
... }

>>> @check_units
... def foo(L=None):
...     print(L)
```

If we call the function with the argument as a float:
```python
>>> foo(L=0.5)
0.5 meter
```

the L argument will be available inside the function as a pint.Quantity object
(with the magnitude and units attributes).

If we call the function with a pint.Quantity object the value is automatically converted to the default:
```python
>>> foo(L=Q_(0.5, 'inches'))
0.0127 meter
```

Closes #440 