### PR TITLE
Add binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ After defining the elements for the model, you can plot the rotor geometry and r
 Campbell Diagram, mode shapes, frequency response, and time response.
 
 You can try it out now by running the tutorial on [binder](https://mybinder.org/v2/gh/ross-rotordynamics/ross/0.3?filepath=%2Fdocs%2Fexamples).
-After binder starts, navigate to the ross/docs/examples directory and open the tutorial notebook.
 
 # Documentation 
 Access the documentation [here](https://ross-rotordynamics.github.io/ross-website/).

--- a/docs/download.rst
+++ b/docs/download.rst
@@ -4,3 +4,11 @@ Download notebooks
 Here you can download the tutorial and examples notebooks.
 
 | :download:`Tutorial </examples/tutorial.ipynb>`
+| :download:`Example 1 </examples/example_1.ipynb>`
+| :download:`Example 2 </examples/example_2.ipynb>`
+| :download:`Example 3 </examples/example_3.ipynb>`
+| :download:`Example 4 </examples/example_4.ipynb>`
+| :download:`Example 5 </examples/example_5.ipynb>`
+| :download:`Example 6 </examples/example_6.ipynb>`
+| :download:`Example 7 </examples/example_7.ipynb>`
+| :download:`Example 8 </examples/example_8.ipynb>`

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,11 +4,11 @@ Examples
 .. toctree::
    :maxdepth: 1
 
-   examples/example_05_08_01
-   examples/example_05_08_02
-   examples/example_05_09_01 
-   examples/example_05_09_02 
-   examples/example_05_09_04
-   examples/example_05_09_05 
-   examples/example_05_09_06
-   examples/example_05_09_09
+   examples/example_1
+   examples/example_2
+   examples/example_3
+   examples/example_4
+   examples/example_5
+   examples/example_6
+   examples/example_7
+   examples/example_8

--- a/docs/examples/example_1.ipynb
+++ b/docs/examples/example_1.ipynb
@@ -480,7 +480,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_2.ipynb
+++ b/docs/examples/example_2.ipynb
@@ -170,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_3.ipynb
+++ b/docs/examples/example_3.ipynb
@@ -661,7 +661,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_4.ipynb
+++ b/docs/examples/example_4.ipynb
@@ -757,7 +757,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_5.ipynb
+++ b/docs/examples/example_5.ipynb
@@ -604,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_6.ipynb
+++ b/docs/examples/example_6.ipynb
@@ -667,7 +667,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_7.ipynb
+++ b/docs/examples/example_7.ipynb
@@ -672,7 +672,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_8.ipynb
+++ b/docs/examples/example_8.ipynb
@@ -538,7 +538,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_9.ipynb
+++ b/docs/examples/example_9.ipynb
@@ -811,7 +811,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   },
   "pycharm": {
    "stem_cell": {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,10 @@
 |ross-logo| ROSS: Rotordynamic Open-Source Software
 ===================================================
 
-Ross is a library written in Python for rotordynamic analysis. The source is
+ROSS is a library written in Python for rotordynamic analysis. The source is
 available at `github <https://github.com/ross-rotordynamics/ross>`_.
+
+You can check the tutorial and examples on `binder <https://mybinder.org/v2/gh/ross-rotordynamics/ross/0.3?filepath=%2Fdocs%2Fexamples>`_.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This adds a binder link to the docs web page.
It also renames the example notebooks to numerical title.
Related to #473 .