### PR TITLE
Add methods to generate an automatic array to run frequency response

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -13,6 +13,28 @@ from scipy import interpolate
 colors1 = px.colors.qualitative.Dark24
 
 
+class CriticalSpeedResults:
+    """Class used to store results from run_critical_speed() method.
+
+    Parameters
+    ----------
+    wn : array
+        Undamped critical speeds array.
+    wd : array
+        Undamped critical speeds array.
+    log_dec : array
+        Logarithmic decrement for each critical speed.
+    damping_ratio : array
+        Damping ratio for each critical speed.
+    """
+
+    def __init__(self, wn, wd, log_dec, damping_ratio):
+        self.wn = wn
+        self.wd = wd
+        self.log_dec = log_dec
+        self.damping_ratio = damping_ratio
+
+
 class ModalResults:
     """Class used to store results and provide plots for Modal Analysis.
 
@@ -33,7 +55,7 @@ class ModalResults:
     wd : array
         Damped natural frequencies array.
     log_dec : array
-        Logarithmic decrement for each .
+        Logarithmic decrement for each mode.
     damping_ratio : array
         Damping ratio for each mode.
     lti : StateSpaceContinuous
@@ -843,7 +865,7 @@ class CampbellResults:
             title_text="<b>Frequency</b>",
             title_font=dict(family="Arial", size=20),
             tickfont=dict(size=16),
-            range=[0, np.max(speed_range)],
+            range=[np.min(speed_range), np.max(speed_range)],
             gridcolor="lightgray",
             showline=True,
             linewidth=2.5,
@@ -862,8 +884,6 @@ class CampbellResults:
             mirror=True,
         )
         fig.update_layout(
-            width=1200,
-            height=900,
             plot_bgcolor="white",
             hoverlabel_align="right",
             coloraxis=dict(
@@ -1459,7 +1479,7 @@ class ForcedResponseResults:
 
         return fig
 
-    def plot_polar_bode(self, dof, units="mic-pk-pk", **kwargs):
+    def plot_polar_bode(self, dof, units="m", **kwargs):
         """Plot polar forced response using Plotly.
 
         Parameters
@@ -1541,7 +1561,7 @@ class ForcedResponseResults:
     def plot(
         self,
         dof,
-        units="mic-pk-pk",
+        units="m",
         mag_kwargs={},
         phase_kwargs={},
         polar_kwargs={},
@@ -1599,9 +1619,9 @@ class ForcedResponseResults:
         for k, v in kwargs_default_values.items():
             subplot_kwargs.setdefault(k, v)
 
-        fig0 = self.plot_magnitude(dof, **mag_kwargs)
+        fig0 = self.plot_magnitude(dof, units, **mag_kwargs)
         fig1 = self.plot_phase(dof, **phase_kwargs)
-        fig2 = self.plot_polar_bode(dof, **polar_kwargs)
+        fig2 = self.plot_polar_bode(dof, units, **polar_kwargs)
 
         subplots = make_subplots(
             rows=2, cols=2, specs=[[{}, {"type": "polar", "rowspan": 2}], [{}, None]]

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -27,9 +27,9 @@ from ross.bearing_seal_element import (BallBearingElement, BearingElement,
 from ross.disk_element import DiskElement, DiskElement6DoF
 from ross.materials import steel
 from ross.results import (CampbellResults, ConvergenceResults,
-                          ForcedResponseResults, FrequencyResponseResults,
-                          ModalResults, StaticResults, SummaryResults,
-                          TimeResponseResults)
+                          CriticalSpeedResults, ForcedResponseResults,
+                          FrequencyResponseResults, ModalResults,
+                          StaticResults, SummaryResults, TimeResponseResults)
 from ross.shaft_element import ShaftElement, ShaftElement6DoF
 from ross.utils import convert
 
@@ -544,17 +544,28 @@ class Rotor(object):
     def run_modal(self, speed, num_modes=12, sparse=True):
         """Run modal analysis.
 
-        Method to calculate eigenvalues and eigvectors for a given rotor system
+        Method to calculate eigenvalues and eigvectors for a given rotor system.
+        Tthe natural frequencies and dampings ratios are calculated for a given
+        rotor speed. It means that for each speed input there's a different set of
+        eigenvalues and eigenvectors, hence, different natural frequencies and damping
+        ratios are returned.
 
         Parameters
         ----------
         speed : float
             Speed at which the eigenvalues and eigenvectors will be calculated.
-        num_modes : int
-            Number of modes to be calculated. This uses scipy.sparse.eigs method.
+        num_modes : int, optional
+            The number of eigenvalues and eigenvectors to be calculated using ARPACK.
+            If sparse=True, it determines the number of eigenvalues and eigenvectors
+            to be calculated. It must be smaller than Rotor.ndof - 1. It is not
+            possible to compute all eigenvectors of a matrix with ARPACK.
+            If sparse=False, num_modes does not have any effect over the method.
             Default is 12.
         sparse : bool, optional
-            If sparse, eigenvalues will be calculated with arpack.
+            If True, ARPACK is used to calculate a desired number (according to
+            num_modes) or eigenvalues and eigenvectors.
+            If False, scipy.linalg.eig() is used to calculate all the eigenvalues and
+            eigenvectors.
             Default is True.
 
         Returns
@@ -573,14 +584,14 @@ class Rotor(object):
         Example
         -------
         >>> rotor = rotor_example()
-        >>> modal = rotor.run_modal(speed=0)
+        >>> modal = rotor.run_modal(speed=0, sparse=False)
         >>> modal.wn[:2]
         array([91.79655318, 96.28899977])
         >>> modal.wd[:2]
         array([91.79655318, 96.28899977])
         >>> fig = modal.plot_mode3D(0)
         """
-        evalues, evectors = self._eigen(speed, num_modes=num_modes)
+        evalues, evectors = self._eigen(speed, num_modes=num_modes, sparse=sparse)
         wn_len = num_modes // 2
         wn = (np.absolute(evalues))[:wn_len]
         wd = (np.imag(evalues))[:wn_len]
@@ -605,6 +616,81 @@ class Rotor(object):
         )
 
         return modal_results
+
+    def run_critical_speed(self, num_modes=12, sparse=True, rtol=0.005):
+        """Calculate the critical speeds and damping ratios for the rotor model.
+
+        This function runs an iterative method over "run_modal()" to minimize
+        (using scipy.optimize.newton) the error between the rotor speed and the rotor
+        critical speeds (rotor speed - critical speed).
+
+        Differently from run_modal(), this function doesn't take a speed input because
+        it iterates over the natural frequencies calculated in the last iteration.
+        The initial value is considered to be the undamped natural frequecies for
+        speed = 0 (no gyroscopic effect).
+
+        Once the error is within an acceptable range defined by "rtol", it returns the
+        approximated critical speed.
+
+        With the critical speeds calculated, the function uses the results to
+        calculate the log dec and damping ratios for each critical speed.
+
+        Parameters
+        ----------
+        num_modes : int, optional
+            The number of eigenvalues and eigenvectors to be calculated using ARPACK.
+            If sparse=True, it determines the number of eigenvalues and eigenvectors
+            to be calculated. It must be smaller than Rotor.ndof - 1. It is not
+            possible to compute all eigenvectors of a matrix with ARPACK.
+            If sparse=False, num_modes does not have any effect over the method.
+            Default is 12.
+        sparse : bool, optional
+            If True, ARPACK is used to calculate a desired number (according to
+            num_modes) or eigenvalues and eigenvectors.
+            If False, scipy.linalg.eig() is used to calculate all the eigenvalues and
+            eigenvectors.
+            Default is True.
+        rtol : float, optional
+            Tolerance (relative) for termination. Applied to scipy.optimize.newton.
+            Default is 0.005 (0.5%).
+
+        Returns
+        -------
+        CriticalSpeedResults : array
+            CriticalSpeedResults.wn : undamped critical speeds.
+            CriticalSpeedResults.wd : damped critical speeds.
+            CriticalSpeedResults.log_dec : log_dec for each critical speed.
+            CriticalSpeedResults.damping_ratio : damping ratio for each critical speed.
+
+        Examples
+        --------
+        >>> rotor = rotor_example()
+        >>> results = rotor.run_critical_speed(num_modes=8)
+        >>> np.round(results.wd)
+        array([ 92.,  96., 271., 300.])
+        >>> np.round(results.wn)
+        array([ 92.,  96., 271., 300.])
+        """
+        _wn = self.run_modal(0, num_modes, sparse).wn
+        wn = np.zeros_like(_wn)
+        wd = np.zeros_like(_wn)
+        log_dec = np.zeros_like(_wn)
+        damping_ratio = np.zeros_like(_wn)
+
+        for i in range(len(wn)):
+            wn_func = lambda s: (s - self.run_modal(s, num_modes, sparse).wn[i])
+            wn[i] = newton(func=wn_func, x0=_wn[i], rtol=rtol)
+
+        for i in range(len(wn)):
+            wd_func = lambda s: (s - self.run_modal(s, num_modes, sparse).wd[i])
+            wd[i] = newton(func=wd_func, x0=wn[i], rtol=rtol)
+
+        for i, s in enumerate(wd):
+            modal = self.run_modal(s, num_modes, sparse)
+            log_dec[i] = modal.log_dec[i]
+            damping_ratio[i] = modal.damping_ratio[i]
+
+        return CriticalSpeedResults(wn, wd, log_dec, damping_ratio)
 
     def convergence(self, n_eigval=0, err_max=1e-02):
         """Run convergence analysis.
@@ -911,6 +997,76 @@ class Rotor(object):
                     break
         # fmt: on
 
+    def _clustering_points(self, num_modes=12, num_points=10, modes=None, rtol=0.005):
+        """Create an array with points clustered close to the natural frequencies.
+
+        This method generates an automatic array to run frequency response analyses.
+        The frequency points are calculated based on the damped natural frequencies and
+        their respective damping ratios. The greater the damping ratio, the more spread
+        the points are. If the damping ratio, for a given critical speed, is smaller
+        than 0.005, it is redefined to be 0.005 (for this method only).
+
+        Parameters
+        ----------
+        num_modes : int, optional
+            The number of eigenvalues and eigenvectors to be calculated using ARPACK.
+            It also defines the range for the output array, since the method generates
+            points only for the critical speed calculated by run_critical_speed().
+            Default is 12.
+        num_points : int, optional
+            The number of points generated for each critical speed.
+            The method set the same number of points for slightly less and slightly
+            higher than the natural circular frequency. It means there'll be num_points
+            greater and num_points smaller than a given critical speed.
+            num_points may be between 2 and 12. Anything above this range defaults
+            to 10 and anything below this range defaults to 4.
+            The default is 10.
+        modes : list, optional
+            Modes that will be used to calculate the frequency response.
+            The possibilities are limited by the num_modes argument.
+            (all modes will be used if a list is not given).
+        rtol : float, optional
+            Tolerance (relative) for termination. Applied to scipy.optimize.newton in
+            run_critical_speed() method.
+            Default is 0.005 (0.5%).
+
+        Returns
+        -------
+        speed_range : array
+            Range of frequencies (or speed).
+
+        Examples
+        --------
+        >>> rotor = rotor_example()
+        >>> speed_range = rotor._clustering_points(num_modes=12, num_points=5)
+        >>> speed_range.shape
+        (60,)
+        """
+        critical_speeds = self.run_critical_speed(num_modes=num_modes, rtol=rtol)
+        omega = critical_speeds.wd
+        damping = critical_speeds.damping_ratio
+        damping = np.array([d if d >= 0.005 else 0.005 for d in damping])
+
+        if num_points > 12:
+            num_points = 10
+        elif num_points < 2:
+            num_points = 4
+
+        if modes is not None:
+            omega = omega[modes]
+            damping = damping[modes]
+
+        a = np.zeros((len(omega), num_points))
+        for i in range(len(omega)):
+            for j in range(num_points):
+                b = 2 * (num_points - j + 1) / (num_points - 1)
+                a[i, j] = 1 + damping[i] ** b
+
+        omega = omega.reshape((len(omega), 1))
+        speed_range = np.sort(np.ravel(np.concatenate((omega / a, omega * a))))
+
+        return speed_range
+
     @staticmethod
     def _index(eigenvalues):
         """Generate indexes to sort eigenvalues and eigenvectors.
@@ -1096,15 +1252,15 @@ class Rotor(object):
         >>> speed = 100.0
         >>> H = rotor.transfer_matrix(speed=speed)
         """
-        modal = self.run_modal(speed=speed)
-        B = modal.lti.B
-        C = modal.lti.C
-        D = modal.lti.D
+        lti = self._lti(speed=speed)
+        B = lti.B
+        C = lti.C
+        D = lti.D
 
         # calculate eigenvalues and eigenvectors using la.eig to get
         # left and right eigenvectors.
 
-        evals, psi, = la.eig(self.A(speed, frequency))
+        evals, psi = self._eigen(speed=speed, frequency=frequency, sparse=False)
 
         psi_inv = la.inv(psi)
 
@@ -1115,7 +1271,6 @@ class Rotor(object):
             idx = np.zeros((2 * m), int)
             idx[0:m] = modes  # modes
             idx[m:] = range(2 * n)[-m:]  # conjugates (see how evalues are ordered)
-
             evals = evals[np.ix_(idx)]
             psi = psi[np.ix_(range(2 * n), idx)]
             psi_inv = psi_inv[np.ix_(idx, range(2 * n))]
@@ -1126,27 +1281,59 @@ class Rotor(object):
 
         return H
 
-    def run_freq_response(self, speed_range=None, modes=None):
+    def run_freq_response(
+        self,
+        speed_range=None,
+        modes=None,
+        cluster_points=False,
+        num_modes=12,
+        num_points=10,
+        rtol=0.005,
+    ):
         """Frequency response for a mdof system.
 
-        This method returns the frequency response for a mdof system
-        given a range of frequencies and the modes that will be used.
+        This method returns the frequency response for a mdof system given a range of
+        frequencies and the modes that will be used.
 
-        Parameters
-        ----------
+        General parameters
+        ------------------
         speed_range : array, optional
-            Array with the desired range of frequencies (the default
-             is 0 to 1.5 x highest damped natural frequency.
+            Array with the desired range of frequencies.
+            Default is 0 to 1.5 x highest damped natural frequency.
         modes : list, optional
             Modes that will be used to calculate the frequency response
             (all modes will be used if a list is not given).
+
+        Frequency spacing parameters
+        ----------------------------
+        cluster_points : bool, optional
+            boolean to activate the automatic frequency spacing method. If True, the
+            method uses _clustering_points() to create an speed_range.
+            Default is False
+        num_points : int, optional
+            The number of points generated per critical speed.
+            The method set the same number of points for slightly less and slightly
+            higher than the natural circular frequency. It means there'll be num_points
+            greater and num_points smaller than a given critical speed.
+            num_points may be between 2 and 12. Anything above this range defaults
+            to 10 and anything below this range defaults to 4.
+            The default is 10.
+        num_modes
+            The number of eigenvalues and eigenvectors to be calculated using ARPACK.
+            It also defines the range for the output array, since the method generates
+            points only for the critical speed calculated by run_critical_speed().
+            Default is 12.
+        rtol : float, optional
+            Tolerance (relative) for termination. Applied to scipy.optimize.newton to
+            calculate the approximated critical speeds.
+            Default is 0.005 (0.5%).
 
         Returns
         -------
         results : array
             Array with the frequencies, magnitude (dB) of the frequency
             response for each pair input/output, and
-            phase of the frequency response for each pair input/output..
+            phase of the frequency response for each pair input/output.
             It will be returned if plot=False.
 
         Examples
@@ -1157,12 +1344,25 @@ class Rotor(object):
         >>> response.magnitude # doctest: +ELLIPSIS
         array([[[1.00000000e-06, 1.00261725e-06, 1.01076952e-06, ...
 
+        Using clustered points option.
+        Set `cluster_points=True` and choose how many modes the method must search and
+        how many points to add just before and after each critical speed.
+
+        >>> response = rotor.run_freq_response(cluster_points=True, num_modes=12, num_points=5)
+        >>> response.speed_range.shape
+        (60,)
+
         # plot frequency response function:
         >>> fig = response.plot(inp=13, out=13)
         """
         if speed_range is None:
-            modal = self.run_modal(0)
-            speed_range = np.linspace(0, max(modal.evalues.imag) * 1.5, 1000)
+            if not cluster_points:
+                modal = self.run_modal(0)
+                speed_range = np.linspace(0, max(modal.evalues.imag) * 1.5, 1000)
+            else:
+                speed_range = self._clustering_points(
+                    num_modes, num_points, modes, rtol
+                )
 
         self._check_frequency_array(speed_range)
 

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1052,6 +1052,67 @@ def test_static_analysis_rotor6(rotor6):
     )
 
 
+def test_run_critical_speed(rotor5, rotor6):
+    results5 = rotor5.run_critical_speed(num_modes=12, rtol=0.005)
+    results6 = rotor6.run_critical_speed(num_modes=12, rtol=0.005)
+
+    wn5 = np.array(
+        [
+            86.10505193,
+            86.60492546,
+            198.93259257,
+            207.97165539,
+            244.95609413,
+            250.53522782,
+        ]
+    )
+    wd5 = np.array(
+        [
+            86.1050519,
+            86.60492544,
+            198.93259256,
+            207.97165539,
+            244.95609413,
+            250.53522782,
+        ]
+    )
+    log_dec5 = np.zeros_like(wd5)
+    damping_ratio5 = np.zeros_like(wd5)
+
+    wd6 = np.array(
+        [
+            61.52110644,
+            63.72862198,
+            117.49491374,
+            118.55829416,
+            233.83724523,
+            236.40346235,
+        ]
+    )
+    wn6 = np.array(
+        [
+            61.52110644,
+            63.72862198,
+            117.49491375,
+            118.55829421,
+            233.83724523,
+            236.40346458,
+        ]
+    )
+    log_dec6 = np.zeros_like(wd6)
+    damping_ratio6 = np.zeros_like(wd6)
+
+    assert_almost_equal(results5.wd, wd5, decimal=4)
+    assert_almost_equal(results5.wn, wn5, decimal=4)
+    assert_almost_equal(results5.log_dec, log_dec5, decimal=4)
+    assert_almost_equal(results5.damping_ratio, damping_ratio5, decimal=4)
+
+    assert_almost_equal(results6.wd, wd6, decimal=4)
+    assert_almost_equal(results6.wn, wn6, decimal=4)
+    assert_almost_equal(results6.log_dec, log_dec6, decimal=4)
+    assert_almost_equal(results6.damping_ratio, damping_ratio6, decimal=4)
+
+
 @pytest.fixture
 def coaxrotor():
     #  Co-axial rotor system with 2 shafts, 4 disks and


### PR DESCRIPTION
- **run_critical_speed():**
This function runs an iterative method over "run_modal()" to minimize (using scipy.optimize.newton) the error between the rotor speed and the rotor critical speeds (rotor speed - critical speed).
Differently from run_modal(), this function doesn't take a speed input because it iterates over the natural frequencies calculated in the last iteration. The initial value is considered to be the undamped natural frequecies for speed = 0 (no gyroscopic effect).
Once the error is within an acceptable range defined by "rtol", it returns the approximated critical speed.
With the critical speeds calculated, the function uses the results to calculate the log dec and damping ratios for each critical speed.

- **_clustering_points()**
This method generates an automatic array to run frequency response analyses. The frequency points are calculated based on the damped natural frequencies and their respective damping ratios. The greater the damping ratio, the more spread the points are. If the damping ratio, for a given critical speed, is smaller than 0.005, it is redefined to be 0.005 (for this method only).