### PR TITLE
Add synchronous option to plot_ucs

### DIFF
--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -284,23 +284,13 @@ class Report:
         dk_elm = rotor.disk_elements
         pm_elm = rotor.point_mass_elements
         sparse = rotor.sparse
-        n_eigen = rotor.n_eigen
         min_w = rotor.min_w
         max_w = rotor.max_w
         rated_w = rotor.rated_w
         tag = rotor.tag
 
         aux_rotor = Rotor(
-            sh_elm,
-            dk_elm,
-            bearing_list,
-            pm_elm,
-            sparse,
-            n_eigen,
-            min_w,
-            max_w,
-            rated_w,
-            tag,
+            sh_elm, dk_elm, bearing_list, pm_elm, sparse, min_w, max_w, rated_w, tag
         )
 
         return aux_rotor
@@ -466,12 +456,9 @@ class Report:
         for i, k in enumerate(stiffness_log):
             bearings = [BearingElement(b.n, kxx=k, cxx=0) for b in bearings_elements]
             rotor = self.rotor.__class__(
-                self.rotor.shaft_elements,
-                self.rotor.disk_elements,
-                bearings,
-                n_eigen=16,
+                self.rotor.shaft_elements, self.rotor.disk_elements, bearings
             )
-            modal = rotor.run_modal(speed=0)
+            modal = rotor.run_modal(speed=0, num_modes=16)
             rotor_wn[:, i] = modal.wn[:8:2]
 
         bearing0 = bearings_elements[0]

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -180,14 +180,14 @@ class _Coefficient:
         >>> fig = bearing.kxx.plot()
         >>> # fig.show()
         """
-        w_range = np.linspace(min(self.frequency), max(self.frequency), 30)
+        frequency_range = np.linspace(min(self.frequency), max(self.frequency), 30)
 
         fig = go.Figure()
 
         fig.add_trace(
             go.Scatter(
-                x=w_range,
-                y=self.interpolated(w_range),
+                x=frequency_range,
+                y=self.interpolated(frequency_range),
                 mode="lines",
                 line=dict(width=3.0, color="royalblue"),
                 showlegend=False,
@@ -196,7 +196,7 @@ class _Coefficient:
         )
 
         fig.update_xaxes(
-            title_text="<b>Frequency</b>",
+            title_text="<b>Frequency (rad/s)</b>",
             title_font=dict(family="Arial", size=20),
             tickfont=dict(size=16),
             gridcolor="lightgray",

--- a/ross/element.py
+++ b/ross/element.py
@@ -13,10 +13,9 @@ class Element(ABC):
     create specific elements for the user.
     """
 
-    def __init__(self, n):
+    def __init__(self, n, tag=None):
         self.n = n
-        self.dof_mapping = None
-        pass
+        self.tag = tag
 
     def save(self, file_name):
         """Save the element in a file.

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1634,7 +1634,7 @@ class Rotor(object):
 
         bearings_elements = []  # exclude the seals
         for bearing in self.bearing_elements:
-            if not isinstance(SealElement):
+            if not isinstance(bearing, SealElement):
                 bearings_elements.append(bearing)
 
         for i, k in enumerate(stiffness_log):

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1729,8 +1729,6 @@ class Rotor(object):
             exponentformat="power",
         )
         fig.update_layout(
-            width=1200,
-            height=900,
             plot_bgcolor="white",
             legend=dict(
                 font=dict(family="sans-serif", size=14),

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1557,7 +1557,7 @@ class Rotor(object):
 
         return results
 
-    def plot_ucs(self, stiffness_range=None, num=20, **kwargs):
+    def plot_ucs(self, stiffness_range=None, num=20, fig=None, **kwargs):
         """Plot undamped critical speed map.
 
         This method will plot the undamped critical speed map for a given range
@@ -1571,6 +1571,8 @@ class Rotor(object):
         num : int
             Number of steps in the range.
             Default is 20.
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
         kwargs : optional
             Additional key word arguments can be passed to change the plot layout only
             (e.g. width=1000, height=800, ...).
@@ -1607,8 +1609,6 @@ class Rotor(object):
         >>> rotor = Rotor(shaft_elem, [disk0, disk1], [bearing0, bearing1])
         >>> fig = rotor.plot_ucs()
         """
-        fig = go.Figure()
-
         if stiffness_range is None:
             if self.rated_w is not None:
                 bearing = self.bearing_elements[0]
@@ -1638,7 +1638,8 @@ class Rotor(object):
 
         bearing0 = bearings_elements[0]
 
-        fig = go.Figure()
+        if fig is None:
+            fig = go.Figure()
 
         fig.add_trace(
             go.Scatter(

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -950,13 +950,13 @@ class ShaftElement(Element):
                 ]
                 hovertemplate = (
                     f"<b>Element Number: {customdata[0]}<b><br>"
-                    + f"<b>Left Outer Diameter: {customdata[1]}<b><br>"
-                    + f"<b>Left Inner Diameter: {customdata[2]}<b><br>"
-                    + f"<b>Right Outer Diameter: {customdata[3]}<b><br>"
-                    + f"<b>Right Inner Diameter: {customdata[4]}<b><br>"
-                    + f"<b>Alpha Damp. Factor: {customdata[5]}<b><br>"
-                    + f"<b>Beta Damp. Factor: {customdata[6]}<b><br>"
-                    + f"<b>Element Length: {customdata[7]}<b><br>"
+                    + f"<b>Left Outer Diameter: {round(customdata[1], 6)}<b><br>"
+                    + f"<b>Left Inner Diameter: {round(customdata[2], 6)}<b><br>"
+                    + f"<b>Right Outer Diameter: {round(customdata[3], 6)}<b><br>"
+                    + f"<b>Right Inner Diameter: {round(customdata[4], 6)}<b><br>"
+                    + f"<b>Alpha Damp. Factor: {round(customdata[5], 6)}<b><br>"
+                    + f"<b>Beta Damp. Factor: {round(customdata[6], 6)}<b><br>"
+                    + f"<b>Element Length: {round(customdata[7], 6)}<b><br>"
                     + f"<b>Material: {customdata[8]}<b><br>"
                 )
             else:
@@ -971,11 +971,11 @@ class ShaftElement(Element):
                 ]
                 hovertemplate = (
                     f"<b>Element Number: {customdata[0]}<b><br>"
-                    + f"<b>Left Outer Diameter: {customdata[1]}<b><br>"
-                    + f"<b>Left Inner Diameter: {customdata[2]}<b><br>"
-                    + f"<b>Right Outer Diameter: {customdata[3]}<b><br>"
-                    + f"<b>Right Inner Diameter: {customdata[4]}<b><br>"
-                    + f"<b>Element Length: {customdata[5]}<b><br>"
+                    + f"<b>Left Outer Diameter: {round(customdata[1], 6)}<b><br>"
+                    + f"<b>Left Inner Diameter: {round(customdata[2], 6)}<b><br>"
+                    + f"<b>Right Outer Diameter: {round(customdata[3], 6)}<b><br>"
+                    + f"<b>Right Inner Diameter: {round(customdata[4], 6)}<b><br>"
+                    + f"<b>Element Length: {round(customdata[5], 6)}<b><br>"
                     + f"<b>Material: {customdata[6]}<b><br>"
                 )
         fig.add_trace(

--- a/ross/stochastic/st_rotor_assembly.py
+++ b/ross/stochastic/st_rotor_assembly.py
@@ -100,7 +100,6 @@ class ST_Rotor(object):
         bearing_elements=None,
         point_mass_elements=None,
         sparse=True,
-        n_eigen=12,
         min_w=None,
         max_w=None,
         rated_w=None,
@@ -190,7 +189,6 @@ class ST_Rotor(object):
             bearing_elements=bearing_elements,
             point_mass_elements=point_mass_elements,
             sparse=sparse,
-            n_eigen=n_eigen,
             min_w=min_w,
             max_w=max_w,
             rated_w=rated_w,
@@ -275,9 +273,9 @@ class ST_Rotor(object):
         -------
         >>> import ross.stochastic as srs
         >>> rotors = srs.st_rotor_example()
-        >>> rotors["n_eigen"] = 18
-        >>> rotors["n_eigen"]
-        18
+        >>> rotors["sparse"] = True
+        >>> rotors["sparse"]
+        True
         """
         if key not in self.attribute_dict.keys():
             raise KeyError("Object does not have parameter: {}.".format(key))


### PR DESCRIPTION
This adds an option to run plot_ucs with synchronous option, where the
rotor speed will be equal to the frequency of the first forward mode.
This was implemented with the following steps:
1. Run modal analysis with speed=0;
2. Get frequency of first forward mode;
3. Run modal analysis with speed=<frequency from step 2>.

The time to run the speed=0 method:
10.3 s ± 1.03 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

The time to run synchronous=True method:
42.7 s ± 3.24 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

Regarding this method:

"Also, the rotor transverse inertia, It, is replaced with the
transverse minus the polar inertia (It-Ip). This last modification, in
effect, constrains the rotor rotational speed to equal the eigenvalue
frequency."

We are still evaluating how to implement it, but it should give a good
performance improvement.
