### PR TITLE
Fix issue with check_units

### DIFF
--- a/ross/units.py
+++ b/ross/units.py
@@ -59,19 +59,17 @@ def check_units(func):
         args_names = inspect.getfullargspec(func)[0]
 
         for arg_name, arg_value in zip(args_names, args):
-            if arg_name in units:
+            if arg_name in units and arg_value is not None:
                 # For now, we only return the magnitude for the converted Quantity
                 # If pint is fully adopted by ross in the future, and we have all Quantities
                 # using it, we could remove this, which would allows us to use pint in its full capability
-                if arg_value is None:
-                    pass
-                else:
-                    try:
-                        base_unit_args.append(arg_value.to(units[arg_name]).m)
-                    except AttributeError:
-                        base_unit_args.append(Q_(arg_value, units[arg_name]).m)
+                try:
+                    base_unit_args.append(arg_value.to(units[arg_name]).m)
+                except AttributeError:
+                    base_unit_args.append(Q_(arg_value, units[arg_name]).m)
             else:
                 base_unit_args.append(arg_value)
+
 
         base_unit_kwargs = {}
         for k, v in kwargs.items():

--- a/ross/units.py
+++ b/ross/units.py
@@ -70,7 +70,6 @@ def check_units(func):
             else:
                 base_unit_args.append(arg_value)
 
-
         base_unit_kwargs = {}
         for k, v in kwargs.items():
             if k in units and v is not None:

--- a/ross/units.py
+++ b/ross/units.py
@@ -63,10 +63,13 @@ def check_units(func):
                 # For now, we only return the magnitude for the converted Quantity
                 # If pint is fully adopted by ross in the future, and we have all Quantities
                 # using it, we could remove this, which would allows us to use pint in its full capability
-                try:
-                    base_unit_args.append(arg_value.to(units[arg_name]).m)
-                except AttributeError:
-                    base_unit_args.append(Q_(arg_value, units[arg_name]).m)
+                if arg_value is None:
+                    pass
+                else:
+                    try:
+                        base_unit_args.append(arg_value.to(units[arg_name]).m)
+                    except AttributeError:
+                        base_unit_args.append(Q_(arg_value, units[arg_name]).m)
             else:
                 base_unit_args.append(arg_value)
 


### PR DESCRIPTION
Related to Issue #511 

Add a condition to verify if the argument value is None. It allows the user to pass "None" args without getting an error with the code trying to assign a unit to a None value.