### PR TITLE
Plotting statistics for random variables

### DIFF
--- a/ross/stochastic/st_disk_element.py
+++ b/ross/stochastic/st_disk_element.py
@@ -5,6 +5,7 @@ analysis.
 """
 import bokeh.palettes as bp
 import numpy as np
+
 from ross.disk_element import DiskElement
 from ross.stochastic.st_materials import ST_Material
 from ross.stochastic.st_results_elements import plot_histogram

--- a/ross/stochastic/st_materials.py
+++ b/ross/stochastic/st_materials.py
@@ -6,8 +6,8 @@ some of the most common materials used in rotors.
 from collections.abc import Iterable
 
 import numpy as np
-
 from ross.materials import Material
+from ross.stochastic.st_results_elements import plot_histogram
 
 __all__ = ["ST_Material"]
 
@@ -55,7 +55,7 @@ class ST_Material:
     >>> import ross.stochastic as srs
     >>> E = np.random.uniform(208e9, 211e9, 5)
     >>> st_steel = srs.ST_Material(name="Steel", rho=7810, E=E, G_s=81.2e9)
-    >>> len(list(st_steel.__iter__()))
+    >>> len(list(iter(st_steel)))
     5
     """
 
@@ -89,18 +89,28 @@ class ST_Material:
         if type(Poisson) == list:
             Poisson = np.asarray(Poisson)
 
-        self.name = name
-        self.rho = rho
-        self.E = E
-        self.G_s = G_s
-        self.Poisson = Poisson
-        self.color = color
-
         attribute_dict = dict(
             name=name, rho=rho, E=E, G_s=G_s, Poisson=Poisson, color=color,
         )
         self.is_random = is_random
         self.attribute_dict = attribute_dict
+
+    def __iter__(self):
+        """Return an iterator for the container.
+
+        Returns
+        -------
+        An iterator over random material properties.
+
+        Examples
+        --------
+        >>> import ross.stochastic as srs
+        >>> E = np.random.uniform(208e9, 211e9, 5)
+        >>> st_steel = srs.ST_Material(name="Steel", rho=7810, E=E, G_s=81.2e9)
+        >>> len(list(iter(st_steel)))
+        5
+        """
+        return iter(self.random_var(self.is_random, self.attribute_dict))
 
     def __getitem__(self, key):
         """Return the value for a given key from attribute_dict.
@@ -143,7 +153,7 @@ class ST_Material:
         key : str
             A class parameter as string.
         value : The corresponding value for the attrbiute_dict's key.
-            ***check the correct type for each key in ST_ShaftElement
+            ***check the correct type for each key in ST_Material
             docstring.
 
         Raises
@@ -168,14 +178,14 @@ class ST_Material:
         """Generate a list of objects as random attributes.
 
         This function creates a list of objects with random values for selected
-        attributes from ShaftElement.
+        attributes from ross.Material.
 
         Parameters
         ----------
         is_random : list
             List of the object attributes to become stochastic.
         *args : dict
-            Dictionary instanciating the ShaftElement class.
+            Dictionary instanciating the ross.Material class.
             The attributes that are supposed to be stochastic should be
             set as lists of random variables.
 
@@ -198,11 +208,46 @@ class ST_Material:
 
         return f_list
 
-    def __iter__(self):
-        """Return an iterator for the container.
+    def plot_random_var(self, var_list=[], **kwargs):
+        """Plot histogram and the PDF.
+
+        This function creates a histogram to display the random variable
+        distribution.
+
+        Parameters
+        ----------
+        var_list : list, optional
+            List of random variables, in string format, to plot.
+        **kwargs : optional
+            Additional key word arguments can be passed to change
+            the numpy.histogram (e.g. density=True, bins=11, ...)
 
         Returns
         -------
-        An iterator over random material properties.
+        grid_plot : bokeh row
+            A row with the histogram plots.
+
+        Examples
+        --------
+        >>> import ross.stochastic as srs
+        >>> E = np.random.uniform(208e9, 211e9, 5)
+        >>> st_steel = ST_Material(name="Steel", rho=7810, E=E, G_s=81.2e9)
+        >>> st_steel.plot_random_var(["E"]) # doctest: +ELLIPSIS
+        Row...
         """
-        return iter(self.random_var(self.is_random, self.attribute_dict))
+        label = dict(
+            E="Young's Modulus",
+            G_s="Shear Modulus",
+            Poisson="Poisson coefficient",
+            rho="density",
+        )
+        is_random = self.is_random
+
+        if not all(var in self.is_random for var in var_list):
+            raise ValueError(
+                "Not random variable in var_list. Select variables from {}".format(
+                    is_random
+                )
+            )
+
+        return plot_histogram(self.attribute_dict, label, var_list, **kwargs)

--- a/ross/stochastic/st_materials.py
+++ b/ross/stochastic/st_materials.py
@@ -6,6 +6,7 @@ some of the most common materials used in rotors.
 from collections.abc import Iterable
 
 import numpy as np
+
 from ross.materials import Material
 from ross.stochastic.st_results_elements import plot_histogram
 

--- a/ross/stochastic/st_point_mass.py
+++ b/ross/stochastic/st_point_mass.py
@@ -1,4 +1,12 @@
+"""Point mass element module for STOCHASTIC ROSS.
+
+This module creates an instance of random point mass for stochastic
+analysis.
+"""
 from ross.point_mass import PointMass
+from ross.stochastic.st_results_elements import plot_histogram
+
+__all__ = ["ST_PointMass", "st_pointmass_example"]
 
 
 class ST_PointMass:
@@ -41,7 +49,7 @@ class ST_PointMass:
     ...                         my=np.random.uniform(2.0, 2.5, 5),
     ...                         is_random=["mx", "my"],
     ...                         )
-    >>> len(list(elms.__iter__()))
+    >>> len(list(iter(elms)))
     5
     """
 
@@ -59,6 +67,13 @@ class ST_PointMass:
         Returns
         -------
         An iterator over random point mass elements.
+
+        Examples
+        --------
+        >>> import ross.stochastic as srs
+        >>> elm = srs.st_pointmass_example()
+        >>> len(list(iter(elm)))
+        2
         """
         return iter(self.random_var(self.is_random, self.attribute_dict))
 
@@ -107,7 +122,7 @@ class ST_PointMass:
         key : str
             A class parameter as string.
         value : The corresponding value for the attrbiute_dict's key.
-            ***check the correct type for each key in ST_ShaftElement
+            ***check the correct type for each key in ST_PointMass
             docstring.
 
         Raises
@@ -136,14 +151,14 @@ class ST_PointMass:
         """Generate a list of objects as random attributes.
 
         This function creates a list of objects with random values for selected
-        attributes from PointMass.
+        attributes from ross.PointMass.
 
         Parameters
         ----------
         is_random : list
             List of the object attributes to become stochastic.
         *args : dict
-            Dictionary instanciating the PointMass class.
+            Dictionary instanciating the ross.PointMass class.
             The attributes that are supposed to be stochastic should be
             set as lists of random variables.
 
@@ -165,3 +180,65 @@ class ST_PointMass:
         f_list = (PointMass(*arg) for arg in new_args)
 
         return f_list
+
+    def plot_random_var(self, var_list=[], **kwargs):
+        """Plot histogram and the PDF.
+
+        This function creates a histogram to display the random variable
+        distribution.
+
+        Parameters
+        ----------
+        var_list : list, optional
+            List of random variables, in string format, to plot.
+        **kwargs : optional
+            Additional key word arguments can be passed to change
+            the numpy.histogram (e.g. density=True, bins=11, ...)
+
+        Returns
+        -------
+        grid_plot : bokeh row
+            A row with the histogram plots.
+
+        Examples
+        --------
+        >>> import ross.stochastic as srs
+        >>> elm = srs.st_pointmass_example()
+        >>> elm.plot_random_var(["mx"]) # doctest: +ELLIPSIS
+        Row...
+        """
+        label = dict(
+            mx="Mass on the X direction", my="Mass on the Y direction", m="Mass",
+        )
+        if not all(var in self.is_random for var in var_list):
+            raise ValueError(
+                "Not random variable in var_list. Select variables from {}".format(
+                    self.is_random
+                )
+            )
+
+        return plot_histogram(self.attribute_dict, label, var_list, **kwargs)
+
+
+def st_pointmass_example():
+    """Return an instance of a simple random point mass.
+
+    The purpose is to make available a simple model so that doctest can be
+    written using it.
+
+    Returns
+    -------
+    elm : ross.stochastic.ST_PointMass
+        An instance of a random point mass element object.
+
+    Examples
+    --------
+    >>> import ross.stochastic as srs
+    >>> elm = srs.st_pointmass_example()
+    >>> len(list(iter(elm)))
+    2
+    """
+    mx = [2.0, 2.5]
+    my = [3.0, 3.5]
+    elm = ST_PointMass(n=1, mx=mx, my=my, is_random=["mx", "my"])
+    return elm

--- a/ross/stochastic/st_results_elements.py
+++ b/ross/stochastic/st_results_elements.py
@@ -1,0 +1,89 @@
+"""Plotting module for elements.
+
+This modules provides functions to plot the elements statistic data.
+"""
+import numpy as np
+from bokeh.layouts import gridplot
+from bokeh.plotting import figure
+from scipy.stats import gaussian_kde
+
+
+def plot_histogram(attribute_dict, label={}, var_list=[], **kwargs):
+    """Plot histogram and the PDF.
+
+    This function creates a histogram to display the random variable
+    distribution.
+
+    Parameters
+    ----------
+    attribute_dict : dict
+        Dictionary with element parameters.
+    label : dict
+        Dictionary with labels for each element parameter. Labels are displayed
+        on bokeh figure.
+    var_list : list, optional
+        List of random variables, in string format, to plot.
+    **kwargs : optional
+        Additional key word arguments can be passed to change
+        the numpy.histogram (e.g. density=True, bins=11, ...)
+
+    Returns
+    -------
+    grid_plot : bokeh row
+        A row with the histogram plots.
+    """
+    default_values = dict(density=True, bins=21)
+    for k, v in default_values.items():
+        kwargs.setdefault(k, v)
+
+    figures = []
+
+    for var in var_list:
+        hist, edges = np.histogram(attribute_dict[var], **kwargs)
+        if kwargs["density"] is True:
+            y_label = "PDF"
+        else:
+            y_label = "Frequency"
+
+        fig = figure(
+            width=640,
+            height=480,
+            title="Histogram - {}".format(var),
+            x_axis_label="{}".format(label[var]),
+            y_axis_label="{}".format(y_label),
+        )
+        fig.xaxis.axis_label_text_font_size = "14pt"
+        fig.yaxis.axis_label_text_font_size = "14pt"
+        fig.axis.major_label_text_font_size = "14pt"
+        fig.title.text_font_size = "14pt"
+
+        fig.quad(
+            top=hist,
+            bottom=0,
+            left=edges[:-1],
+            right=edges[1:],
+            fill_color="red",
+            line_color="white",
+            alpha=1.0,
+        )
+        if y_label == "PDF":
+            x = np.linspace(
+                min(attribute_dict[var]),
+                max(attribute_dict[var]),
+                len(attribute_dict[var]),
+            )
+            kernel = gaussian_kde(attribute_dict[var])
+            fig.line(
+                x,
+                kernel(x),
+                line_alpha=1.0,
+                line_width=3.0,
+                line_color="royalblue",
+                legend_label="pdf estimation",
+            )
+
+        figures.append(fig)
+
+    grid_plot = gridplot([figures], toolbar_location="right")
+
+    return grid_plot


### PR DESCRIPTION
- Add `.plot_random_var()`: a method to plot histograms with the Frequency or the PDF for random variables.
- Add tests for `.plot_random_var()`

Example:
```
kxx = np.random.uniform(1e6, 2e6, 1000)
cxx = 1e3
elm = ST_BearingElement(n=1, kxx=kxx, cxx=cxx, is_random=["kxx"])
show(elm.plot_random_var(["kxx"]))
show(elm.plot_random_var(["kxx"], density=False))
```
The pdf estimation use the "kernel density estimation" tool from Scipy.

![image](https://user-images.githubusercontent.com/45969994/79754083-539ed680-82ed-11ea-83ae-64927606109b.png)

![image](https://user-images.githubusercontent.com/45969994/79754259-a082ad00-82ed-11ea-8ebc-abea807f1419.png)
