### PR TITLE
Fix missing y_pos and y_pos_sup in df_seals

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -241,14 +241,14 @@ class Rotor(object):
             [
                 el.summary()
                 for el in self.bearing_elements
-                if (isinstance(el, BearingElement))
+                if not (isinstance(el, SealElement))
             ]
         )
         df_seals = pd.DataFrame(
             [
                 el.summary()
                 for el in self.bearing_elements
-                if (el.__class__.__name__ == "SealElement")
+                if (isinstance(el, SealElement))
             ]
         )
         df_point_mass = pd.DataFrame([el.summary() for el in self.point_mass_elements])
@@ -439,7 +439,7 @@ class Rotor(object):
             else:
                 break
 
-        dfb = df[df.type == "BearingElement"]
+        dfb = df[(df.type == "BearingElement") | (df.type == "SealElement")]
         z_positions = [pos for pos in dfb["nodes_pos_l"]]
         z_positions = list(dict.fromkeys(z_positions))
         for z_pos in z_positions:
@@ -492,7 +492,7 @@ class Rotor(object):
                 y_pos_sup += 2 * mean_od * df["scale_factor"][df.tag == t].values[0]
 
         # define position for point mass elements
-        dfb = df[df.type == "BearingElement"]
+        dfb = df[(df.type == "BearingElement") | (df.type == "SealElement")]
         for p in point_mass_elements:
             z_pos = dfb[dfb.n_l == p.n]["nodes_pos_l"].values[0]
             y_pos = dfb[dfb.n_l == p.n]["y_pos"].values[0]


### PR DESCRIPTION
Related to Issue #571.

Seals can be displayed in different colors than bearings
![image](https://user-images.githubusercontent.com/45969994/83309725-6e177a00-a1e0-11ea-95a3-8a69ebce9eda.png)
