### PR TITLE
Add frequency 0 to automatic frequency range

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1040,7 +1040,7 @@ class Rotor(object):
         >>> rotor = rotor_example()
         >>> speed_range = rotor._clustering_points(num_modes=12, num_points=5)
         >>> speed_range.shape
-        (60,)
+        (61,)
         """
         critical_speeds = self.run_critical_speed(num_modes=num_modes, rtol=rtol)
         omega = critical_speeds.wd
@@ -1064,6 +1064,7 @@ class Rotor(object):
 
         omega = omega.reshape((len(omega), 1))
         speed_range = np.sort(np.ravel(np.concatenate((omega / a, omega * a))))
+        speed_range = np.insert(speed_range, 0, 0)
 
         return speed_range
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1351,7 +1351,7 @@ class Rotor(object):
 
         >>> response = rotor.run_freq_response(cluster_points=True, num_points=5)
         >>> response.speed_range.shape
-        (60,)
+        (61,)
 
         # plot frequency response function:
         >>> fig = response.plot(inp=13, out=13)
@@ -1466,7 +1466,7 @@ class Rotor(object):
         ...     force=force, cluster_points=True, num_modes=12, num_points=5
         ... )
         >>> response.speed_range.shape
-        (60,)
+        (61,)
         """
         if speed_range is None:
             if cluster_points:
@@ -1631,7 +1631,7 @@ class Rotor(object):
         ...     node=3, magnitude=0.01, phase=0.0, cluster_points=True, num_points=5
         ... )
         >>> response2.speed_range.shape
-        (60,)
+        (61,)
 
         plot unbalance response:
         >>> fig = response.plot(dof=13)


### PR DESCRIPTION
The output array from `_clustering_points()` now evaluates the results at frequency equals 0.
It will allow a better graphical visualization for the response.