### PR TITLE
Change tempfile to be crossplatform

### DIFF
--- a/ross/element.py
+++ b/ross/element.py
@@ -33,9 +33,13 @@ class Element(ABC):
         Examples
         --------
         >>> # Example using DiskElement
+        >>> from tempfile import tempdir
+        >>> from pathlib import Path
         >>> from ross.disk_element import disk_example
+        >>> # create path for a temporary file 
+        >>> file = Path(tempdir) / 'disk.toml'
         >>> disk = disk_example()
-        >>> disk.save('/tmp/disk.toml')
+        >>> disk.save(file)
         """
         # get __init__ arguments
         signature = inspect.signature(self.__init__)
@@ -69,11 +73,15 @@ class Element(ABC):
         Examples
         --------
         >>> # Example using BearingElement
+        >>> from tempfile import tempdir
+        >>> from pathlib import Path
         >>> from ross.bearing_seal_element import bearing_example
         >>> from ross.bearing_seal_element import BearingElement
+        >>> # create path for a temporary file 
+        >>> file = Path(tempdir) / 'bearing1.toml'
         >>> bearing1 = bearing_example()
-        >>> bearing1.save('/tmp/bearing1.toml')
-        >>> bearing1_loaded = BearingElement.load('/tmp/bearing1.toml')
+        >>> bearing1.save(file)
+        >>> bearing1_loaded = BearingElement.load(file)
         >>> bearing1 == bearing1_loaded
         True
         """

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2289,8 +2289,12 @@ class Rotor(object):
 
         Examples
         --------
+        >>> from tempfile import tempdir
+        >>> from pathlib import Path
+        >>> # create path for temporary file
+        >>> file = Path(tempdir) / 'new_matrices'
         >>> rotor = rotor_example()
-        >>> rotor.save_mat('/tmp/new_matrices', speed=0)
+        >>> rotor.save_mat(file, speed=0)
         """
         if frequency is None:
             frequency = speed
@@ -2314,8 +2318,12 @@ class Rotor(object):
 
         Examples
         --------
+        >>> from tempfile import tempdir
+        >>> from pathlib import Path
+        >>> # create path for temporary file
+        >>> file = Path(tempdir) / 'rotor.toml'
         >>> rotor = rotor_example()
-        >>> rotor.save('/tmp/rotor.toml')
+        >>> rotor.save(file)
         """
         with open(file, "w") as f:
             toml.dump({"parameters": self.parameters}, f)
@@ -2337,9 +2345,13 @@ class Rotor(object):
 
         Example
         -------
+        >>> from tempfile import tempdir
+        >>> from pathlib import Path
+        >>> # create path for temporary file
+        >>> file = Path(tempdir) / 'new_rotor1.toml'
         >>> rotor1 = rotor_example()
-        >>> rotor1.save('/tmp/new_rotor1.toml')
-        >>> rotor2 = Rotor.load('/tmp/new_rotor1.toml')
+        >>> rotor1.save(file)
+        >>> rotor2 = Rotor.load(file)
         >>> rotor1 == rotor2
         True
         """

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -1,5 +1,7 @@
 # fmt: off
 import os
+from pathlib import Path
+from tempfile import tempdir
 
 import numpy as np
 import pytest
@@ -336,14 +338,17 @@ def test_bearing_6dof_equality():
 
 
 def test_save_load(bearing0, bearing_constant, bearing_6dof):
-    bearing0.save("/tmp/bearing0.toml")
-    bearing0_loaded = BearingElement.load("/tmp/bearing0.toml")
+    file = Path(tempdir) / "bearing0.toml"
+    bearing0.save(file)
+    bearing0_loaded = BearingElement.load(file)
     assert bearing0 == bearing0_loaded
 
-    bearing_constant.save("/tmp/bearing_constant.toml")
-    bearing_constant_loaded = BearingElement.load("/tmp/bearing_constant.toml")
+    file = Path(tempdir) / "bearing_constant.toml"
+    bearing_constant.save(file)
+    bearing_constant_loaded = BearingElement.load(file)
     assert bearing_constant == bearing_constant_loaded
 
-    bearing_6dof.save("/tmp/bearing_6dof.toml")
-    bearing_6dof_loaded = BearingElement6DoF.load("/tmp/bearing_6dof.toml")
+    file = Path(tempdir) / "bearing_6dof.toml"
+    bearing_6dof.save(file)
+    bearing_6dof_loaded = BearingElement6DoF.load(file)
     assert bearing_6dof == bearing_6dof_loaded

--- a/ross/tests/test_disk_element.py
+++ b/ross/tests/test_disk_element.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+from tempfile import tempdir
 
 import numpy as np
 import pytest
@@ -48,8 +50,9 @@ def disk_from_geometry():
 
 
 def test_save_load(disk, disk_from_geometry):
-    disk.save("/tmp/disk.toml")
-    disk_loaded = DiskElement.load("/tmp/disk.toml")
+    file = Path(tempdir) / "disk.toml"
+    disk.save(file)
+    disk_loaded = DiskElement.load(file)
     assert disk == disk_loaded
 
 

--- a/ross/tests/test_point_mass.py
+++ b/ross/tests/test_point_mass.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from tempfile import tempdir
+
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -31,7 +34,8 @@ def test_local_index():
 
 def test_save_load():
     p = PointMass(n=0, m=10.0, tag="pointmass")
-    p.save("/tmp/point_mass.toml")
-    p_loaded = p.load("/tmp/point_mass.toml")
+    file = Path(tempdir) / "point_mass.toml"
+    p.save(file)
+    p_loaded = p.load(file)
 
     assert p == p_loaded

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from tempfile import tempdir
 
 import numpy as np
 import pytest
@@ -1769,7 +1770,8 @@ def test_ucs_calc(rotor8):
 
 
 def test_save_load(rotor8):
-    rotor8.save("/tmp/rotor8.toml")
-    rotor8_loaded = Rotor.load("/tmp/rotor8.toml")
+    file = Path(tempdir) / "rotor8.toml"
+    rotor8.save(file)
+    rotor8_loaded = Rotor.load(file)
 
     rotor8 == rotor8_loaded

--- a/ross/tests/test_shaft_element.py
+++ b/ross/tests/test_shaft_element.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+from tempfile import tempdir
 
 import numpy as np
 import pytest
@@ -6,8 +8,6 @@ from numpy.testing import assert_allclose, assert_almost_equal
 
 from ross.materials import steel
 from ross.shaft_element import ShaftElement, ShaftElement6DoF
-
-test_dir = os.path.dirname(__file__)
 
 
 @pytest.fixture
@@ -309,11 +309,14 @@ def test_match_gyroscopic_matrix(tap2, tim2):
 
 
 def test_save_load(tim, tap_tim):
-    tim.save("/tmp/tim.toml")
-    tim_loaded = ShaftElement.load("/tmp/tim.toml")
+    file = Path(tempdir) / "tim.toml"
+    tim.save(file)
+    tim_loaded = ShaftElement.load(file)
     assert tim == tim_loaded
-    tap_tim.save("/tmp/tap_tim.toml")
-    tap_tim_loaded = ShaftElement.load("/tmp/tap_tim.toml")
+
+    file = Path(tempdir) / "tap_tim.toml"
+    tap_tim.save(file)
+    tap_tim_loaded = ShaftElement.load(file)
     assert tap_tim == tap_tim_loaded
 
 


### PR DESCRIPTION
The approach used before ('/tmp/file') would work only on unix systems
since this path does not exist on windows.
Now the tempdir is obtained using the tempfile module.

Closes #590.