### PR TITLE
Pinned pytest version to 4.6 or superior

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ with open("requirements.txt") as f:
 # What packages are optional?
 EXTRAS = {
     "dev": [
-        "pytest",
+        "pytest>=4.6",
         "pytest-cov",
         "coverage",
         "codecov",


### PR DESCRIPTION
Fix Issue #586.

Travis was currently getting the latest pytest pytest-cov versions. Apparently, pytest-cov bumped a new version (up to 2.10, some hours ago) that requires pytest >=4.6.
