### PR TITLE
Configuring flake8 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 ignore = E203, E266, E501, W503
+exclude = ross/tests
 # line length is intentionally set to 88 here because ROSS uses Black default config
 max-line-length = 88
 max-complexity = 18

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+ignore = E203, E266, E501, W503
+# line length is intentionally set to 88 here because ROSS uses Black default config
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
File configuring options for code formatting.

Related to Issue #463. I copied the file from Black repository and I did some adjustments to fit our repository. As we're using Black with default options (max line length equals to 88) I set the .flake8 file to max line length to 88 either (we can change it later).