### PR TITLE
Add methods to plot the deflected shape

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1211,6 +1211,9 @@ class Rotor(object):
             speed_range=speed_range,
             magnitude=abs(forced_resp),
             phase=np.angle(forced_resp),
+            nodes_list=self.nodes,
+            nodes_pos=self.nodes_pos,
+            number_dof=self.number_dof,
         )
 
         return forced_resp

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1308,8 +1308,8 @@ class Rotor(object):
         >>> fig = response.plot(dof=13)
         
         # plot deflected shape configuration
-        >>> speed = 600
-        >>> fig = response.response.plot_deflected_shape(speed=speed)
+        >>> value = 600
+        >>> fig = response.plot_deflected_shape(speed=value)
         """
         force = np.zeros((self.ndof, len(frequency_range)), dtype=np.complex)
 


### PR DESCRIPTION
Related to Issue #569.

After running the method `.run_unbalance_response()` the user is able to call a `.plot()` method to display the amplitude and phase vs frequency response.
This PR adds an alternative method to plot a 3D orbit (rotor deflected shape) response for a given unbalance: `.plot_deflected_shape()`.

```
>>> rotor = rotor_example()
>>> speed_range = np.linspace(0, 1000, 101)
>>> response = rotor.run_unbalance_response(node=3,
...                                         magnitude=10.0,
...                                         phase=0.0,
...                                         frequency_range=speed_range)
# plot unbalance response:
>>> fig = response.plot(dof=13)
# plot deflected shape:
>>> speed = 900
>>> fig = response.plot_deflected_shape(speed)
```

The image below is the current output:

![image](https://user-images.githubusercontent.com/45969994/83434271-840b8180-a410-11ea-8622-cb482d6a25f4.png)
