### PR TITLE
Move "sparse" argument to run_modal() 

### DIFF
--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -283,14 +283,13 @@ class Report:
         sh_elm = rotor.shaft_elements
         dk_elm = rotor.disk_elements
         pm_elm = rotor.point_mass_elements
-        sparse = rotor.sparse
         min_w = rotor.min_w
         max_w = rotor.max_w
         rated_w = rotor.rated_w
         tag = rotor.tag
 
         aux_rotor = Rotor(
-            sh_elm, dk_elm, bearing_list, pm_elm, sparse, min_w, max_w, rated_w, tag
+            sh_elm, dk_elm, bearing_list, pm_elm, min_w, max_w, rated_w, tag
         )
 
         return aux_rotor

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -57,9 +57,6 @@ class Rotor(object):
         List with the bearing elements
     point_mass_elements: list
         List with the point mass elements
-    sparse : bool, optional
-        If sparse, eigenvalues will be calculated with arpack.
-        Default is True.
     tag : str
         A tag for the rotor
 
@@ -114,7 +111,6 @@ class Rotor(object):
         disk_elements=None,
         bearing_elements=None,
         point_mass_elements=None,
-        sparse=True,
         min_w=None,
         max_w=None,
         rated_w=None,
@@ -122,7 +118,6 @@ class Rotor(object):
     ):
 
         self.parameters = {
-            "sparse": True,
             "min_w": min_w,
             "max_w": max_w,
             "rated_w": rated_w,
@@ -134,7 +129,6 @@ class Rotor(object):
         # Config attributes
         ####################################################
 
-        self.sparse = sparse
         # operational speeds
         self.min_w = min_w
         self.max_w = max_w
@@ -547,7 +541,7 @@ class Rotor(object):
         else:
             return False
 
-    def run_modal(self, speed, num_modes=12):
+    def run_modal(self, speed, num_modes=12, sparse=True):
         """Run modal analysis.
 
         Method to calculate eigenvalues and eigvectors for a given rotor system
@@ -559,6 +553,9 @@ class Rotor(object):
         num_modes : int
             Number of modes to be calculated. This uses scipy.sparse.eigs method.
             Default is 12.
+        sparse : bool, optional
+            If sparse, eigenvalues will be calculated with arpack.
+            Default is True.
 
         Returns
         -------
@@ -583,7 +580,7 @@ class Rotor(object):
         array([91.79655318, 96.28899977])
         >>> fig = modal.plot_mode3D(0)
         """
-        evalues, evectors = self._eigen(speed, num_modes=num_modes)
+        evalues, evectors = self._eigen(speed, num_modes=num_modes, sparse=sparse)
         wn_len = len(evalues) // 2
         wn = (np.absolute(evalues))[:wn_len]
         wd = (np.imag(evalues))[:wn_len]
@@ -955,7 +952,9 @@ class Rotor(object):
 
         return idx
 
-    def _eigen(self, speed, num_modes=12, frequency=None, sorted_=True, A=None):
+    def _eigen(
+        self, speed, num_modes=12, frequency=None, sorted_=True, A=None, sparse=True
+    ):
         """Calculate eigenvalues and eigenvectors.
 
         This method will return the eigenvalues and eigenvectors of the
@@ -975,7 +974,9 @@ class Rotor(object):
         A: np.array, optional
             Matrix for which eig will be calculated.
             Defaul is the rotor A matrix.
-
+        sparse : bool, optional
+            If sparse, eigenvalues will be calculated with arpack.
+            Default is True.
 
         Returns
         -------
@@ -994,7 +995,7 @@ class Rotor(object):
         if A is None:
             A = self.A(speed=speed, frequency=frequency)
 
-        if self.sparse is True:
+        if sparse is True:
             try:
                 evalues, evectors = las.eigs(
                     A, k=num_modes, sigma=0, ncv=2 * num_modes, which="LM", v0=self._v0
@@ -2368,11 +2369,9 @@ class Rotor(object):
         material_data=None,
         disk_data=None,
         brg_seal_data=None,
-        sparse=True,
         min_w=None,
         max_w=None,
         rated_w=None,
-        n_eigen=12,
         nel_r=1,
         tag=None,
     ):
@@ -2416,9 +2415,6 @@ class Rotor(object):
         nel_r : int, optional
             Number or elements per shaft region.
             Default is 1.
-        n_eigen : int, optional
-            Number of eigenvalues calculated by arpack.
-            Default is 12.
         tag : str
             A tag for the rotor
 
@@ -2572,7 +2568,6 @@ class Rotor(object):
             shaft_elements,
             disk_elements,
             bearing_elements,
-            sparse=sparse,
             min_w=min_w,
             max_w=max_w,
             rated_w=rated_w,
@@ -2600,12 +2595,6 @@ class CoAxialRotor(Rotor):
     shaft_start_pos : list
         List indicating the initial node position for each shaft.
         Default is zero for each shaft created.
-    sparse : bool, optional
-        If sparse, eigenvalues will be calculated with arpack.
-        Default is True.
-    n_eigen : int, optional
-        Number of eigenvalues calculated by arpack.
-        Default is 12.
     tag : str
         A tag for the rotor
 
@@ -2674,8 +2663,6 @@ class CoAxialRotor(Rotor):
         disk_elements=None,
         bearing_elements=None,
         point_mass_elements=None,
-        sparse=True,
-        n_eigen=12,
         min_w=None,
         max_w=None,
         rated_w=None,
@@ -2683,8 +2670,6 @@ class CoAxialRotor(Rotor):
     ):
 
         self.parameters = {
-            "sparse": True,
-            "n_eigen": n_eigen,
             "min_w": min_w,
             "max_w": max_w,
             "rated_w": rated_w,
@@ -2696,8 +2681,6 @@ class CoAxialRotor(Rotor):
         # Config attributes
         ####################################################
 
-        self.sparse = sparse
-        self.n_eigen = n_eigen
         # operational speeds
         self.min_w = min_w
         self.max_w = max_w

--- a/ross/stochastic/st_rotor_assembly.py
+++ b/ross/stochastic/st_rotor_assembly.py
@@ -40,12 +40,6 @@ class ST_Rotor(object):
         List with the bearing elements
     point_mass_elements: list
         List with the point mass elements
-    sparse : bool, optional
-        If sparse, eigenvalues will be calculated with arpack.
-        Default is True.
-    n_eigen : int, optional
-        Number of eigenvalues calculated by arpack.
-        Default is 12.
     tag : str
         A tag for the rotor
 
@@ -99,7 +93,6 @@ class ST_Rotor(object):
         disk_elements=None,
         bearing_elements=None,
         point_mass_elements=None,
-        sparse=True,
         min_w=None,
         max_w=None,
         rated_w=None,
@@ -188,7 +181,6 @@ class ST_Rotor(object):
             disk_elements=disk_elements,
             bearing_elements=bearing_elements,
             point_mass_elements=point_mass_elements,
-            sparse=sparse,
             min_w=min_w,
             max_w=max_w,
             rated_w=rated_w,
@@ -273,9 +265,9 @@ class ST_Rotor(object):
         -------
         >>> import ross.stochastic as srs
         >>> rotors = srs.st_rotor_example()
-        >>> rotors["sparse"] = True
-        >>> rotors["sparse"]
-        True
+        >>> rotors["tag"] = "rotor"
+        >>> rotors["tag"]
+        'rotor'
         """
         if key not in self.attribute_dict.keys():
             raise KeyError("Object does not have parameter: {}.".format(key))
@@ -372,6 +364,7 @@ class ST_Rotor(object):
         """
         args_dict = args[0]
         new_args = []
+        var_size = None
 
         if self.iter_break is True:
             var_size = 1
@@ -381,9 +374,8 @@ class ST_Rotor(object):
                 if isinstance(v, Iterable):
                     var_size = len(v)
                     break
-                else:
-                    var_size = len(list(map(args_dict.get, is_random))[0])
-                    break
+            if var_size is None:
+                var_size = len(list(map(args_dict.get, is_random))[0])
 
         for i in range(var_size):
             arg = []


### PR DESCRIPTION
The eigenvalue / eigenvector solver is chosen when running the run_modal() method, and not anymore an parameter from the rotor model