### PR TITLE
Remove line setting renderer to browser

### DIFF
--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-import plotly.io as pio
 from plotly.subplots import make_subplots
 from scipy.interpolate import interp1d
 from scipy.signal import argrelextrema
@@ -17,8 +16,6 @@ from ross.rotor_assembly import Rotor
 from ross.shaft_element import ShaftElement
 
 # fmt: on
-
-pio.renderers.default = "browser"
 
 # set Plotly palette of colors
 colors1 = px.colors.qualitative.Dark24
@@ -1365,7 +1362,7 @@ class Report:
 
         # Plotting area
         default_layout = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         fig1 = go.Figure()
 
@@ -1500,7 +1497,7 @@ class Report:
             )
         )
 
-        fig2.update_xaxes(mirror=True,)
+        fig2.update_xaxes(mirror=True)
         fig2.update_yaxes(
             title_text="<b>Maximum Critical Speed Ratio</b>",
             title_font=dict(family="Arial", size=20),

--- a/ross/results.py
+++ b/ross/results.py
@@ -5,12 +5,9 @@ This module returns graphs for each type of analyses in rotor_assembly.py.
 import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
-import plotly.io as pio
 import scipy.linalg as la
 from plotly.subplots import make_subplots
 from scipy import interpolate
-
-pio.renderers.default = "browser"
 
 # set Plotly palette of colors
 colors1 = px.colors.qualitative.Dark24
@@ -543,7 +540,7 @@ class ModalResults:
                 ),
                 yaxis=dict(
                     title=dict(
-                        text="<b>Dimensionless deformation</b>", font=dict(size=14),
+                        text="<b>Dimensionless deformation</b>", font=dict(size=14)
                     ),
                     tickfont=dict(size=16),
                     range=[-2, 2],
@@ -554,7 +551,7 @@ class ModalResults:
                 ),
                 zaxis=dict(
                     title=dict(
-                        text="<b>Dimensionless deformation</b>", font=dict(size=14),
+                        text="<b>Dimensionless deformation</b>", font=dict(size=14)
                     ),
                     tickfont=dict(size=16),
                     range=[-2, 2],
@@ -955,7 +952,7 @@ class FrequencyResponseResults:
             y_axis_label = "<b>Amplitude (dB)</b>"
 
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             mag_kwargs.setdefault(k, v)
@@ -1034,7 +1031,7 @@ class FrequencyResponseResults:
         phase = self.phase
 
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             phase_kwargs.setdefault(k, v)
@@ -1124,7 +1121,7 @@ class FrequencyResponseResults:
             r_axis_label = "<b>Amplitude (dB)</b>"
 
         kwargs_default_values = dict(
-            width=1200, height=900, polar_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, polar_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             polar_kwargs.setdefault(k, v)
@@ -1323,7 +1320,7 @@ class ForcedResponseResults:
             y_axis_label = "<b>Amplitude (μ pk-pk)</b>"
 
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             mag_kwargs.setdefault(k, v)
@@ -1398,7 +1395,7 @@ class ForcedResponseResults:
         phase = self.phase
 
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             phase_kwargs.setdefault(k, v)
@@ -1483,7 +1480,7 @@ class ForcedResponseResults:
             r_axis_label = "<b>Amplitude (dB)</b>"
 
         kwargs_default_values = dict(
-            width=1200, height=900, polar_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, polar_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             polar_kwargs.setdefault(k, v)
@@ -1696,7 +1693,7 @@ class StaticResults:
             The figure object with the plot.
         """
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             kwargs.setdefault(k, v)
@@ -1723,7 +1720,7 @@ class StaticResults:
         ):
             interpolated = interpolate.interp1d(nodes_pos, disp_y, kind="cubic")
             xnew = np.linspace(
-                nodes_pos[0], nodes_pos[-1], num=len(nodes_pos) * 20, endpoint=True,
+                nodes_pos[0], nodes_pos[-1], num=len(nodes_pos) * 20, endpoint=True
             )
 
             ynew = interpolated(xnew)
@@ -1933,7 +1930,7 @@ class StaticResults:
                 col=col,
             )
             fig.update_yaxes(
-                visible=False, gridcolor="lightgray", showline=False, row=row, col=col,
+                visible=False, gridcolor="lightgray", showline=False, row=row, col=col
             )
             j += 1
 
@@ -1960,7 +1957,7 @@ class StaticResults:
             The figure object with the plot.
         """
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             kwargs.setdefault(k, v)
@@ -2044,7 +2041,7 @@ class StaticResults:
             Plotly figure with the bending moment diagram plot
         """
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             kwargs.setdefault(k, v)
@@ -2563,7 +2560,7 @@ class TimeResponseResults:
         obs_dof = dof_dict[str(obs_dof)]
 
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             kwargs.setdefault(k, v)
@@ -2634,7 +2631,7 @@ class TimeResponseResults:
             The figure object with the plot.
         """
         kwargs_default_values = dict(
-            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right",
+            width=1200, height=900, plot_bgcolor="white", hoverlabel_align="right"
         )
         for k, v in kwargs_default_values.items():
             kwargs.setdefault(k, v)

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-import plotly.io as pio
 import scipy.io as sio
 import scipy.linalg as la
 import scipy.signal as signal
@@ -36,8 +35,6 @@ from ross.utils import convert
 # fmt: on
 
 __all__ = ["Rotor", "CoAxialRotor", "rotor_example", "coaxrotor_example"]
-
-pio.renderers.default = "browser"
 
 # set Plotly palette of colors
 colors = px.colors.qualitative.Dark24
@@ -1472,12 +1469,12 @@ class Rotor(object):
 
         fig.update_xaxes(
             title_text="<b>Axial location</b>",
-            title_font=dict(family="Verdana", size=20),
-            tickfont=dict(size=16),
+            # title_font=dict(family="Verdana", size=20),
+            # tickfont=dict(size=16),
             range=[-0.1 * shaft_end, 1.1 * shaft_end],
             showgrid=False,
             showline=True,
-            linewidth=2.5,
+            # linewidth=2.5,
             linecolor="black",
             mirror=True,
         )
@@ -1493,8 +1490,8 @@ class Rotor(object):
             mirror=True,
         )
         fig.update_layout(
-            width=1200,
-            height=900,
+            # width=1200,
+            # height=900,
             plot_bgcolor="white",
             title=dict(text="<b>Rotor Model</b>", font=dict(size=18)),
             **kwargs,

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1469,12 +1469,12 @@ class Rotor(object):
 
         fig.update_xaxes(
             title_text="<b>Axial location</b>",
-            # title_font=dict(family="Verdana", size=20),
-            # tickfont=dict(size=16),
+            title_font=dict(family="Verdana", size=20),
+            tickfont=dict(size=16),
             range=[-0.1 * shaft_end, 1.1 * shaft_end],
             showgrid=False,
             showline=True,
-            # linewidth=2.5,
+            linewidth=2.5,
             linecolor="black",
             mirror=True,
         )
@@ -1490,8 +1490,6 @@ class Rotor(object):
             mirror=True,
         )
         fig.update_layout(
-            # width=1200,
-            # height=900,
             plot_bgcolor="white",
             title=dict(text="<b>Rotor Model</b>", font=dict(size=18)),
             **kwargs,


### PR DESCRIPTION
Plotly has a way to check where the user is running the code and it
will set the renderer accordingly.

This also removes the dimensions for the figure of the rotor.
We used to define the figure width and height, but plotly has a way to 
identify the dimensions of the place where the user is plotting 
(notebook, browser etc.) and it will plot the figure with a proper 
dimension.

Closes #575.