### PR TITLE
Add requirements.txt file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md LICENSE
+include README.md LICENSE ross/new_units.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy
+scipy
+matplotlib
+toml
+pandas>=0.23
+bokeh
+xlrd
+pint

--- a/ross/__init__.py
+++ b/ross/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .bearing_seal_element import *
 from .disk_element import *

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import re
 import sys
 from shutil import rmtree
 
-from setuptools import find_packages, setup, Command
+from setuptools import Command, find_packages, setup
 
 
 def read(path, encoding="utf-8"):
@@ -39,16 +39,8 @@ REQUIRES_PYTHON = ">=3.6.0"
 VERSION = version("ross/__init__.py")
 
 # What packages are required for this module to be executed?
-REQUIRED = [
-    "numpy",
-    "scipy",
-    "matplotlib",
-    "toml",
-    "pandas>=0.23",
-    "bokeh",
-    "xlrd",
-    "pint",
-]
+with open("requirements.txt") as f:
+    REQUIRED = f.read().splitlines()
 
 # What packages are optional?
 EXTRAS = {


### PR DESCRIPTION
This PR adds the requirements.txt (closes #461) file and also solves the issue regarding the new_units.txt file missing after installation.