### PR TITLE
Remove duplicated colon from hover tool

### DIFF
--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -452,11 +452,11 @@ class DiskElement(Element):
 
         hover = HoverTool(names=["uc_disk", "lc_disk", "ub_disk", "lb_disk"])
         hover.tooltips = [
-            ("Disk Node :", "@elnum"),
-            ("Polar Moment of Inertia :", "@IP"),
-            ("Diametral Moment of Inertia :", "@ID"),
-            ("Disk mass :", "@mass"),
-            ("Tag :", "@tag"),
+            ("Disk Node", "@elnum"),
+            ("Polar Moment of Inertia", "@IP"),
+            ("Diametral Moment of Inertia", "@ID"),
+            ("Disk mass", "@mass"),
+            ("Tag", "@tag"),
         ]
         hover.mode = "mouse"
 

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -372,10 +372,10 @@ class PointMass(Element):
 
         hover = HoverTool(names=["pmass_l", "pmass_u"])
         hover.tooltips = [
-            ("Point Mass Node :", "@elnum"),
-            ("Mass (x) :", "@mx"),
-            ("Mass (y) :", "@my"),
-            ("Tag :", "@tag"),
+            ("Point Mass Node", "@elnum"),
+            ("Mass (x)", "@mx"),
+            ("Mass (y)", "@my"),
+            ("Tag", "@tag"),
         ]
         hover.mode = "mouse"
 

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -1023,31 +1023,31 @@ class ShaftElement(Element):
         hover = HoverTool(names=["l_shaft", "u_shaft"])
         if check_sld:
             hover.tooltips = [
-                ("Element Number :", "@elnum"),
-                ("Slenderness Ratio :", "@sld"),
+                ("Element Number", "@elnum"),
+                ("Slenderness Ratio", "@sld"),
             ]
         else:
             if isinstance(self, ShaftElement6DoF):
                 hover.tooltips = [
-                    ("Element Number :", "@elnum"),
-                    ("Left Outer Diameter :", "@out_d_l"),
-                    ("Left Inner Diameter :", "@in_d_l"),
-                    ("Right Outer Diameter :", "@out_d_r"),
-                    ("Right Inner Diameter :", "@in_d_r"),
-                    ("Alpha Damp. Factor :", "@alpha_factor"),
-                    ("Beta Damp. Factor :", "@beta_factor"),
-                    ("Element Length :", "@length"),
-                    ("Material :", "@mat"),
+                    ("Element Number", "@elnum"),
+                    ("Left Outer Diameter", "@out_d_l"),
+                    ("Left Inner Diameter", "@in_d_l"),
+                    ("Right Outer Diameter", "@out_d_r"),
+                    ("Right Inner Diameter", "@in_d_r"),
+                    ("Alpha Damp. Factor", "@alpha_factor"),
+                    ("Beta Damp. Factor", "@beta_factor"),
+                    ("Element Length", "@length"),
+                    ("Material", "@mat"),
                 ]
             else:
                 hover.tooltips = [
-                    ("Element Number :", "@elnum"),
-                    ("Left Outer Diameter :", "@out_d_l"),
-                    ("Left Inner Diameter :", "@in_d_l"),
-                    ("Right Outer Diameter :", "@out_d_r"),
-                    ("Right Inner Diameter :", "@in_d_r"),
-                    ("Element Length :", "@length"),
-                    ("Material :", "@mat"),
+                    ("Element Number", "@elnum"),
+                    ("Left Outer Diameter", "@out_d_l"),
+                    ("Left Inner Diameter", "@in_d_l"),
+                    ("Right Outer Diameter", "@out_d_r"),
+                    ("Right Inner Diameter", "@in_d_r"),
+                    ("Element Length", "@length"),
+                    ("Material", "@mat"),
                 ]
         hover.mode = "mouse"
 


### PR DESCRIPTION
Bokeh already inserts a colon between key and value in the hover, so
we need to remove this, otherwise we get duplicated colons.