### PR TITLE
Removing deprecations and warnings

### DIFF
--- a/ross/fluid_flow/fluid_flow_graphics.py
+++ b/ross/fluid_flow/fluid_flow_graphics.py
@@ -81,7 +81,7 @@ def plot_pressure_z(fluid_flow_object, theta=0):
         p.line(
             fluid_flow_object.z_list,
             y_n,
-            legend="Numerical pressure",
+            legend_label="Numerical pressure",
             color="blue",
             line_width=2,
         )
@@ -89,7 +89,7 @@ def plot_pressure_z(fluid_flow_object, theta=0):
         p.line(
             fluid_flow_object.z_list,
             y_a,
-            legend="Analytical pressure",
+            legend_label="Analytical pressure",
             color="red",
             line_width=2,
         )
@@ -170,7 +170,7 @@ def plot_pressure_theta(fluid_flow_object, z=0):
         p.line(
             fluid_flow_object.gama[z],
             fluid_flow_object.p_mat_numerical[z],
-            legend="Numerical pressure",
+            legend_label="Numerical pressure",
             line_width=2,
             color="blue",
         )
@@ -178,7 +178,7 @@ def plot_pressure_theta(fluid_flow_object, z=0):
         p.line(
             fluid_flow_object.gama[z],
             fluid_flow_object.p_mat_analytical[z],
-            legend="Analytical pressure",
+            legend_label="Analytical pressure",
             line_width=2,
             color="red",
         )

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2,7 +2,8 @@
 import os
 import shutil
 import warnings
-from collections import Counter, Iterable, namedtuple
+from collections import Counter, namedtuple
+from collections.abc import Iterable
 from copy import copy, deepcopy
 from itertools import chain, cycle
 from pathlib import Path


### PR DESCRIPTION
Related to Issue #472 

- In `results.py`
    - Replace invalid escape sequence to create greek letters by actual greek letters
    - Replace bokeh.widgetbox by bokeh.Column due deprecation warning
    - Update docstrings

- In `api_report.py`
    - I'll commit in this file when PR #477 is merged.

- In `rotor_assembly.py`
    - `Iterable` now is imported from `collections.abc` instead of `collections` 

- In `fluid_flow_graphics.py`
    - Replace `legend` by `legend_label` when plotting with bokeh