### PR TITLE
Set default values to log_dec color scale

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -733,10 +733,18 @@ class CampbellResults:
         log_dec = self.log_dec
         whirl = self.whirl_values
         speed_range = self.speed_range
-        log_dec_map = log_dec.flatten()
 
         if fig is None:
             fig = go.Figure()
+
+        default_values = dict(
+            coloraxis_cmin=0.0,
+            coloraxis_cmax=1.0,
+            coloraxis_colorscale="rdbu",
+            coloraxis_colorbar=dict(title=dict(text="<b>Log Dec</b>", side="right")),
+        )
+        for k, v in default_values.items():
+            kwargs.setdefault(k, v)
 
         scatter_marker = ["triangle-up", "circle", "triangle-down"]
         for mark, whirl_dir, legend in zip(
@@ -795,11 +803,8 @@ class CampbellResults:
                             y=w_i[whirl_mask],
                             marker=dict(
                                 symbol=mark,
-                                cmax=max(log_dec_map),
-                                cmin=min(log_dec_map),
                                 color=log_dec_i[whirl_mask],
                                 coloraxis="coloraxis",
-                                colorscale="rdbu",
                             ),
                             mode="markers",
                             name=legend,
@@ -838,17 +843,14 @@ class CampbellResults:
         fig.update_xaxes(
             title_text="<b>Frequency</b>",
             range=[np.min(speed_range), np.max(speed_range)],
+            exponentformat="none",
         )
         fig.update_yaxes(
-            title_text="<b>Damped Natural Frequencies</b>", range=[0, 1.1 * np.max(wd)]
+            title_text="<b>Damped Natural Frequencies</b>",
+            range=[0, 1.1 * np.max(wd)],
+            exponentformat="none",
         )
         fig.update_layout(
-            coloraxis=dict(
-                cmin=min(log_dec_map),
-                cmax=max(log_dec_map),
-                colorscale="rdbu",
-                colorbar=dict(title=dict(text="<b>Log Dec</b>", side="right")),
-            ),
             legend=dict(
                 itemsizing="constant",
                 orientation="h",


### PR DESCRIPTION
The color scale to represent the log_dec values ranges between 0 and 1, independently of the log_dec values calculated.
It can be manually modified by insert 2 simple kwargs: coloraxis_cmin and coloraxis_cmax. It will change
respectively the minimum and maximum values for the color scale.
Also adds exponentformat = "none" to X and Y axis for better visualization of values

Example with default options: 
```python
>>> speed_range = np.linspace(0, 3000, 51)
>>> campbell = rotor.run_campbell(speed_range)
>>> campbell.plot(harmonics=[0.5, 1])
```
![image](https://user-images.githubusercontent.com/45969994/87157591-def88a00-c294-11ea-9f26-8807122feb08.png)

Example changing the max value for the scale: 
```python
>>> speed_range = np.linspace(0, 3000, 51)
>>> campbell = rotor.run_campbell(speed_range)
>>> campbell.plot(harmonics=[0.5, 1], coloraxis_cmax=2.0)
```
![image](https://user-images.githubusercontent.com/45969994/87157716-06e7ed80-c295-11ea-9eff-89e5a2c6164c.png)
