### PR TITLE
Add file to configurate rotordynamic report

### DIFF
--- a/ross/config.py
+++ b/ross/config.py
@@ -1,0 +1,245 @@
+"""Rotordynamic Report Configuration File."""
+
+
+class _Dict:
+    def __init__(self, dictionary):
+        for k, v in dictionary.items():
+            if isinstance(v, dict):
+                setattr(self, k, self.__class__(v))
+            else:
+                setattr(self, k, v)
+
+    def __repr__(self):
+        return repr(self.__dict__)
+
+    def __getitem__(self, option):
+        if option not in self.__dict__.keys():
+            raise KeyError("Option '{}' not found.".format(option))
+
+        return self.__dict__[option]
+
+    def __setitem__(self, **kwargs):
+        for k, v in kwargs.items():
+            if k not in self.__dict__.keys():
+                raise KeyError("Option '{}' not found.".format(k))
+
+            self.__dict__[k] = v
+
+
+class Config:
+    """Configurate parameters for rotordynamic report.
+
+    This class generates an object with several preset parameters to run the
+    rotordynamics analyses. It's a must to check all the options for a correct
+    functioning.
+
+    The attributes are automatically generated and it's not possible to remove then or
+    add new ones.
+
+    Attributes
+    ----------
+    rotor_properties : dict
+        Dictionary of rotor properties.
+
+        rotor_speed : dict
+            Dictionary indicating the operational speeds which will be used in the
+            analyses.
+
+            min_speed : float
+                The machine minimum operational speed.
+            max_speed : float
+                The machine  maximum operational speed.
+            oper_speed : float
+                The machine  nominal operational speed.
+            trip_speed : float
+                The machine overspeed trip.
+            speed_factor : float
+                Multiplicative factor of the speed range - according to API 684.
+            unit : str
+                Unit system to speed values. Options: "rad/s", "rpm"
+
+        rotor_id : dict
+            Dictionary with rotor identifications.
+
+            type : str
+                Machine type: Options are: "compressor", "turbine", "axial_flow". Each
+                options has it's own considerations (according to API 684). If a different
+                option is input, it will be the software will treat as a "compressor".
+            tag : str
+                Tag for the rotor. If None, it'll copy the tag from rotor object.
+
+    bearings : dict
+        The analyses consider different configurations for the bearings. It should be done
+        for minimum, maximum and the nominal clearance.
+
+        oper_clearance : list
+            List of bearing elements. The coefficients should be calculated for the nominal
+            clearance.
+        min_clearance : list
+            List of bearing elements. The coefficients should be calculated for the minimum
+            clearance.
+        max_clearance : list
+            List of bearing elements. The coefficients should be calculated for the maximum
+            clearance.
+
+    run_campbell : dict
+        Dictionary configurating run_campbell parameters.
+
+        speed_range : list, array
+            Array with the speed range.
+        num_modes : float
+            Number of frequencies that will be calculated.
+
+    plot_ucs : dict
+        Dictionary configurating plot_ucs parameters.
+
+        stiffness_range : tuple, optional
+            Tuple with (start, end) for stiffness range.
+        num : int
+            Number of steps in the range.
+            Default is 30.
+        num_modes : int, optional
+            Number of modes to be calculated.
+            Default is 16.
+        synchronous : bool
+            If True a synchronous analysis is carried out and the frequency of
+            the first forward model will be equal to the speed.
+            Default is False.
+
+    run_unbalance_response : dict
+        Dictionary configurating run_unbalance_response parameters.
+
+        frequency_range : list, float
+            Array with the desired range of frequencies. If None and cluster_points is
+            False, it will create an array from the min_speed to max_speed
+            (rotor_propeties config).
+        modes : list, optional
+            Modes that will be used to calculate the frequency response
+            (all modes will be used if a list is not given).
+        cluster_points : bool, optional
+            Boolean to activate the automatic frequency spacing method. If True, the
+            method uses _clustering_points() to create an speed_range.
+            Default is False
+        num_points : int, optional
+            The number of points generated per critical speed.
+            The method set the same number of points for slightly less and slightly
+            higher than the natural circular frequency. It means there'll be num_points
+            greater and num_points smaller than a given critical speed.
+            num_points may be between 2 and 12. Anything above this range defaults
+            to 10 and anything below this range defaults to 4.
+            The default is 10.
+        num_modes
+            The number of eigenvalues and eigenvectors to be calculated using ARPACK.
+            It also defines the range for the output array, since the method generates
+            points only for the critical speed calculated by Rotor.run_critical_speed().
+            Default is 12.
+        rtol : float, optional
+            Tolerance (relative) for termination. Applied to scipy.optimize.newton to
+            calculate the approximated critical speeds.
+            Default is 0.005 (0.5%).
+
+    stability_level1 : dict
+        Dictionary configurating stability_level_1 parameters.
+
+        D : list, array
+            Impeller diameter, m (in.) or Blade pitch diameter, m (in.).
+            The disk elements order must be observed to input this list.
+        H : list, array
+            Minimum diffuser width per impeller, m (in.) or Effective blade height, m (in.).
+            The disk elements order must be observed to input this list.
+        rated_power : list
+            Rated power per stage/impeller, W (HP),
+            The disk elements order must be observed to input this list.
+        rho_ratio : list
+            Density ratio between the discharge gas density and the suction
+            gas density per impeller, kg/m3 (lbm/in.3),
+            The disk elements order must be observed to input this list.
+        rho_suction : float
+            Suction gas density in the first stage, kg/m3 (lbm/in.3).
+        rho_discharge : float
+            Discharge gas density in the last stage, kg/m3 (lbm/in.3),
+        unit: str, optional
+            Unit system. Options are "m" (meter) and "in" (inch)
+            Default is "m"
+
+    Returns
+    -------
+    A config object to rotordynamic report.
+    """
+
+    def __init__(self):
+        # fmt: off
+        # Configurating rotor properties
+        self.rotor_properties = _Dict({
+            "rotor_speeds": {
+                "min_speed": 1000.,
+                "max_speed": 10000.,
+                "oper_speed": 5000.,
+                "trip_speed": 12500.,
+                "speed_factor ": 1.25,
+                "unit": "rpm",
+            },
+            "rotor_id": {
+                "type": "compressor",
+                "tag": None
+            },
+        })
+
+        # Configurating bearing elements for diferent clearances
+        self.bearings = _Dict({
+            "oper_clearance": None,
+            "min_clearance": None,
+            "max_clearance": None,
+        })
+
+        # Configurating campbell options
+        self.run_campbell = _Dict({
+            "speed_range": None,
+            "num_modes": 6,
+        })
+
+        # Configurating UCS options
+        self.plot_ucs = {
+            "stiffness_range": None,
+            "num": 30,
+            "num_modes": 16,
+            "synchronous": False,
+        }
+
+        # Configurating unbalance response options
+        self.run_unbalance_response = _Dict({
+            "frequency_range": None,
+            "modes": None,
+            "cluster_points": False,
+            "num_modes": 12,
+            "num_points": 10,
+            "rtol": 0.005,
+        })
+
+        # Configurating stability level 1 analysis
+        self.stability_level1 = _Dict({
+            "D": None,
+            "H": None,
+            "rated_power": None,
+            "rho_ratio": None,
+            "rho_suction": None,
+            "rho_discharge": None,
+            "unit": "m",
+        })
+        # fmt: on
+
+    def __repr__(self):
+        return repr(self.__dict__)
+
+    def __getitem__(self, option):
+        if option not in self.__dict__.keys():
+            raise KeyError("Option '{}' not found.".format(option))
+
+        return self.__dict__[option]
+
+    def update_config(self, **kwargs):
+        for k, v in kwargs.items():
+            if k not in self.__dict__.keys():
+                raise KeyError("Option '{}' not found.".format(k))
+
+            self.__dict__[k] = v

--- a/ross/config.py
+++ b/ross/config.py
@@ -49,8 +49,8 @@ class _Dict:
         ...     "min_clearance": None,
         ...     "max_clearance": None,
         ... })
-        >>> param
-        {"oper_clearance": None, "min_clearance": None, "max_clearance": None}
+        >>> param # doctest: +ELLIPSIS
+        {"oper_clearance": None, "min_clearance": None, "max_clearance": None}...
         """
         return black.format_file_contents(
             repr(self.__dict__), fast=True, mode=black.FileMode()
@@ -117,8 +117,8 @@ class _Dict:
         ...     "synchronous": False,
         ... })
         >>> param._update(num=20, num_modes=10)
-        >>> param
-        {"stiffness_range": None, "num": 20, "num_modes": 10, "synchronous": False}
+        >>> param # doctest: +ELLIPSIS
+        {"stiffness_range": None, "num": 20, "num_modes": 10, "synchronous": False}...
         """
         for k, v in kwargs.items():
             if k not in self.__dict__.keys():
@@ -280,13 +280,13 @@ class Config:
 
     First syntax opion:
     >>> configs = Config()
-    >>> configs.rotor_properties.rotor_id
-    {"type": "compressor", "tag": None}
+    >>> configs.rotor_properties.rotor_id # doctest: +ELLIPSIS
+    {"type": "compressor", "tag": None}...
 
     Second syntax opion:
     >>> configs = Config()
-    >>> configs["rotor_properties"]["rotor_id"]
-    {"type": "compressor", "tag": None}
+    >>> configs["rotor_properties"]["rotor_id"] # doctest: +ELLIPSIS
+    {"type": "compressor", "tag": None}...
     """
 
     def __init__(self):
@@ -394,8 +394,8 @@ class Config:
         Examples
         --------
         >>> configs = Config()
-        >>> configs["bearings"]
-        {"oper_clearance": None, "min_clearance": None, "max_clearance": None}
+        >>> configs["bearings"] # doctest: +ELLIPSIS
+        {"oper_clearance": None, "min_clearance": None, "max_clearance": None}...
         """
         if option not in self.__dict__.keys():
             raise KeyError("Option '{}' not found.".format(option))
@@ -429,7 +429,7 @@ class Config:
         ...         rotor_id=dict(type="turbine", tag="Model"),
         ...     )
         ... )
-        >>> configs.rotor_properties
+        >>> configs.rotor_properties # doctest: +ELLIPSIS
         {
             "rotor_speeds": {
                 "min_speed": 1000.0,
@@ -440,7 +440,7 @@ class Config:
                 "unit": "rpm",
             },
             "rotor_id": {"type": "turbine", "tag": "Model"},
-        }
+        }...
         """
         for k, v in kwargs.items():
             if k not in self.__dict__.keys():

--- a/ross/config.py
+++ b/ross/config.py
@@ -159,7 +159,7 @@ class Config:
                 The machine overspeed trip.
             speed_factor : float
                 Multiplicative factor of the speed range - according to API 684.
-                Default is 1.25.
+                Default is 1.50.
             unit : str
                 Unit system to speed values. Options: "rad/s", "rpm".
                 Default is "rpm".
@@ -216,10 +216,27 @@ class Config:
     run_unbalance_response : dict
         Dictionary configurating run_unbalance_response parameters.
 
-        frequency_range : list, float
+        probes : dict
+            Dictionary with the node where the probe is set and its respective
+            orientation angle.
+
+            node : list
+                List with the nodes where probes are located.
+            orientation : list
+                List with the respective orientation angle for the probes.
+                0 or π (rad) corresponds to the X orientation and
+                π / 2 or 3 * π / 2 (rad) corresponds to the Y orientation.
+            unit : str
+                Unit system for the orientation angle. Can be "rad" or "degree".
+                Default is "rad".
+
+        frequency_range : list, array
             Array with the desired range of frequencies. If None and cluster_points is
-            False, it will create an array from the min_speed to max_speed
-            (rotor_propeties config).
+            False, it creates an array from 0 to the max continuos speed times the 
+            speed_factor.
+            If None and cluster_points is True, it creates and automatic array based on
+            the number of modes selected.
+            Default is None with cluster_points False.
         modes : list, optional
             Modes that will be used to calculate the frequency response
             (all modes will be used if a list is not given).
@@ -298,7 +315,7 @@ class Config:
                 "max_speed": None,
                 "oper_speed": None,
                 "trip_speed": None,
-                "speed_factor ": 1.25,
+                "speed_factor": 1.50,
                 "unit": "rpm",
             },
             "rotor_id": {
@@ -330,6 +347,11 @@ class Config:
 
         # Configurating unbalance response options
         self.run_unbalance_response = _Dict({
+            "probes": {
+                "node": None,
+                "orientation": None,
+                "unit": "rad",
+            },
             "frequency_range": None,
             "modes": None,
             "cluster_points": False,

--- a/ross/config.py
+++ b/ross/config.py
@@ -232,7 +232,7 @@ class Config:
 
         frequency_range : list, array
             Array with the desired range of frequencies. If None and cluster_points is
-            False, it creates an array from 0 to the max continuos speed times the 
+            False, it creates an array from 0 to the max continuos speed times the
             speed_factor.
             If None and cluster_points is True, it creates and automatic array based on
             the number of modes selected.
@@ -458,7 +458,7 @@ class Config:
                 "max_speed": 10000.0,
                 "oper_speed": None,
                 "trip_speed": None,
-                "speed_factor ": 1.25,
+                "speed_factor": 1.5,
                 "unit": "rpm",
             },
             "rotor_id": {"type": "turbine", "tag": "Model"},

--- a/ross/config.py
+++ b/ross/config.py
@@ -1,4 +1,5 @@
 """Rotordynamic Report Configuration File."""
+import black
 
 
 class _Dict:
@@ -10,7 +11,9 @@ class _Dict:
                 setattr(self, k, v)
 
     def __repr__(self):
-        return repr(self.__dict__)
+        return black.format_file_contents(
+            repr(self.__dict__), fast=True, mode=black.FileMode()
+        )
 
     def __getitem__(self, option):
         if option not in self.__dict__.keys():
@@ -232,7 +235,9 @@ class Config:
         # fmt: on
 
     def __repr__(self):
-        return repr(self.__dict__)
+        return black.format_file_contents(
+            repr(self.__dict__), fast=True, mode=black.FileMode()
+        )
 
     def __getitem__(self, option):
         if option not in self.__dict__.keys():

--- a/ross/config.py
+++ b/ross/config.py
@@ -18,12 +18,15 @@ class _Dict:
 
         return self.__dict__[option]
 
-    def __setitem__(self, **kwargs):
+    def update(self, **kwargs):
         for k, v in kwargs.items():
             if k not in self.__dict__.keys():
                 raise KeyError("Option '{}' not found.".format(k))
 
-            self.__dict__[k] = v
+            if isinstance(v, dict):
+                getattr(self, k).update(**v)
+            else:
+                self.__dict__[k] = v
 
 
 class Config:
@@ -241,5 +244,5 @@ class Config:
         for k, v in kwargs.items():
             if k not in self.__dict__.keys():
                 raise KeyError("Option '{}' not found.".format(k))
-
-            self.__dict__[k] = v
+            else:
+                getattr(self, k).update(**v)


### PR DESCRIPTION
- Class "Config" generates an object with several preset parameters to run the rotordynamics analyses. It's a must to check all the options for a correct functioning. The attributes are automatically generated and it's not possible to remove then or add new ones.
- Class "_Dict" is a subclass used to organize nested dictionaries and set each key / value as attribute for the config object.

@raphaeltimbo and @GabrielBachmann I'd like to ask for some ideas for this file. I'm trying to follow a dictionary rule, just like Plotly does, but I couldn't find a pythonic way of how to update the config options. For now the user should change one by one, and it would be exhaustive. 
I'd like to introduce a way for the user input several options at the same time, like we do with Plotly. I've been taking a closer look on Plotly's code, but it seems too complex for what we need to do here.

Here is an example of how we could use `Config`:

```python
>>> options = Config()

# If we want to check the options, we just do:
>>> options
{'rotor_properties': {'rotor_speeds': {'min_speed': 1000.0, 'max_speed': 10000.0, 'oper_speed': 5000.0,
 'trip_speed': 12500.0, 'speed_factor ': 1.25, 'unit': 'rpm'}, 'rotor_id': {'type': 'compressor', 'tag': None}},
 'bearings': {'oper_clearance': None, 'min_clearance': None, 'max_clearance': None}, 'run_campbell': {'speed_range': None,
 'num_modes': 6}, 'plot_ucs': {'stiffness_range': None, 'num': 30, 'num_modes': 16, 'synchronous': False},
 'run_unbalance_response': {'frequency_range': None, 'modes': None, 'cluster_points': False, 'num_modes': 12, 'num_points': 10,
 'rtol': 0.005}, 'stability_level1': {'D': None, 'H': None, 'rated_power': None, 'rho_ratio': None, 'rho_suction': None,
 'rho_discharge': None, 'unit': 'm'}}

# I still need to work on a better repr or str method to display the options for the user

>>> # Displaying the options attributes. The dictionary syntax
>>> options["rotor_properties"]["rotor_id"]
{'type': 'compressor', 'tag': None}

>>> # Displaying the options attributes. The attribute syntax works too
>>> options.rotor_properties.rotor_id
{'type': 'compressor', 'tag': None}

>>> # Changing an option. This is the only syntax acceptable at this moment.
>>> options.rotor_properties.rotor_id.type = "turbine"
>>> options["rotor_properties"]["rotor_id"]
{'type': 'turbine', 'tag': None}

>>> # It's not possible to use the dictionary syntax so far:
>>> options["rotor_properties"]["rotor_id"]["type"] = "turbine" 
Traceback (most recent call last):

  File "<ipython-input-234-1d8cae20ceb8>", line 1, in <module>
    c["rotor_properties"]["rotor_id"]["type"] = "turbine"

TypeError: __setitem__() takes 1 positional argument but 3 were given
```

I wanted to add a `update_config` method to replace the `__setitem__` magic method.