### PR TITLE
Change save functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 numpy
 scipy
 matplotlib
-toml
+toml>=0.10.1
 pandas>=0.23
 plotly>=4.7.0
 bokeh>=1.4.0

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -429,8 +429,10 @@ class BearingElement(Element):
         self.n_link = n_link
         self.n_l = n
         self.n_r = n
-
-        self.frequency = np.array(frequency, dtype=np.float64)
+        if frequency is not None:
+            self.frequency = np.array(frequency, dtype=np.float64)
+        else:
+            self.frequency = frequency
         self.tag = tag
         self.color = color
         self.scale_factor = scale_factor
@@ -522,12 +524,17 @@ class BearingElement(Element):
             "cyy": [float(i) for i in self.cyy.coefficient],
             "cxy": [float(i) for i in self.cxy.coefficient],
             "cyx": [float(i) for i in self.cyx.coefficient],
-            "frequency": [float(i) for i in self.frequency],
             "tag": self.tag,
             "n_link": self.n_link,
             "scale_factor": self.scale_factor,
         }
+        if self.frequency is not None:
+            args["frequency"] = [float(i) for i in self.frequency]
+        else:
+            args["frequency"] = self.frequency
+
         data[f"{self.__class__.__name__}_{self.tag}"] = args
+
         with open(file, "w") as f:
             toml.dump(data, f)
 
@@ -1731,101 +1738,37 @@ class BearingElement6DoF(BearingElement):
             )
         return False
 
-    def save(self, file_name=Path(os.getcwd())):
-        """Save a bearing element in a toml format.
+    def save(self, file):
+        try:
+            data = toml.load(file)
+        except FileNotFoundError:
+            data = {}
 
-        It works as an auxiliary function of the save function in the Rotor class.
-
-        Parameters
-        ----------
-        file_name : string
-            The name of the file the bearing element will be saved in.
-
-        Examples
-        --------
-        >>> bearing = bearing_6dof_example()
-        >>> bearing.save(Path(os.getcwd()))
-        """
-        data = self.get_data(Path(file_name) / "BearingElement6DoF.toml")
-
-        if type(self.frequency) == np.ndarray:
-            try:
-                self.frequency[0]
-                frequency = list(self.frequency)
-            except IndexError:
-                frequency = None
-
-        data["BearingElement6DoF"][str(self.n)] = {
+        args = {
             "n": self.n,
-            "kxx": self.kxx.coefficient,
-            "cxx": self.cxx.coefficient,
-            "kyy": self.kyy.coefficient,
-            "kxy": self.kxy.coefficient,
-            "kyx": self.kyx.coefficient,
-            "kzz": self.kzz.coefficient,
-            "cyy": self.cyy.coefficient,
-            "cxy": self.cxy.coefficient,
-            "cyx": self.cyx.coefficient,
-            "czz": self.czz.coefficient,
-            "frequency": frequency,
+            "kxx": [float(i) for i in self.kxx.coefficient],
+            "cxx": [float(i) for i in self.cxx.coefficient],
+            "kyy": [float(i) for i in self.kyy.coefficient],
+            "kxy": [float(i) for i in self.kxy.coefficient],
+            "kyx": [float(i) for i in self.kyx.coefficient],
+            "kzz": [float(i) for i in self.kzz.coefficient],
+            "cyy": [float(i) for i in self.cyy.coefficient],
+            "cxy": [float(i) for i in self.cxy.coefficient],
+            "cyx": [float(i) for i in self.cyx.coefficient],
+            "czz": [float(i) for i in self.czz.coefficient],
             "tag": self.tag,
             "n_link": self.n_link,
             "scale_factor": self.scale_factor,
         }
-        self.dump_data(data, Path(file_name) / "BearingElement6DoF.toml")
+        if self.frequency is not None:
+            args["frequency"] = [float(i) for i in self.frequency]
+        else:
+            args["frequency"] = self.frequency
 
-    @staticmethod
-    def load(file_name=""):
-        """Load a list of bearing elements saved in a toml format.
+        data[f"{self.__class__.__name__}_{self.tag}"] = args
 
-        Parameters
-        ----------
-        file_name : string
-            The name of the file of the bearing element to be loaded.
-
-        Returns
-        -------
-        A list of bearing elements.
-
-        Examples
-        --------
-        >>> bearing1 = bearing_6dof_example()
-        >>> bearing1.save(os.getcwd())
-        >>> list_of_bearings = BearingElement6DoF.load(os.getcwd())
-        >>> bearing1 == list_of_bearings[0]
-        True
-        """
-        bearing_elements = []
-        bearing_elements_dict = BearingElement.get_data(
-            file_name=Path(file_name) / "BearingElement6DoF.toml"
-        )
-        for element in bearing_elements_dict["BearingElement6DoF"]:
-            bearing = BearingElement6DoF(
-                **bearing_elements_dict["BearingElement6DoF"][element]
-            )
-            data = bearing_elements_dict["BearingElement6DoF"]
-            bearing.kxx.coefficient = data[element]["kxx"]
-
-            bearing.kxy.coefficient = data[element]["kxy"]
-
-            bearing.kyx.coefficient = data[element]["kyx"]
-
-            bearing.kyy.coefficient = data[element]["kyy"]
-
-            bearing.kzz.coefficient = data[element]["kzz"]
-
-            bearing.cxx.coefficient = data[element]["cxx"]
-
-            bearing.cxy.coefficient = data[element]["cxy"]
-
-            bearing.cyx.coefficient = data[element]["cyx"]
-
-            bearing.cyy.coefficient = data[element]["cyy"]
-
-            bearing.czz.coefficient = data[element]["czz"]
-
-            bearing_elements.append(bearing)
-        return bearing_elements
+        with open(file, "w") as f:
+            toml.dump(data, f)
 
     def dof_mapping(self):
         """Degrees of freedom mapping.

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -507,6 +507,29 @@ class BearingElement(Element):
         return hash(self.tag)
 
     def save(self, file):
+        """Save the element in a .toml file.
+
+        This function will save the element to a .toml file.
+        The file will have all the argument's names and values that are needed to
+        reinstantiate the element.
+
+        Parameters
+        ----------
+        file : str, pathlib.Path
+            The name of the file the element will be saved in.
+
+        Examples
+        --------
+        >>> # Example using DiskElement
+        >>> import ross as rs
+        >>> kxx = 1e6
+        >>> kyy = 0.8e6
+        >>> cxx = 2e2
+        >>> cyy = 1.5e2
+        >>> frequency = np.linspace(0, 200, 11)
+        >>> bearing0 = rs.BearingElement(n=0, kxx=kxx, kyy=kyy, cxx=cxx, cyy=cyy, frequency=frequency)
+        >>> bearing0.save('/tmp/bearing0.toml')
+        """
         try:
             data = toml.load(file)
         except FileNotFoundError:

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -507,29 +507,6 @@ class BearingElement(Element):
         return hash(self.tag)
 
     def save(self, file):
-        """Save the element in a .toml file.
-
-        This function will save the element to a .toml file.
-        The file will have all the argument's names and values that are needed to
-        reinstantiate the element.
-
-        Parameters
-        ----------
-        file : str, pathlib.Path
-            The name of the file the element will be saved in.
-
-        Examples
-        --------
-        >>> # Example using DiskElement
-        >>> import ross as rs
-        >>> kxx = 1e6
-        >>> kyy = 0.8e6
-        >>> cxx = 2e2
-        >>> cyy = 1.5e2
-        >>> frequency = np.linspace(0, 200, 11)
-        >>> bearing0 = rs.BearingElement(n=0, kxx=kxx, kyy=kyy, cxx=cxx, cyy=cyy, frequency=frequency)
-        >>> bearing0.save('/tmp/bearing0.toml')
-        """
         try:
             data = toml.load(file)
         except FileNotFoundError:

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -126,66 +126,6 @@ class DiskElement(Element):
     def __hash__(self):
         return hash(self.tag)
 
-    def save(self, file_name=os.getcwd()):
-        """Save a disk element in a toml format.
-
-        It works as an auxiliary function of the save function in the Rotor class.
-
-        Parameters
-        ----------
-        file_name : string
-            The name of the file the disk element will be saved in.
-
-        Examples
-        --------
-        >>> disk = disk_example()
-        >>> disk.save()
-        """
-        data = self.get_data(Path(file_name) / "DiskElement.toml")
-        data["DiskElement"][str(self.n)] = {
-            "n": self.n,
-            "m": self.m,
-            "Id": self.Id,
-            "Ip": self.Ip,
-            "tag": self.tag,
-            "scale_factor": self.scale_factor,
-            "color": self.color,
-        }
-        self.dump_data(data, Path(file_name) / "DiskElement.toml")
-
-    @staticmethod
-    def load(file_name=os.getcwd()):
-        """Load a list of disk elements saved in a toml format.
-
-        It works as an auxiliary function of the load function in the Rotor class.
-
-        Parameters
-        ----------
-        file_name: str
-            The name of the file of the disk element to be loaded.
-
-        Returns
-        -------
-        disk_elements: list
-            A list of disk elements.
-
-        Examples
-        --------
-        >>> disk1 = disk_example()
-        >>> disk1.save(os.getcwd())
-        >>> list_of_disks = DiskElement.load(os.getcwd())
-        >>> disk1 == list_of_disks[0]
-        True
-        """
-        disk_elements = []
-        with open("DiskElement.toml", "r") as f:
-            disk_elements_dict = toml.load(f)
-            for element in disk_elements_dict["DiskElement"]:
-                disk_elements.append(
-                    DiskElement(**disk_elements_dict["DiskElement"][element])
-                )
-        return disk_elements
-
     def dof_mapping(self):
         """Degrees of freedom mapping.
 
@@ -354,12 +294,7 @@ class DiskElement(Element):
         y_upper.append(None)
         y_pos.extend(y_lower)
 
-        customdata = [
-            self.n,
-            self.Ip,
-            self.Id,
-            self.m,
-        ]
+        customdata = [self.n, self.Ip, self.Id, self.m]
         hovertemplate = (
             f"<b>Disk Node: {customdata[0]}<b><br>"
             + f"<b>Polar Inertia: {customdata[1]:.3e}<b><br>"
@@ -419,15 +354,7 @@ class DiskElement(Element):
     @classmethod
     @check_units
     def from_geometry(
-        cls,
-        n,
-        material,
-        width,
-        i_d,
-        o_d,
-        tag=None,
-        scale_factor=1.0,
-        color="Firebrick",
+        cls, n, material, width, i_d, o_d, tag=None, scale_factor=1.0, color="Firebrick"
     ):
         """Create a disk element from geometry properties.
 
@@ -485,9 +412,7 @@ class DiskElement(Element):
         return cls(n, m, Id, Ip, tag, scale_factor, color)
 
     @classmethod
-    def from_table(
-        cls, file, sheet_name=0, tag=None, scale_factor=None, color=None,
-    ):
+    def from_table(cls, file, sheet_name=0, tag=None, scale_factor=None, color=None):
         """Instantiate one or more disks using inputs from an Excel table.
 
         A header with the names of the columns is required. These names should

--- a/ross/element.py
+++ b/ross/element.py
@@ -204,65 +204,6 @@ class Element(ABC):
         attributes["type"] = self.__class__.__name__
         return pd.Series(attributes)
 
-    @staticmethod
-    def get_data(file_name):
-        """Load elements data saved in a toml format.
-
-        Parameters
-        ----------
-        file_name: string
-            The name of the file to be loaded.
-
-        Returns
-        -------
-        data: dict
-            The element parameters presented as a dictionary.
-
-        Examples
-        --------
-        >>> # Example using BearingElement
-        >>> from ross.bearing_seal_element import bearing_example
-        >>> from ross.bearing_seal_element import BearingElement
-        >>> bearing = bearing_example()
-        >>> bearing.save(Path('.'))
-        >>> BearingElement.get_data('BearingElement.toml') # doctest: +ELLIPSIS
-        {'BearingElement': {'0': {'n': 0, 'kxx': [1000000.0, 1000000.0,...
-        """
-        try:
-            with open(file_name, "r") as f:
-                data = toml.load(f)
-                if data == {"": {}}:
-                    data = {str(file_name.name)[:-5]: {}}
-
-        except FileNotFoundError:
-            data = {str(file_name.name)[:-5]: {}}
-            Element.dump_data(data, file_name)
-        return data
-
-    @staticmethod
-    def dump_data(data, file_name):
-        """Dump element data in a toml file.
-
-        Parameters
-        ----------
-        data: dict
-            The data that should be dumped.
-        file_name: string
-            The name of the file the data will be dumped in.
-
-        Examples
-        --------
-        >>> # Example using BearingElement
-        >>> from ross.bearing_seal_element import bearing_example
-        >>> from ross.bearing_seal_element import BearingElement
-        >>> bearing = bearing_example()
-        >>> bearing.save(Path('.'))
-        >>> data = BearingElement.get_data('BearingElement.toml')
-        >>> BearingElement.dump_data(data, 'BearingElement.toml') # doctest: +ELLIPSIS
-        """
-        with open(file_name, "w") as f:
-            toml.dump(data, f)
-
     @abstractmethod
     def dof_mapping(self):
         """Degrees of freedom mapping.

--- a/ross/materials.py
+++ b/ross/materials.py
@@ -210,7 +210,6 @@ class Material:
         Examples
         --------
         >>> import ross as rs
-        >>> rs.steel.save_material()
         >>> steel = rs.Material.use_material('Steel')
         """
         data = Material.get_data()

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -113,64 +113,6 @@ class PointMass(Element):
             f" my={self.my:{0}.{5}}, tag={self.tag!r})"
         )
 
-    def save(self, file_name=os.getcwd()):
-        """Save a point mass element in a toml format.
-
-        It works as an auxiliary function of the save function in the Rotor class.
-
-        Parameters
-        ----------
-        file_name: string
-            The name of the file the point mass element will be saved in.
-
-        Examples
-        --------
-        >>> point_mass = point_mass_example()
-        >>> point_mass.save()
-        """
-        data = self.get_data(Path(file_name) / "PointMass.toml")
-        data["PointMass"][str(self.n)] = {
-            "n": self.n,
-            "m": self.m,
-            "mx": self.mx,
-            "my": self.my,
-            "tag": self.tag,
-        }
-        self.dump_data(data, Path(file_name) / "PointMass.toml")
-
-    @staticmethod
-    def load(file_name=os.getcwd()):
-        """Load a list of point mass elements saved in a toml format.
-
-        It works as an auxiliary function of the load function in the Rotor class.
-
-        Parameters
-        ----------
-        file_name: str
-            The name of the file of the point mass element to be loaded.
-
-        Returns
-        -------
-        point_mass_elements: list
-            A list of point mass elements.
-
-        Examples
-        --------
-        >>> point_mass1 = point_mass_example()
-        >>> point_mass1.save(os.getcwd())
-        >>> list_of_pointmass = PointMass.load(os.getcwd())
-        >>> point_mass1 == list_of_pointmass[0]
-        True
-        """
-        point_mass_elements = []
-        with open("PointMass.toml", "r") as f:
-            point_mass_dict = toml.load(f)
-            for element in point_mass_dict["PointMass"]:
-                point_mass_elements.append(
-                    PointMass(**point_mass_dict["PointMass"][element])
-                )
-        return point_mass_elements
-
     def M(self):
         """Mass matrix for an instance of a point mass element.
 
@@ -305,11 +247,7 @@ class PointMass(Element):
         zpos, ypos = position
         radius = ypos / 8
 
-        customdata = [
-            self.n,
-            self.mx,
-            self.my,
-        ]
+        customdata = [self.n, self.mx, self.my]
         hovertemplate = (
             f"<b>PointMass Node: {customdata[0]}<b><br>"
             + f"<b>Mass (X): {customdata[1]:.3f}<b><br>"

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2302,12 +2302,12 @@ class Rotor(object):
 
         return results
 
-    def save_mat(self, file_path, speed, frequency=None):
+    def save_mat(self, file, speed, frequency=None):
         """Save matrices and rotor model to a .mat file.
 
         Parameters
         ----------
-        file_path : str
+        file : str, pathlib.Path
 
         speed: float
             Rotor speed.
@@ -2318,7 +2318,7 @@ class Rotor(object):
         Examples
         --------
         >>> rotor = rotor_example()
-        >>> rotor.save_mat('new_matrices.mat', speed=0)
+        >>> rotor.save_mat('/tmp/new_matrices', speed=0)
         """
         if frequency is None:
             frequency = speed
@@ -2331,7 +2331,7 @@ class Rotor(object):
             "nodes": self.nodes_pos,
         }
 
-        sio.savemat("%s/%s.mat" % (os.getcwd(), file_path), dic)
+        sio.savemat(file, dic)
 
     def save(self, file):
         """Save the rotor to a .toml file.
@@ -2357,7 +2357,7 @@ class Rotor(object):
         Parameters
         ----------
         file : str or pathlib.Path
-            String or Path for a ROSS model file (.rsm).
+            String or Path for a .toml file.
 
         Returns
         -------

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -190,6 +190,11 @@ class Rotor(object):
             )
         ]
 
+        # check if tags are unique
+        tags_list = [el.tag for el in self.elements]
+        if len(tags_list) != len(set(tags_list)):
+            raise ValueError("Tags should be unique.")
+
         self.number_dof = self._check_number_dof()
 
         ####################################################

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -3,6 +3,7 @@
 This module defines the ShaftElement classes which will be used to represent the rotor
 shaft. There're 2 options, an element with 8 or 12 degrees of freedom.
 """
+import inspect
 import os
 from pathlib import Path
 
@@ -380,12 +381,12 @@ class ShaftElement(Element):
     def __hash__(self):
         return hash(self.tag)
 
-    def save(self, file_name=Path(os.getcwd())):
+    def save(self, file):
         """Save shaft elements to toml file.
 
         Parameters
         ----------
-        file_name : str
+        file : str
 
         Examples
         --------
@@ -396,54 +397,33 @@ class ShaftElement(Element):
         ... )
         >>> shaft1.save()
         """
-        data = self.get_data(Path(file_name) / "ShaftElement.toml")
-        data["ShaftElement"][str(self.n)] = {
-            "L": self.L,
-            "idl": self.idl,
-            "odl": self.odl,
-            "idr": self.idr,
-            "odr": self.odr,
-            "material": self.material.name,
-            "n": self.n,
-            "axial_force": self.axial_force,
-            "torque": self.torque,
-            "shear_effects": self.shear_effects,
-            "rotary_inertia": self.rotary_inertia,
-            "gyroscopic": self.gyroscopic,
-            "shear_method_calc": self.shear_method_calc,
+        signature = inspect.signature(self.__init__)
+        args_list = list(signature.parameters)
+        args = {arg: getattr(self, arg) for arg in args_list}
+
+        # add material characteristics so that the shaft element can be reconstructed
+        # even if the material is not in the available_materials file.
+        args["material"] = {
+            "name": self.material.name,
+            "rho": self.material.rho,
+            "E": self.material.E,
+            "G_s": self.material.G_s,
+            "color": self.material.color,
         }
-        self.dump_data(data, Path(file_name) / "ShaftElement.toml")
 
-    @staticmethod
-    def load(file_name="ShaftElement"):
-        """Load a list of shaft elements saved in a toml format.
+        try:
+            data = toml.load(file)
+        except FileNotFoundError:
+            data = {}
 
-        It works as an auxiliary function of the load function in the Rotor class.
+        data[f"{self.__class__.__name__}_{self.tag}"] = args
+        with open(file, "w") as f:
+            toml.dump(data, f)
 
-        Parameters
-        ----------
-        file_name : str, optional
-
-        Examples
-        --------
-        >>> from ross.materials import steel
-        >>> shaft1 = ShaftElement(
-        ...        L=0.25, idl=0, idr=0, odl=0.05, odr=0.08,
-        ...        material=steel, rotary_inertia=True, shear_effects=True
-        ... )
-        >>> shaft1.save(os.getcwd())
-        >>> shaft2 = ShaftElement.load(os.getcwd())
-        >>> shaft2 # doctest: +ELLIPSIS
-        [ShaftElement(L=0.25, idl=0.0...
-        """
-        shaft_elements = []
-        with open("ShaftElement.toml", "r") as f:
-            shaft_elements_dict = toml.load(f)
-            for element in shaft_elements_dict["ShaftElement"]:
-                shaft_elements.append(
-                    ShaftElement(**shaft_elements_dict["ShaftElement"][element])
-                )
-        return shaft_elements
+    @classmethod
+    def read_toml_data(cls, data):
+        data["material"] = Material(**data["material"])
+        return cls(**data)
 
     @property
     def n(self):

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -382,21 +382,6 @@ class ShaftElement(Element):
         return hash(self.tag)
 
     def save(self, file):
-        """Save shaft elements to toml file.
-
-        Parameters
-        ----------
-        file : str
-
-        Examples
-        --------
-        >>> from ross.materials import steel
-        >>> shaft1 = ShaftElement(
-        ...        L=0.25, idl=0, idr=0, odl=0.05, odr=0.08,
-        ...        material=steel, rotary_inertia=True, shear_effects=True,
-        ... )
-        >>> shaft1.save()
-        """
         signature = inspect.signature(self.__init__)
         args_list = list(signature.parameters)
         args = {arg: getattr(self, arg) for arg in args_list}

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -231,12 +231,6 @@ def test_from_table():
     assert_allclose(bearing.kxx.coefficient[2], 53565700)
 
 
-def test_save_load(bearing0):
-    bearing0.save("/tmp/bearing0.toml")
-    bearing0_loaded = BearingElement.load("/tmp/bearing0.toml")
-    assert bearing0 == bearing0_loaded
-
-
 def test_bearing_link_matrices():
     b0 = BearingElement(n=0, n_link=3, kxx=1, cxx=1)
     # fmt: off
@@ -296,19 +290,25 @@ def test_roller_bearing_element():
     assert_allclose(rollerbearing.G(), G)
 
 
-def test_bearing_6dof():
+@pytest.fixture
+def bearing_6dof():
     bearing_6dof = BearingElement6DoF(
         n=0, kxx=1e6, kyy=0.8e6, kzz=1e5, cxx=2e2, cyy=1.5e2, czz=0.5e2
     )
+
+    return bearing_6dof
+
+
+def test_bearing6(bearing_6dof):
     # fmt: off
     K = np.array(
-        [[1000000.,       0.,       0.],
-         [      0.,  800000.,       0.],
-         [      0.,       0.,  100000.]])
+        [[1000000., 0., 0.],
+         [0., 800000., 0.],
+         [0., 0., 100000.]])
     C = np.array(
-        [[200.,   0.,   0.],
-         [  0., 150.,   0.],
-         [  0.,   0.,  50.]])
+        [[200., 0., 0.],
+         [0., 150., 0.],
+         [0., 0., 50.]])
     M = np.zeros((3, 3))
     G = np.zeros((3, 3))
     # fmt: on
@@ -333,3 +333,17 @@ def test_bearing_6dof_equality():
     assert bearing_6dof_0 == bearing_6dof_1
     assert not bearing_6dof_1 == bearing_6dof_2
     assert not bearing_6dof_0 == bearing_6dof_2
+
+
+def test_save_load(bearing0, bearing_constant, bearing_6dof):
+    bearing0.save("/tmp/bearing0.toml")
+    bearing0_loaded = BearingElement.load("/tmp/bearing0.toml")
+    assert bearing0 == bearing0_loaded
+
+    bearing_constant.save("/tmp/bearing_constant.toml")
+    bearing_constant_loaded = BearingElement.load("/tmp/bearing_constant.toml")
+    assert bearing_constant == bearing_constant_loaded
+
+    bearing_6dof.save("/tmp/bearing_6dof.toml")
+    bearing_6dof_loaded = BearingElement6DoF.load("/tmp/bearing_6dof.toml")
+    assert bearing_6dof == bearing_6dof_loaded

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -231,6 +231,12 @@ def test_from_table():
     assert_allclose(bearing.kxx.coefficient[2], 53565700)
 
 
+def test_save_load(bearing0):
+    bearing0.save("/tmp/bearing0.toml")
+    bearing0_loaded = BearingElement.load("/tmp/bearing0.toml")
+    assert bearing0 == bearing0_loaded
+
+
 def test_bearing_link_matrices():
     b0 = BearingElement(n=0, n_link=3, kxx=1, cxx=1)
     # fmt: off

--- a/ross/tests/test_disk_element.py
+++ b/ross/tests/test_disk_element.py
@@ -47,6 +47,12 @@ def disk_from_geometry():
     return DiskElement.from_geometry(0, steel, 0.07, 0.05, 0.28)
 
 
+def test_save_load(disk, disk_from_geometry):
+    disk.save("/tmp/disk.toml")
+    disk_loaded = DiskElement.load("/tmp/disk.toml")
+    assert disk == disk_loaded
+
+
 def test_mass_matrix_disk1(disk_from_geometry):
     # fmt: off
     Md1 = np.array([[ 32.58973,   0.     ,   0.     ,   0.     ],

--- a/ross/tests/test_point_mass.py
+++ b/ross/tests/test_point_mass.py
@@ -27,3 +27,11 @@ def test_local_index():
 
     assert p.dof_local_index().x_0 == 0
     assert p.dof_local_index().y_0 == 1
+
+
+def test_save_load():
+    p = PointMass(n=0, m=10.0, tag="pointmass")
+    p.save("/tmp/point_mass.toml")
+    p_loaded = p.load("/tmp/point_mass.toml")
+
+    assert p == p_loaded

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -11,8 +11,6 @@ from ross.point_mass import *
 from ross.rotor_assembly import *
 from ross.rotor_assembly import MAC_modes
 from ross.shaft_element import *
-
-test_dir = os.path.dirname(__file__)
 
 
 @pytest.fixture
@@ -1517,11 +1515,10 @@ def test_H_kappa(rotor7):
 
 
 def test_save_load():
-
     a = rotor_example()
     a.save("teste00000000000000001")
-    b = Rotor.load("teste00000000000000001")
-    Rotor.remove("teste00000000000000001")
+    b = Rotor.load("teste00000000000000001.rsm")
+    (Path.cwd() / "teste00000000000000001.rsm").unlink()
 
     assert a == b
 

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1766,3 +1766,10 @@ def test_ucs_calc(rotor8):
     assert_allclose(rotor_wn[0, :3], exp_rotor_wn)
     assert_allclose(intersection_points["x"][:3], exp_intersection_points_x, rtol=1e-3)
     assert_allclose(intersection_points["y"][:3], exp_intersection_points_y, rtol=1e-3)
+
+
+def test_save_load(rotor8):
+    rotor8.save("/tmp/rotor8.toml")
+    rotor8_loaded = Rotor.load("/tmp/rotor8.toml")
+
+    rotor8 == rotor8_loaded

--- a/ross/tests/test_shaft_element.py
+++ b/ross/tests/test_shaft_element.py
@@ -308,6 +308,15 @@ def test_match_gyroscopic_matrix(tap2, tim2):
     assert_almost_equal(G_tap, G_tim, decimal=5)
 
 
+def test_save_load(tim, tap_tim):
+    tim.save("/tmp/tim.toml")
+    tim_loaded = ShaftElement.load("/tmp/tim.toml")
+    assert tim == tim_loaded
+    tap_tim.save("/tmp/tap_tim.toml")
+    tap_tim_loaded = ShaftElement.load("/tmp/tap_tim.toml")
+    assert tap_tim == tap_tim_loaded
+
+
 @pytest.fixture
 def s6_eb():
 


### PR DESCRIPTION
This PR makes some modifications to the save functions implemented in each element class:

- [x] Rotor will be saved to a single `.toml` file. 
Each element has a .save method that writes to a .toml file, if the
file already exists the method appends to the end of the file. So the
process of saving the rotor is basically an iteration over all the
rotor elements and a call to the element.save() method.
The load method goes through all items in the .toml file and calls the
elements .read_toml_data, which parses the dictionary stored in the
.toml and returns the Element.
The elements are then separated in lists and given to the cls()
constructor. ;
- [x] Check if tag for each element is unique. This will be used to differentiate each element in the saved files, using class name + tag, instead of class name + n (node), since distinct elements can be located at the same node (e.g. shaft elements with different diameters);
- [x] Change `Element.save()` method so each element can use the inherited method;

This also moves all saved files to /tmp/, this way running the tests will not create several files in the ross directory (closes #590).
The ShaftElement.save method also writes the properties of the used material, so we don't have to rely on saved materials to recreate a shaft element from a saved file. This closes #600.

