### PR TITLE
Add units to plot functions

### DIFF
--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -296,10 +296,10 @@ class DiskElement(Element):
 
         customdata = [self.n, self.Ip, self.Id, self.m]
         hovertemplate = (
-            f"<b>Disk Node: {customdata[0]}<b><br>"
-            + f"<b>Polar Inertia: {customdata[1]:.3e}<b><br>"
-            + f"<b>Diametral Inertia: {customdata[2]:.3e}<b><br>"
-            + f"<b>Disk mass: {customdata[3]:.3f}<b><br>"
+            f"Disk Node: {customdata[0]}<br>"
+            + f"Polar Inertia: {customdata[1]:.3e}<br>"
+            + f"Diametral Inertia: {customdata[2]:.3e}<br>"
+            + f"Disk mass: {customdata[3]:.3f}<br>"
         )
 
         fig.add_trace(

--- a/ross/new_units.txt
+++ b/ross/new_units.txt
@@ -1,2 +1,3 @@
 RPM = rpm * 1
+Hz = rps
 hour = 60 * minute = h = hr

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -249,9 +249,9 @@ class PointMass(Element):
 
         customdata = [self.n, self.mx, self.my]
         hovertemplate = (
-            f"<b>PointMass Node: {customdata[0]}<b><br>"
-            + f"<b>Mass (X): {customdata[1]:.3f}<b><br>"
-            + f"<b>Mass (Y): {customdata[2]:.3f}<b><br>"
+            f"PointMass Node: {customdata[0]}<br>"
+            + f"Mass (X): {customdata[1]:.3f}<br>"
+            + f"Mass (Y): {customdata[2]:.3f}<br>"
         )
 
         fig.add_trace(

--- a/ross/results.py
+++ b/ross/results.py
@@ -2136,7 +2136,9 @@ class StaticResults:
         self.nodes_pos = nodes_pos
         self.Vx_axis = Vx_axis
 
-    def plot_deformation(self, fig=None, **kwargs):
+    def plot_deformation(
+        self, deformation_units="m", shaft_length_units="m", fig=None, **kwargs
+    ):
         """Plot the shaft static deformation.
 
         This method plots:
@@ -2144,6 +2146,12 @@ class StaticResults:
 
         Parameters
         ----------
+        deformation_units : str
+            Deformation units.
+            Default is 'm'.
+        shaft_length_units : str
+            Deformation units.
+            Default is 'm'.
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         kwargs : optional
@@ -2160,6 +2168,7 @@ class StaticResults:
             fig = go.Figure()
 
         shaft_end = max([sublist[-1] for sublist in self.nodes_pos])
+        shaft_end = Q_(shaft_end, "m").to(shaft_length_units).m
 
         # fig - plot centerline
         fig.add_trace(
@@ -2182,7 +2191,8 @@ class StaticResults:
                 nodes_pos[0], nodes_pos[-1], num=len(nodes_pos) * 20, endpoint=True
             )
 
-            ynew = interpolated(xnew)
+            ynew = Q_(interpolated(xnew), "m").to(deformation_units)
+            xnew = Q_(xnew, "m").to(deformation_units)
 
             fig.add_trace(
                 go.Scatter(
@@ -2192,14 +2202,14 @@ class StaticResults:
                     name=f"Shaft {count}",
                     showlegend=True,
                     hovertemplate=(
-                        "Shaft lengh: %{x:.2f}<br>" + "Displacement: %{y:.2e}"
+                        f"Shaft length ({shaft_length_units}): %{{x:.2f}}<br> Displacement ({deformation_units}): %{{y:.2e}}"
                     ),
                 )
             )
             count += 1
 
-        fig.update_xaxes(title_text="<b>Shaft Length</b>")
-        fig.update_yaxes(title_text="<b>Deformation</b>")
+        fig.update_xaxes(title_text=f"<b>Shaft Length ({shaft_length_units})</b>")
+        fig.update_yaxes(title_text=f"<b>Deformation ({deformation_units})</b>")
         fig.update_layout(title=dict(text="<b>Static Deformation</b>"), **kwargs)
 
         return fig

--- a/ross/results.py
+++ b/ross/results.py
@@ -902,7 +902,9 @@ class FrequencyResponseResults:
         self.magnitude = magnitude
         self.phase = phase
 
-    def plot_magnitude(self, inp, out, units="mic-pk-pk", fig=None, **mag_kwargs):
+    def plot_magnitude(
+        self, inp, out, x_units="rad/s", y_units="m/N", fig=None, **mag_kwargs
+    ):
         """Plot frequency response (magnitude) using Plotly.
 
         This method plots the frequency response magnitude given an output and
@@ -914,9 +916,12 @@ class FrequencyResponseResults:
             Input.
         out : int
             Output.
-        units : str
-            Unit system
-            Default is "mic-pk-pk"
+        x_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        y_units : str, optional
+            Units for the y axis.
+            Default is "m/N"
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         mag_kwargs : optional
@@ -932,12 +937,8 @@ class FrequencyResponseResults:
         frequency_range = self.speed_range
         mag = self.magnitude
 
-        if units == "m":
-            y_axis_label = "<b>Amplitude (m)</b>"
-        elif units == "mic-pk-pk":
-            y_axis_label = "<b>Amplitude (μ pk-pk)</b>"
-        else:
-            y_axis_label = "<b>Amplitude (dB)</b>"
+        frequency_range = Q_(frequency_range, "rad/s").to(x_units).m
+        mag = Q_(mag, "m/N").to(y_units).m
 
         if fig is None:
             fig = go.Figure()
@@ -951,20 +952,20 @@ class FrequencyResponseResults:
                 name="Amplitude",
                 legendgroup="Amplitude",
                 showlegend=False,
-                hovertemplate=("Frequency: %{x:.2f}<br>" + "Amplitude: %{y:.2e}"),
+                hovertemplate=f"Frequency ({x_units}): %{{x:.2f}}<br>Amplitude ({y_units}): %{{y:.2e}}",
             )
         )
 
         fig.update_xaxes(
-            title_text="<b>Frequency</b>",
+            title_text=f"<b>Frequency ({x_units})</b>",
             range=[np.min(frequency_range), np.max(frequency_range)],
         )
-        fig.update_yaxes(title_text=y_axis_label)
+        fig.update_yaxes(title_text=f"<b>Amplitude ({y_units})</b>")
         fig.update_layout(**mag_kwargs)
 
         return fig
 
-    def plot_phase(self, inp, out, fig=None, **phase_kwargs):
+    def plot_phase(self, inp, out, x_units="rad/s", fig=None, **phase_kwargs):
         """Plot frequency response (phase) using Plotly.
 
         This method plots the frequency response phase given an output and
@@ -976,6 +977,9 @@ class FrequencyResponseResults:
             Input.
         out : int
             Output.
+        x_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         phase_kwargs : optional
@@ -991,6 +995,8 @@ class FrequencyResponseResults:
         frequency_range = self.speed_range
         phase = self.phase
 
+        frequency_range = Q_(frequency_range, "rad/s").to(x_units)
+
         if fig is None:
             fig = go.Figure()
 
@@ -1003,12 +1009,12 @@ class FrequencyResponseResults:
                 name="Phase",
                 legendgroup="Phase",
                 showlegend=False,
-                hovertemplate=("Frequency: %{x:.2f}<br>" + "Phase: %{y:.2f}"),
+                hovertemplate=f"Frequency ({x_units}): %{{x:.2f}}<br>Phase: %{{y:.2e}}",
             )
         )
 
         fig.update_xaxes(
-            title_text="<b>Frequency</b>",
+            title_text=f"<b>Frequency ({x_units})</b>",
             range=[np.min(frequency_range), np.max(frequency_range)],
         )
         fig.update_yaxes(title_text="<b>Phase</b>")
@@ -1016,7 +1022,9 @@ class FrequencyResponseResults:
 
         return fig
 
-    def plot_polar_bode(self, inp, out, units="mic-pk-pk", fig=None, **polar_kwargs):
+    def plot_polar_bode(
+        self, inp, out, x_units="rad/s", y_units="m/N", fig=None, **polar_kwargs
+    ):
         """Plot frequency response (polar) using Plotly.
 
         This method plots the frequency response (polar graph) given an output and
@@ -1028,9 +1036,12 @@ class FrequencyResponseResults:
             Input.
         out : int
             Output.
-        units : str
-            Magnitude unit system.
-            Default is "mic-pk-pk"
+        x_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        y_units : str, optional
+            Units for the y axis.
+            Default is "m/N"
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         polar_kwargs : optional
@@ -1047,12 +1058,8 @@ class FrequencyResponseResults:
         mag = self.magnitude
         phase = self.phase
 
-        if units == "m":
-            r_axis_label = "<b>Amplitude (m)</b>"
-        elif units == "mic-pk-pk":
-            r_axis_label = "<b>Amplitude (μ pk-pk)</b>"
-        else:
-            r_axis_label = "<b>Amplitude (dB)</b>"
+        frequency_range = Q_(frequency_range, "rad/s").to(x_units)
+        mag = Q_(mag, "m/N").to(y_units)
 
         if fig is None:
             fig = go.Figure()
@@ -1069,17 +1076,15 @@ class FrequencyResponseResults:
                 name="Polar_plot",
                 legendgroup="Polar",
                 showlegend=False,
-                hovertemplate=(
-                    "<b>Amplitude: %{r:.2e}</b><br>"
-                    + "<b>Phase: %{theta:.2f}</b><br>"
-                    + "<b>Frequency: %{customdata:.2f}</b>"
-                ),
+                hovertemplate=f"Amplitude ({y_units}): %{{r:.2e}}<br>Phase: %{{theta:.2f}}<br>Frequency ({x_units}): %{{customdata:.2f}}",
             )
         )
 
         fig.update_layout(
             polar=dict(
-                radialaxis=dict(title=dict(text=r_axis_label), exponentformat="power")
+                radialaxis=dict(
+                    title=dict(text=f"Amplitude ({y_units})"), exponentformat="power"
+                )
             ),
             **polar_kwargs,
         )
@@ -1090,7 +1095,8 @@ class FrequencyResponseResults:
         self,
         inp,
         out,
-        units="mic-pk-pk",
+        x_units="rad/s",
+        y_units="m/N",
         mag_kwargs=None,
         phase_kwargs=None,
         polar_kwargs=None,
@@ -1112,13 +1118,12 @@ class FrequencyResponseResults:
             Input.
         out : int
             Output.
-        units : str, optional
-            Magnitude unit system.
-            Options:
-                - "m" : meters
-                - "mic-pk-pk" : microns peak to peak
-                - "db" : decibels
-            Default is "mic-pk-pk".
+        x_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        y_units : str, optional
+            Units for the y axis.
+            Default is "m/N"
         mag_kwargs : optional
             Additional key word arguments can be passed to change the magnitude plot
             layout only (e.g. width=1000, height=800, ...).
@@ -1148,9 +1153,9 @@ class FrequencyResponseResults:
         polar_kwargs = {} if polar_kwargs is None else copy.copy(polar_kwargs)
         subplot_kwargs = {} if subplot_kwargs is None else copy.copy(subplot_kwargs)
 
-        fig0 = self.plot_magnitude(inp, out, units, **mag_kwargs)
-        fig1 = self.plot_phase(inp, out, **phase_kwargs)
-        fig2 = self.plot_polar_bode(inp, out, units, **polar_kwargs)
+        fig0 = self.plot_magnitude(inp, out, x_units, y_units, **mag_kwargs)
+        fig1 = self.plot_phase(inp, out, x_units, **phase_kwargs)
+        fig2 = self.plot_polar_bode(inp, out, x_units, y_units, **polar_kwargs)
 
         subplots = make_subplots(
             rows=2, cols=2, specs=[[{}, {"type": "polar", "rowspan": 2}], [{}, None]]

--- a/ross/results.py
+++ b/ross/results.py
@@ -1888,7 +1888,9 @@ class ForcedResponseResults:
 
         return fig
 
-    def plot_bending_moment(self, speed, moment_units="N*m", fig=None, **kwargs):
+    def plot_bending_moment(
+        self, speed, moment_units="N*m", shaft_length_units="m", fig=None, **kwargs
+    ):
         """Plot the bending moment diagram.
 
         Parameters
@@ -1899,6 +1901,9 @@ class ForcedResponseResults:
         moment_units : str, optional
             Moment units.
             Default is 'N*m'.
+        shaft_length_units : str
+            Shaft length units.
+            Default is m.
         kwargs : optional
             Additional key word arguments can be passed to change the deflected shape
             plot layout only (e.g. width=1000, height=800, ...).
@@ -1917,7 +1922,7 @@ class ForcedResponseResults:
         My = Q_(My, "N*m").to(moment_units).m
         Mr = np.sqrt(Mx ** 2 + My ** 2)
 
-        nodes_pos = self.rotor.nodes_pos
+        nodes_pos = Q_(self.rotor.nodes_pos, "m").to(shaft_length_units).m
 
         if fig is None:
             fig = go.Figure()
@@ -1967,7 +1972,7 @@ class ForcedResponseResults:
             )
         )
 
-        fig.update_xaxes(title_text="Rotor Length")
+        fig.update_xaxes(title_text=f"Rotor Length ({shaft_length_units})")
         fig.update_yaxes(title_text=f"Bending Moment ({moment_units})")
         fig.update_layout(**kwargs)
 
@@ -2372,7 +2377,9 @@ class StaticResults:
 
         return fig
 
-    def plot_shearing_force(self, fig=None, **kwargs):
+    def plot_shearing_force(
+        self, force_units="N", shaft_length_units="m", fig=None, **kwargs
+    ):
         """Plot the rotor shearing force diagram.
 
         This method plots:
@@ -2380,6 +2387,12 @@ class StaticResults:
 
         Parameters
         ----------
+        force_units : str
+            Force units.
+            Default is 'N'.
+        shaft_length_units : str
+            Shaft length units.
+            Default is 'm'.
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         kwargs : optional
@@ -2395,7 +2408,11 @@ class StaticResults:
         if fig is None:
             fig = go.Figure()
 
-        shaft_end = max([sublist[-1] for sublist in self.nodes_pos])
+        shaft_end = (
+            Q_(max([sublist[-1] for sublist in self.nodes_pos]), "m")
+            .to(shaft_length_units)
+            .m
+        )
 
         # fig - plot centerline
         fig.add_trace(
@@ -2413,28 +2430,31 @@ class StaticResults:
         for Vx, Vx_axis in zip(self.Vx, self.Vx_axis):
             fig.add_trace(
                 go.Scatter(
-                    x=Vx_axis,
-                    y=Vx,
+                    x=Q_(Vx_axis, "m").to(shaft_length_units).m,
+                    y=Q_(Vx, "N").to(force_units).m,
                     mode="lines",
                     name=f"Shaft {j}",
                     legendgroup=f"Shaft {j}",
                     showlegend=True,
                     hovertemplate=(
-                        "Shaft lengh: %{x:.2f}<br>" + "Shearing Force: %{y:.2f}"
+                        f"Shaft length ({shaft_length_units}): %{{x:.2f}}<br>Shearing Force ({force_units}): %{{y:.2f}}"
                     ),
                 )
             )
             j += 1
 
         fig.update_xaxes(
-            title_text="Shaft Length", range=[-0.1 * shaft_end, 1.1 * shaft_end]
+            title_text=f"Shaft Length ({shaft_length_units})",
+            range=[-0.1 * shaft_end, 1.1 * shaft_end],
         )
-        fig.update_yaxes(title_text="Force")
+        fig.update_yaxes(title_text=f"Force ({force_units})")
         fig.update_layout(title=dict(text="Shearing Force Diagram"), **kwargs)
 
         return fig
 
-    def plot_bending_moment(self, fig=None, **kwargs):
+    def plot_bending_moment(
+        self, moment_units="N*m", shaft_length_units="m", fig=None, **kwargs
+    ):
         """Plot the rotor bending moment diagram.
 
         This method plots:
@@ -2442,6 +2462,12 @@ class StaticResults:
 
         Parameters
         ----------
+        moment_units : str, optional
+            Moment units.
+            Default is 'N*m'.
+        shaft_length_units : str
+            Shaft length units.
+            Default is 'm'.
         fig : Plotly graph_objects.Figure()
             Plotly figure with the bending moment diagram plot
 
@@ -2453,7 +2479,11 @@ class StaticResults:
         if fig is None:
             fig = go.Figure()
 
-        shaft_end = max([sublist[-1] for sublist in self.nodes_pos])
+        shaft_end = (
+            Q_(max([sublist[-1] for sublist in self.nodes_pos]), "m")
+            .to(shaft_length_units)
+            .m
+        )
 
         # fig - plot centerline
         fig.add_trace(
@@ -2471,21 +2501,21 @@ class StaticResults:
         for Bm, nodes_pos in zip(self.Bm, self.Vx_axis):
             fig.add_trace(
                 go.Scatter(
-                    x=nodes_pos,
-                    y=Bm,
+                    x=Q_(nodes_pos, "m").to(shaft_length_units).m,
+                    y=Q_(Bm, "N*m").to(moment_units).m,
                     mode="lines",
                     name=f"Shaft {j}",
                     legendgroup=f"Shaft {j}",
                     showlegend=True,
                     hovertemplate=(
-                        "Shaft lengh: %{x:.2f}<br>" + "Bending Moment: %{y:.2f}"
+                        f"Shaft length ({shaft_length_units}): %{{x:.2f}}<br>Bending Moment ({moment_units}): %{{y:.2f}}"
                     ),
                 )
             )
             j += 1
 
-        fig.update_xaxes(title_text="Shaft Length")
-        fig.update_yaxes(title_text="Bending Moment")
+        fig.update_xaxes(title_text=f"Shaft Length ({shaft_length_units})")
+        fig.update_yaxes(title_text=f"Bending Moment ({moment_units})")
         fig.update_layout(title=dict(text="Bending Moment Diagram"), **kwargs)
 
         return fig

--- a/ross/results.py
+++ b/ross/results.py
@@ -719,7 +719,7 @@ class CampbellResults:
         self.log_dec = log_dec
         self.whirl_values = whirl_values
 
-    def plot(self, harmonics=[1], fig=None, **kwargs):
+    def plot(self, harmonics=[1], frequency_units="rad/s", fig=None, **kwargs):
         """Create Campbell Diagram figure using Plotly.
 
         Parameters
@@ -727,6 +727,9 @@ class CampbellResults:
         harmonics: list, optional
             List withe the harmonics to be plotted.
             The default is to plot 1x.
+        frequency_units : str, optional
+            Frequency units.
+            Default is "rad/s"
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         kwargs : optional
@@ -739,11 +742,11 @@ class CampbellResults:
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
-        wd = self.wd
+        wd = Q_(self.wd, "rad/s").to(frequency_units).m
         num_frequencies = wd.shape[1]
         log_dec = self.log_dec
         whirl = self.whirl_values
-        speed_range = self.speed_range
+        speed_range = Q_(self.speed_range, "rad/s").to(frequency_units).m
         log_dec_map = log_dec.flatten()
 
         if fig is None:
@@ -790,8 +793,7 @@ class CampbellResults:
                                 legendgroup="Crit. Speed",
                                 showlegend=False,
                                 hovertemplate=(
-                                    "Frequency: %{x:.2f}<br>"
-                                    + "Critical Speed: %{y:.2f}"
+                                    f"Frequency ({frequency_units}): %{{x:.2f}}<br> Critical Speed ({frequency_units}): %{{y:.2f}}"
                                 ),
                             )
                         )
@@ -847,11 +849,12 @@ class CampbellResults:
             )
 
         fig.update_xaxes(
-            title_text="<b>Frequency</b>",
+            title_text=f"<b>Frequency ({frequency_units})</b>",
             range=[np.min(speed_range), np.max(speed_range)],
         )
         fig.update_yaxes(
-            title_text="<b>Damped Natural Frequencies</b>", range=[0, 1.1 * np.max(wd)]
+            title_text=f"<b>Natural Frequencies ({frequency_units})</b>",
+            range=[0, 1.1 * np.max(wd)],
         )
         fig.update_layout(
             coloraxis=dict(
@@ -1492,13 +1495,13 @@ class ForcedResponseResults:
         dof : int
             Degree of freedom.
         frequency_units : str, optional
-            Units for the x axis.
+            Frequency units.
             Default is "rad/s"
         amplitude_units : str, optional
-            Units for the y axis.
+            Amplitude units.
             Default is "m/N"
         phase_units : str, optional
-            Units for the x axis.
+            Phase units.
             Default is "rad"
         mag_kwargs : optional
             Additional key word arguments can be passed to change the magnitude plot

--- a/ross/results.py
+++ b/ross/results.py
@@ -1795,9 +1795,7 @@ class ForcedResponseResults:
                     legendgroup="Orbit",
                     showlegend=False,
                     hovertemplate=(
-                        "Nodal Position: %{x:.2f}<br>"
-                        + "X - Amplitude: %{y:.2e}<br>"
-                        + "Y - Amplitude: %{z:.2e}"
+                        f"Position ({displacement_units}): %{{x:.2f}}<br>X - Amplitude ({displacement_units}): %{{y:.2e}}<br>Y - Amplitude ({displacement_units}): %{{z:.2e}}"
                     ),
                 )
             )

--- a/ross/results.py
+++ b/ross/results.py
@@ -2139,7 +2139,7 @@ class StaticResults:
             Deformation units.
             Default is 'm'.
         shaft_length_units : str
-            Deformation units.
+            Shaft length units.
             Default is 'm'.
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
@@ -2203,11 +2203,19 @@ class StaticResults:
 
         return fig
 
-    def plot_free_body_diagram(self, fig=None, **kwargs):
+    def plot_free_body_diagram(
+        self, force_units="N", shaft_length_units="m", fig=None, **kwargs
+    ):
         """Plot the rotor free-body diagram.
 
         Parameters
         ----------
+        force_units : str
+            Force units.
+            Default is 'N'.
+        shaft_length_units : str
+            Shaft length units.
+            Default is 'm'.
         subplots : Plotly graph_objects.make_subplots()
             The figure object with the plot.
         kwargs : optional
@@ -2239,7 +2247,7 @@ class StaticResults:
 
             fig.add_trace(
                 go.Scatter(
-                    x=nodes_pos,
+                    x=Q_(nodes_pos, "m").to(shaft_length_units).m,
                     y=np.zeros(len(nodes_pos)),
                     mode="lines",
                     line=dict(color="black"),
@@ -2251,7 +2259,7 @@ class StaticResults:
             )
             fig.add_trace(
                 go.Scatter(
-                    x=nodes_pos,
+                    x=Q_(nodes_pos, "m").to(shaft_length_units).m,
                     y=[y_start] * len(nodes_pos),
                     mode="lines",
                     line=dict(color="black"),
@@ -2263,13 +2271,13 @@ class StaticResults:
             )
 
             # fig - plot arrows indicating shaft weight distribution
-            text = "{:.1f}".format(self.w_shaft[j])
+            text = "{:.1f}".format(Q_(self.w_shaft[j], "N").to(force_units).m)
             ini = nodes_pos[0]
             fin = nodes_pos[-1]
             arrows_list = np.arange(ini, 1.01 * fin, (fin - ini) / 5.0)
             for node in arrows_list:
                 fig.add_annotation(
-                    x=node,
+                    x=Q_(node, "m").to(shaft_length_units).m,
                     y=0,
                     axref="x{}".format(j + 1),
                     ayref="y{}".format(j + 1),
@@ -2278,19 +2286,19 @@ class StaticResults:
                     arrowsize=1,
                     arrowwidth=5,
                     arrowcolor="DimGray",
-                    ax=node,
+                    ax=Q_(node, "m").to(shaft_length_units).m,
                     ay=y_start * 1.08,
                     row=row,
                     col=col,
                 )
             fig.add_annotation(
-                x=nodes_pos[0],
+                x=Q_(nodes_pos[0], "m").to(shaft_length_units).m,
                 y=y_start,
                 xref="x{}".format(j + 1),
                 yref="y{}".format(j + 1),
                 xshift=125,
                 yshift=20,
-                text="Shaft weight = {}N".format(text),
+                text=f"Shaft weight = {text}{force_units}",
                 align="right",
                 showarrow=False,
             )
@@ -2300,21 +2308,25 @@ class StaticResults:
                 _, node = k.split("_")
                 node = int(node)
                 if node in nodes:
-                    text = str(v)
+                    text = f"{Q_(v, 'N').to(force_units).m:.2f}"
                     var = 1 if v < 0 else -1
                     fig.add_annotation(
-                        x=nodes_pos[nodes.index(node)],
+                        x=Q_(nodes_pos[nodes.index(node)], "m")
+                        .to(shaft_length_units)
+                        .m,
                         y=0,
                         axref="x{}".format(j + 1),
                         ayref="y{}".format(j + 1),
-                        text="Fb = {}N".format(text),
+                        text=f"Fb = {text}{force_units}",
                         textangle=90,
                         showarrow=True,
                         arrowhead=2,
                         arrowsize=1,
                         arrowwidth=5,
                         arrowcolor="DarkSalmon",
-                        ax=nodes_pos[nodes.index(node)],
+                        ax=Q_(nodes_pos[nodes.index(node)], "m")
+                        .to(shaft_length_units)
+                        .m,
                         ay=var * 2.5 * y_start,
                         row=row,
                         col=col,
@@ -2325,26 +2337,32 @@ class StaticResults:
                 _, node = k.split("_")
                 node = int(node)
                 if node in nodes:
-                    text = str(-v)
+                    text = f"{-Q_(v, 'N').to(force_units).m:.2f}"
                     fig.add_annotation(
-                        x=nodes_pos[nodes.index(node)],
+                        x=Q_(nodes_pos[nodes.index(node)], "m")
+                        .to(shaft_length_units)
+                        .m,
                         y=0,
                         axref="x{}".format(j + 1),
                         ayref="y{}".format(j + 1),
-                        text="Fd = {}N".format(text),
+                        text=f"Fd = {text}{force_units}",
                         textangle=270,
                         showarrow=True,
                         arrowhead=2,
                         arrowsize=1,
                         arrowwidth=5,
                         arrowcolor="FireBrick",
-                        ax=nodes_pos[nodes.index(node)],
+                        ax=Q_(nodes_pos[nodes.index(node)], "m")
+                        .to(shaft_length_units)
+                        .m,
                         ay=2.5 * y_start,
                         row=row,
                         col=col,
                     )
 
-            fig.update_xaxes(title_text="Shaft Length", row=row, col=col)
+            fig.update_xaxes(
+                title_text=f"Shaft Length ({shaft_length_units})", row=row, col=col
+            )
             fig.update_yaxes(
                 visible=False, gridcolor="lightgray", showline=False, row=row, col=col
             )

--- a/ross/results.py
+++ b/ross/results.py
@@ -11,6 +11,7 @@ from plotly.subplots import make_subplots
 from scipy import interpolate
 
 from ross.plotly_theme import tableau_colors
+from ross.units import Q_
 
 
 class CriticalSpeedResults:
@@ -479,7 +480,9 @@ class ModalResults:
 
         return xn, yn, zn, x_circles, y_circles, z_circles_pos, nn
 
-    def plot_mode_3d(self, mode=None, evec=None, fig=None, **kwargs):
+    def plot_mode_3d(
+        self, mode=None, evec=None, fig=None, frequency_units="rad/s", **kwargs
+    ):
         """Plot (3D view) the mode shapes.
 
         Parameters
@@ -491,6 +494,9 @@ class ModalResults:
             Array containing the system eigenvectors
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
+        frequency_units : str, optional
+            Frequency units that will be used in the plot title.
+            Default is rad/s.
         kwargs : optional
             Additional key word arguments can be passed to change the plot layout only
             (e.g. width=1000, height=800, ...).
@@ -586,7 +592,7 @@ class ModalResults:
                 text=(
                     f"<b>Mode</b> {mode + 1} | "
                     f"<b>whirl</b>: {self.whirl_direction()[mode]} | "
-                    f"<b>ω<sub>n</sub></b> = {self.wn[mode]:.1f} rad/s | "
+                    f"<b>ω<sub>n</sub></b> = {Q_(self.wn[mode], 'rad/s').to(frequency_units).m:.1f} {frequency_units} | "
                     f"<b>log dec</b> = {self.log_dec[mode]:.1f}"
                 )
             ),

--- a/ross/results.py
+++ b/ross/results.py
@@ -601,7 +601,9 @@ class ModalResults:
 
         return fig
 
-    def plot_mode_2d(self, mode=None, evec=None, fig=None, **kwargs):
+    def plot_mode_2d(
+        self, mode=None, evec=None, fig=None, frequency_units="rad/s", **kwargs
+    ):
         """Plot (2D view) the mode shapes.
 
         Parameters
@@ -613,6 +615,9 @@ class ModalResults:
             Array containing the system eigenvectors
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
+        frequency_units : str, optional
+            Frequency units that will be used in the plot title.
+            Default is rad/s.
         kwargs : optional
             Additional key word arguments can be passed to change the plot layout only
             (e.g. width=1000, height=800, ...).
@@ -675,7 +680,7 @@ class ModalResults:
                 text=(
                     f"<b>Mode</b> {mode + 1} | "
                     f"<b>whirl</b>: {self.whirl_direction()[mode]} | "
-                    f"<b>ωn</b> = {self.wn[mode]:.1f} rad/s | "
+                    f"<b>ωn</b> = {Q_(self.wn[mode], 'rad/s').to(frequency_units).m:.1f} {frequency_units} | "
                     f"<b>log dec</b> = {self.log_dec[mode]:.1f}"
                 )
             ),

--- a/ross/results.py
+++ b/ross/results.py
@@ -995,7 +995,7 @@ class FrequencyResponseResults:
         frequency_range = self.speed_range
         phase = self.phase
 
-        frequency_range = Q_(frequency_range, "rad/s").to(x_units)
+        frequency_range = Q_(frequency_range, "rad/s").to(x_units).m
 
         if fig is None:
             fig = go.Figure()
@@ -1058,8 +1058,8 @@ class FrequencyResponseResults:
         mag = self.magnitude
         phase = self.phase
 
-        frequency_range = Q_(frequency_range, "rad/s").to(x_units)
-        mag = Q_(mag, "m/N").to(y_units)
+        frequency_range = Q_(frequency_range, "rad/s").to(x_units).m
+        mag = Q_(mag, "m/N").to(y_units).m
 
         if fig is None:
             fig = go.Figure()

--- a/ross/results.py
+++ b/ross/results.py
@@ -1913,8 +1913,8 @@ class ForcedResponseResults:
             raise ValueError("No data available for this speed value.")
 
         Mx, My = self._calculate_bending_moment(speed=speed)
-        Mx = Q_(Mx, "N*m").to(moment_units)
-        My = Q_(My, "N*m").to(moment_units)
+        Mx = Q_(Mx, "N*m").to(moment_units).m
+        My = Q_(My, "N*m").to(moment_units).m
         Mr = np.sqrt(Mx ** 2 + My ** 2)
 
         nodes_pos = self.rotor.nodes_pos

--- a/ross/results.py
+++ b/ross/results.py
@@ -3150,9 +3150,7 @@ class TimeResponseResults:
                 raise Exception("Select a node to plot orbit when plot_type '2d'")
             elif node not in self.nodes_list:
                 raise Exception("Select a valid node to plot 2D orbit")
-            return self._plot2d(
-                node, displacement_units, rotor_length_units, fig, **kwargs
-            )
+            return self._plot2d(node, displacement_units, fig, **kwargs)
         elif plot_type == "1d":
             if dof is None:
                 raise Exception("Select a dof to plot orbit when plot_type == '1d'")

--- a/ross/results.py
+++ b/ross/results.py
@@ -573,27 +573,21 @@ class ModalResults:
         fig.update_layout(
             scene=dict(
                 xaxis=dict(
-                    title=dict(text="<b>Rotor Length</b>"),
-                    autorange="reversed",
-                    nticks=5,
+                    title=dict(text="Rotor Length"), autorange="reversed", nticks=5
                 ),
                 yaxis=dict(
-                    title=dict(text="<b>Relative Displacement</b>"),
-                    range=[-2, 2],
-                    nticks=5,
+                    title=dict(text="Relative Displacement"), range=[-2, 2], nticks=5
                 ),
                 zaxis=dict(
-                    title=dict(text="<b>Relative Displacement</b>"),
-                    range=[-2, 2],
-                    nticks=5,
+                    title=dict(text="Relative Displacement"), range=[-2, 2], nticks=5
                 ),
             ),
             title=dict(
                 text=(
-                    f"<b>Mode</b> {mode + 1} | "
-                    f"<b>whirl</b>: {self.whirl_direction()[mode]} | "
-                    f"<b>ω<sub>n</sub></b> = {Q_(self.wn[mode], 'rad/s').to(frequency_units).m:.1f} {frequency_units} | "
-                    f"<b>log dec</b> = {self.log_dec[mode]:.1f}"
+                    f"Mode {mode + 1} | "
+                    f"whirl: {self.whirl_direction()[mode]} | "
+                    f"ω<sub>n</sub> = {Q_(self.wn[mode], 'rad/s').to(frequency_units).m:.1f} {frequency_units} | "
+                    f"log dec = {self.log_dec[mode]:.1f}"
                 )
             ),
             **kwargs,
@@ -673,15 +667,15 @@ class ModalResults:
             )
         )
 
-        fig.update_xaxes(title_text="<b>Rotor Length</b>")
-        fig.update_yaxes(title_text="<b>Relative Displacement</b>")
+        fig.update_xaxes(title_text="Rotor Length")
+        fig.update_yaxes(title_text="Relative Displacement")
         fig.update_layout(
             title=dict(
                 text=(
-                    f"<b>Mode</b> {mode + 1} | "
-                    f"<b>whirl</b>: {self.whirl_direction()[mode]} | "
-                    f"<b>ωn</b> = {Q_(self.wn[mode], 'rad/s').to(frequency_units).m:.1f} {frequency_units} | "
-                    f"<b>log dec</b> = {self.log_dec[mode]:.1f}"
+                    f"Mode {mode + 1} | "
+                    f"whirl: {self.whirl_direction()[mode]} | "
+                    f"ωn = {Q_(self.wn[mode], 'rad/s').to(frequency_units).m:.1f} {frequency_units} | "
+                    f"log dec = {self.log_dec[mode]:.1f}"
                 )
             ),
             **kwargs,
@@ -849,11 +843,11 @@ class CampbellResults:
             )
 
         fig.update_xaxes(
-            title_text=f"<b>Frequency ({frequency_units})</b>",
+            title_text=f"Frequency ({frequency_units})",
             range=[np.min(speed_range), np.max(speed_range)],
         )
         fig.update_yaxes(
-            title_text=f"<b>Natural Frequencies ({frequency_units})</b>",
+            title_text=f"Natural Frequencies ({frequency_units})",
             range=[0, 1.1 * np.max(wd)],
         )
         fig.update_layout(
@@ -861,7 +855,7 @@ class CampbellResults:
                 cmin=min(log_dec_map),
                 cmax=max(log_dec_map),
                 colorscale="rdbu",
-                colorbar=dict(title=dict(text="<b>Log Dec</b>", side="right")),
+                colorbar=dict(title=dict(text="Log Dec", side="right")),
             ),
             legend=dict(
                 itemsizing="constant",
@@ -966,10 +960,10 @@ class FrequencyResponseResults:
         )
 
         fig.update_xaxes(
-            title_text=f"<b>Frequency ({frequency_units})</b>",
+            title_text=f"Frequency ({frequency_units})",
             range=[np.min(frequency_range), np.max(frequency_range)],
         )
-        fig.update_yaxes(title_text=f"<b>Amplitude ({amplitude_units})</b>")
+        fig.update_yaxes(title_text=f"Amplitude ({amplitude_units})")
         fig.update_layout(**mag_kwargs)
 
         return fig
@@ -1040,10 +1034,10 @@ class FrequencyResponseResults:
         )
 
         fig.update_xaxes(
-            title_text=f"<b>Frequency ({frequency_units})</b>",
+            title_text=f"Frequency ({frequency_units})",
             range=[np.min(frequency_range), np.max(frequency_range)],
         )
-        fig.update_yaxes(title_text=f"<b>Phase ({phase_units})</b>")
+        fig.update_yaxes(title_text=f"Phase ({phase_units})")
         fig.update_layout(**phase_kwargs)
 
         return fig
@@ -1323,7 +1317,7 @@ class ForcedResponseResults:
         )
 
         fig.update_xaxes(
-            title_text=f"<b>Frequency ({frequency_units})</b>",
+            title_text=f"Frequency ({frequency_units})",
             range=[np.min(frequency_range), np.max(frequency_range)],
         )
         fig.update_yaxes(
@@ -1385,10 +1379,10 @@ class ForcedResponseResults:
         )
 
         fig.update_xaxes(
-            title_text=f"<b>Frequency ({frequency_units})</b>",
+            title_text=f"Frequency ({frequency_units})",
             range=[np.min(frequency_range), np.max(frequency_range)],
         )
-        fig.update_yaxes(title_text=f"<b>Phase ({phase_units})</b>")
+        fig.update_yaxes(title_text=f"Phase ({phase_units})")
         fig.update_layout(**kwargs)
 
         return fig
@@ -1714,9 +1708,7 @@ class ForcedResponseResults:
                 name="Major Axis",
                 legendgroup="Major_Axis_2d",
                 showlegend=False,
-                hovertemplate=(
-                    "<b>Nodal Position: %{x:.2f}</b><br>" + "<b>Amplitude: %{y:.2e}</b>"
-                ),
+                hovertemplate=("Nodal Position: %{x:.2f}<br>" + "Amplitude: %{y:.2e}"),
             )
         )
         # plot center line
@@ -1731,8 +1723,8 @@ class ForcedResponseResults:
             )
         )
 
-        fig.update_xaxes(title_text="<b>Rotor Length</b>")
-        fig.update_yaxes(title_text="<b>Major Axis Absolute Amplitude</b>")
+        fig.update_xaxes(title_text="Rotor Length")
+        fig.update_yaxes(title_text="Major Axis Absolute Amplitude")
         fig.update_layout(**kwargs)
 
         return fig
@@ -1806,9 +1798,9 @@ class ForcedResponseResults:
                     legendgroup="Orbit",
                     showlegend=False,
                     hovertemplate=(
-                        "<b>Nodal Position: %{x:.2f}</b><br>"
-                        + "<b>X - Amplitude: %{y:.2e}</b><br>"
-                        + "<b>Y - Amplitude: %{z:.2e}</b>"
+                        "Nodal Position: %{x:.2f}<br>"
+                        + "X - Amplitude: %{y:.2e}<br>"
+                        + "Y - Amplitude: %{z:.2e}"
                     ),
                 )
             )
@@ -1884,11 +1876,11 @@ class ForcedResponseResults:
         fig.update_layout(
             scene=dict(
                 bgcolor="white",
-                xaxis=dict(title=dict(text="<b>Rotor Length</b>")),
-                yaxis=dict(title=dict(text="<b>Amplitude - X</b>")),
-                zaxis=dict(title=dict(text="<b>Amplitude - Y</b>")),
+                xaxis=dict(title=dict(text="Rotor Length")),
+                yaxis=dict(title=dict(text="Amplitude - X")),
+                zaxis=dict(title=dict(text="Amplitude - Y")),
             ),
-            title=dict(text=(f"<b>Deflected Shape</b><br>" f"<b>Speed = {speed}</b>")),
+            title=dict(text=(f"Deflected Shape<br>" f"Speed = {speed}")),
             **kwargs,
         )
 
@@ -1937,9 +1929,7 @@ class ForcedResponseResults:
                 name="Bending Moment (X dir.)",
                 legendgroup="Mx",
                 showlegend=True,
-                hovertemplate=(
-                    "<b>Nodal Position: %{x:.2f}</b><br>" + "<b>Mx: %{y:.2e}</b>"
-                ),
+                hovertemplate=("Nodal Position: %{x:.2f}<br>" + "Mx: %{y:.2e}"),
             )
         )
         fig.add_trace(
@@ -1950,9 +1940,7 @@ class ForcedResponseResults:
                 name="Bending Moment (Y dir.)",
                 legendgroup="My",
                 showlegend=True,
-                hovertemplate=(
-                    "<b>Nodal Position: %{x:.2f}</b><br>" + "<b>My: %{y:.2e}</b>"
-                ),
+                hovertemplate=("Nodal Position: %{x:.2f}<br>" + "My: %{y:.2e}"),
             )
         )
         fig.add_trace(
@@ -1963,9 +1951,7 @@ class ForcedResponseResults:
                 name="Bending Moment (abs)",
                 legendgroup="Mr",
                 showlegend=True,
-                hovertemplate=(
-                    "<b>Nodal Position: %{x:.2f}</b><br>" + "<b>Mr: %{y:.2e}</b>"
-                ),
+                hovertemplate=("Nodal Position: %{x:.2f}<br>" + "Mr: %{y:.2e}"),
             )
         )
 
@@ -1981,8 +1967,8 @@ class ForcedResponseResults:
             )
         )
 
-        fig.update_xaxes(title_text="<b>Rotor Length</b>")
-        fig.update_yaxes(title_text="<b>Bending Moment</b>")
+        fig.update_xaxes(title_text="Rotor Length")
+        fig.update_yaxes(title_text="Bending Moment")
         fig.update_layout(**kwargs)
 
         return fig
@@ -2208,9 +2194,9 @@ class StaticResults:
             )
             count += 1
 
-        fig.update_xaxes(title_text=f"<b>Shaft Length ({shaft_length_units})</b>")
-        fig.update_yaxes(title_text=f"<b>Deformation ({deformation_units})</b>")
-        fig.update_layout(title=dict(text="<b>Static Deformation</b>"), **kwargs)
+        fig.update_xaxes(title_text=f"Shaft Length ({shaft_length_units})")
+        fig.update_yaxes(title_text=f"Deformation ({deformation_units})")
+        fig.update_layout(title=dict(text="Static Deformation"), **kwargs)
 
         return fig
 
@@ -2238,7 +2224,7 @@ class StaticResults:
                 rows=rows,
                 cols=cols,
                 subplot_titles=[
-                    "<b>Free-Body Diagram - Shaft {}</b>".format(j)
+                    "Free-Body Diagram - Shaft {}".format(j)
                     for j in range(len(self.nodes_pos))
                 ],
             )
@@ -2301,7 +2287,7 @@ class StaticResults:
                 yref="y{}".format(j + 1),
                 xshift=125,
                 yshift=20,
-                text="<b>Shaft weight = {}N</b>".format(text),
+                text="Shaft weight = {}N".format(text),
                 align="right",
                 showarrow=False,
             )
@@ -2318,7 +2304,7 @@ class StaticResults:
                         y=0,
                         axref="x{}".format(j + 1),
                         ayref="y{}".format(j + 1),
-                        text="<b>Fb = {}N</b>".format(text),
+                        text="Fb = {}N".format(text),
                         textangle=90,
                         showarrow=True,
                         arrowhead=2,
@@ -2342,7 +2328,7 @@ class StaticResults:
                         y=0,
                         axref="x{}".format(j + 1),
                         ayref="y{}".format(j + 1),
-                        text="<b>Fd = {}N</b>".format(text),
+                        text="Fd = {}N".format(text),
                         textangle=270,
                         showarrow=True,
                         arrowhead=2,
@@ -2355,7 +2341,7 @@ class StaticResults:
                         col=col,
                     )
 
-            fig.update_xaxes(title_text="<b>Shaft Length</b>", row=row, col=col)
+            fig.update_xaxes(title_text="Shaft Length", row=row, col=col)
             fig.update_yaxes(
                 visible=False, gridcolor="lightgray", showline=False, row=row, col=col
             )
@@ -2420,10 +2406,10 @@ class StaticResults:
             j += 1
 
         fig.update_xaxes(
-            title_text="<b>Shaft Length</b>", range=[-0.1 * shaft_end, 1.1 * shaft_end]
+            title_text="Shaft Length", range=[-0.1 * shaft_end, 1.1 * shaft_end]
         )
-        fig.update_yaxes(title_text="<b>Force</b>")
-        fig.update_layout(title=dict(text="<b>Shearing Force Diagram</b>"), **kwargs)
+        fig.update_yaxes(title_text="Force")
+        fig.update_layout(title=dict(text="Shearing Force Diagram"), **kwargs)
 
         return fig
 
@@ -2477,9 +2463,9 @@ class StaticResults:
             )
             j += 1
 
-        fig.update_xaxes(title_text="<b>Shaft Length</b>")
-        fig.update_yaxes(title_text="<b>Bending Moment</b>")
-        fig.update_layout(title=dict(text="<b>Bending Moment Diagram</b>"), **kwargs)
+        fig.update_xaxes(title_text="Shaft Length")
+        fig.update_yaxes(title_text="Bending Moment")
+        fig.update_layout(title=dict(text="Bending Moment Diagram"), **kwargs)
 
         return fig
 
@@ -2593,17 +2579,17 @@ class SummaryResults:
                 [{"type": "table"}, {"type": "table"}],
             ],
             subplot_titles=[
-                "<b>Rotor data</b>",
-                "<b>Shaft Element data</b>",
-                "<b>Disk Element data</b>",
-                "<b>Bearing Element data</b>",
+                "Rotor data",
+                "Shaft Element data",
+                "Disk Element data",
+                "Bearing Element data",
             ],
         )
         colors = ["#ffffff", "#c4d9ed"]
         fig.add_trace(
             go.Table(
                 header=dict(
-                    values=["<b>{}</b>".format(k) for k in rotor_data.keys()],
+                    values=["{}".format(k) for k in rotor_data.keys()],
                     font=dict(size=12, color="white"),
                     line=dict(color="#1f4060", width=1.5),
                     fill=dict(color="#1f4060"),
@@ -2626,7 +2612,7 @@ class SummaryResults:
         fig.add_trace(
             go.Table(
                 header=dict(
-                    values=["<b>{}</b>".format(k) for k in shaft_data.keys()],
+                    values=["{}".format(k) for k in shaft_data.keys()],
                     font=dict(family="Verdana", size=12, color="white"),
                     line=dict(color="#1e4162", width=1.5),
                     fill=dict(color="#1e4162"),
@@ -2649,7 +2635,7 @@ class SummaryResults:
         fig.add_trace(
             go.Table(
                 header=dict(
-                    values=["<b>{}</b>".format(k) for k in disk_data.keys()],
+                    values=["{}".format(k) for k in disk_data.keys()],
                     font=dict(family="Verdana", size=12, color="white"),
                     line=dict(color="#1e4162", width=1.5),
                     fill=dict(color="#1e4162"),
@@ -2672,7 +2658,7 @@ class SummaryResults:
         fig.add_trace(
             go.Table(
                 header=dict(
-                    values=["<b>{}</b>".format(k) for k in bearing_data.keys()],
+                    values=["{}".format(k) for k in bearing_data.keys()],
                     font=dict(family="Verdana", size=12, color="white"),
                     line=dict(color="#1e4162", width=1.5),
                     fill=dict(color="#1e4162"),
@@ -2745,10 +2731,7 @@ class ConvergenceResults:
             fig = make_subplots(
                 rows=1,
                 cols=2,
-                subplot_titles=[
-                    "<b>Frequency Evaluation</b>",
-                    "<b>Relative Error Evaluation</b>",
-                ],
+                subplot_titles=["Frequency Evaluation", "Relative Error Evaluation"],
             )
 
         # plot Frequency vs number of elements
@@ -2765,8 +2748,8 @@ class ConvergenceResults:
             row=1,
             col=1,
         )
-        fig.update_xaxes(title_text="<b>Number of Elements</b>", row=1, col=1)
-        fig.update_yaxes(title_text="<b>Frequency</b>", row=1, col=1)
+        fig.update_xaxes(title_text="Number of Elements", row=1, col=1)
+        fig.update_yaxes(title_text="Frequency", row=1, col=1)
 
         # plot Error vs number of elements
         fig.add_trace(
@@ -2783,8 +2766,8 @@ class ConvergenceResults:
             col=2,
         )
 
-        fig.update_xaxes(title_text="<b>Number of Elements</b>", row=1, col=2)
-        fig.update_yaxes(title_text="<b>Relative Error (%)</b>", row=1, col=2)
+        fig.update_xaxes(title_text="Number of Elements", row=1, col=2)
+        fig.update_yaxes(title_text="Relative Error (%)", row=1, col=2)
 
         fig.update_layout(**kwargs)
 
@@ -2881,12 +2864,10 @@ class TimeResponseResults:
             )
         )
 
-        fig.update_xaxes(title_text="<b>Time</b>")
-        fig.update_yaxes(title_text="<b>Amplitude</b>")
+        fig.update_xaxes(title_text="Time")
+        fig.update_yaxes(title_text="Amplitude")
         fig.update_layout(
-            title=dict(
-                text="<b>Response for node {} - DoF {}</b>".format(dof // 4, obs_dof)
-            ),
+            title=dict(text="Response for node {} - DoF {}".format(dof // 4, obs_dof)),
             **kwargs,
         )
 
@@ -2930,10 +2911,10 @@ class TimeResponseResults:
             )
         )
 
-        fig.update_xaxes(title_text="<b>Amplitude - X direction</b>")
-        fig.update_yaxes(title_text="<b>Amplitude - Y direction</b>")
+        fig.update_xaxes(title_text="Amplitude - X direction")
+        fig.update_yaxes(title_text="Amplitude - Y direction")
         fig.update_layout(
-            title=dict(text="<b>Response for node {}</b>".format(node)), **kwargs
+            title=dict(text="Response for node {}".format(node)), **kwargs
         )
 
         return fig
@@ -2997,9 +2978,9 @@ class TimeResponseResults:
 
         fig.update_layout(
             scene=dict(
-                xaxis=dict(title=dict(text="<b>Rotor Length</b>")),
-                yaxis=dict(title=dict(text="<b>Amplitude - X</b>")),
-                zaxis=dict(title=dict(text="<b>Amplitude - Y</b>")),
+                xaxis=dict(title=dict(text="Rotor Length")),
+                yaxis=dict(title=dict(text="Amplitude - X")),
+                zaxis=dict(title=dict(text="Amplitude - Y")),
             ),
             **kwargs,
         )

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1989,8 +1989,8 @@ class Rotor(object):
         num=30,
         fig=None,
         synchronous=False,
-        x_units="N/m",
-        y_units="rad/s",
+        stiffness_units="N/m",
+        frequency_units="rad/s",
         **kwargs,
     ):
         """Plot undamped critical speed map.
@@ -2015,10 +2015,10 @@ class Rotor(object):
             If True a synchronous analysis is carried out and the frequency of
             the first forward model will be equal to the speed.
             Default is False.
-        x_units : str, optional
+        stiffness_units : str, optional
             Units for the x axis.
             Default is N/m.
-        y_units : str, optional
+        frequency_units : str, optional
             Units for th y axis.
             Default is rad/s
         kwargs : optional
@@ -2071,17 +2071,25 @@ class Rotor(object):
             fig = go.Figure()
 
         # convert to desired units
-        stiffness_log = Q_(stiffness_log, "N/m").to(x_units).m
-        rotor_wn = Q_(rotor_wn, "rad/s").to(y_units).m
-        intersection_points["x"] = Q_(intersection_points["x"], "N/m").to(x_units).m
-        intersection_points["y"] = Q_(intersection_points["y"], "rad/s").to(y_units).m
+        stiffness_log = Q_(stiffness_log, "N/m").to(stiffness_units).m
+        rotor_wn = Q_(rotor_wn, "rad/s").to(frequency_units).m
+        intersection_points["x"] = (
+            Q_(intersection_points["x"], "N/m").to(stiffness_units).m
+        )
+        intersection_points["y"] = (
+            Q_(intersection_points["y"], "rad/s").to(frequency_units).m
+        )
         bearing_kxx_stiffness = (
-            Q_(bearing0.kxx.interpolated(bearing0.frequency), "N/m").to(x_units).m
+            Q_(bearing0.kxx.interpolated(bearing0.frequency), "N/m")
+            .to(stiffness_units)
+            .m
         )
         bearing_kyy_stiffness = (
-            Q_(bearing0.kyy.interpolated(bearing0.frequency), "N/m").to(x_units).m
+            Q_(bearing0.kyy.interpolated(bearing0.frequency), "N/m")
+            .to(stiffness_units)
+            .m
         )
-        bearing_frequency = Q_(bearing0.frequency, "rad/s").to(y_units).m
+        bearing_frequency = Q_(bearing0.frequency, "rad/s").to(frequency_units).m
 
         for j in range(rotor_wn.shape[0]):
             fig.add_trace(
@@ -2100,7 +2108,7 @@ class Rotor(object):
                 y=intersection_points["y"],
                 mode="markers",
                 marker=dict(symbol="circle-open-dot", color="red", size=8),
-                hovertemplate=f"Stiffness ({x_units}): %{{x:.2e}}<br>Frequency ({y_units}): %{{y:.2f}}",
+                hovertemplate=f"Stiffness ({stiffness_units}): %{{x:.2e}}<br>Frequency ({frequency_units}): %{{y:.2f}}",
                 showlegend=False,
                 name="",
             )
@@ -2128,12 +2136,14 @@ class Rotor(object):
         )
 
         fig.update_xaxes(
-            title_text=f"Bearing Stiffness ({x_units})",
+            title_text=f"Bearing Stiffness ({stiffness_units})",
             type="log",
             exponentformat="power",
         )
         fig.update_yaxes(
-            title_text=f"Critical Speed ({y_units})", type="log", exponentformat="power"
+            title_text=f"Critical Speed ({frequency_units})",
+            type="log",
+            exponentformat="power",
         )
         fig.update_layout(title=dict(text="Undamped Critical Speed Map"), **kwargs)
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1771,7 +1771,7 @@ class Rotor(object):
         x_pos = []
         y_pos = np.linspace(0, 0, len(self.nodes_pos[::nodes]))
         for node, position in enumerate(self.nodes_pos[::nodes]):
-            text.append("<b>{}</b>".format(node * nodes))
+            text.append("{}".format(node * nodes))
             x_pos.append(position)
 
         fig.add_trace(
@@ -1819,18 +1819,18 @@ class Rotor(object):
             fig = p_mass._patch(position, fig)
 
         fig.update_xaxes(
-            title_text="<b>Axial location</b>",
+            title_text="Axial location",
             range=[-0.1 * shaft_end, 1.1 * shaft_end],
             showgrid=False,
             mirror=True,
         )
         fig.update_yaxes(
-            title_text="<b>Shaft radius</b>",
+            title_text="Shaft radius",
             range=[-0.3 * shaft_end, 0.3 * shaft_end],
             showgrid=False,
             mirror=True,
         )
-        fig.update_layout(title=dict(text="<b>Rotor Model</b>"), **kwargs)
+        fig.update_layout(title=dict(text="Rotor Model"), **kwargs)
 
         return fig
 
@@ -2128,18 +2128,14 @@ class Rotor(object):
         )
 
         fig.update_xaxes(
-            title_text=f"<b>Bearing Stiffness ({x_units})</b>",
+            title_text=f"Bearing Stiffness ({x_units})",
             type="log",
             exponentformat="power",
         )
         fig.update_yaxes(
-            title_text=f"<b>Critical Speed ({y_units})</b>",
-            type="log",
-            exponentformat="power",
+            title_text=f"Critical Speed ({y_units})", type="log", exponentformat="power"
         )
-        fig.update_layout(
-            title=dict(text="<b>Undamped Critical Speed Map</b>"), **kwargs
-        )
+        fig.update_layout(title=dict(text="Undamped Critical Speed Map"), **kwargs)
 
         return fig
 
@@ -2234,12 +2230,10 @@ class Rotor(object):
         )
 
         fig.update_xaxes(
-            title_text="<b>Applied Cross Coupled Stiffness</b>", exponentformat="power"
+            title_text="Applied Cross Coupled Stiffness", exponentformat="power"
         )
-        fig.update_yaxes(title_text="<b>Log Dec</b>", exponentformat="power")
-        fig.update_layout(
-            title=dict(text="<b>Level 1 stability analysis</b>"), **kwargs
-        )
+        fig.update_yaxes(title_text="Log Dec", exponentformat="power")
+        fig.update_layout(title=dict(text="Level 1 stability analysis"), **kwargs)
 
         return fig
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2099,11 +2099,7 @@ class Rotor(object):
                 y=intersection_points["y"],
                 mode="markers",
                 marker=dict(symbol="circle-open-dot", color="red", size=8),
-                hovertemplate="Stiffness "
-                + f"({x_units})"
-                + ": %{x:.2e}<br>Frequency "
-                + f"({y_units})"
-                + ": %{y:.2f}",
+                hovertemplate=f"Stiffness ({x_units}): %{{x:.2e}}<br>Frequency ({y_units}): %{{y:.2f}}",
                 showlegend=False,
                 name="",
             )

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -897,8 +897,8 @@ class ShaftElement(Element):
         if check_sld:
             customdata = [self.n, self.slenderness_ratio]
             hovertemplate = (
-                f"<b>Element Number: {customdata[0]}<b><br>"
-                + f"<b>Slenderness Ratio: {customdata[1]:.3f}<b>"
+                f"Element Number: {customdata[0]}<br>"
+                + f"Slenderness Ratio: {customdata[1]:.3f}"
             )
         else:
             if isinstance(self, ShaftElement6DoF):
@@ -914,15 +914,15 @@ class ShaftElement(Element):
                     self.material.name,
                 ]
                 hovertemplate = (
-                    f"<b>Element Number: {customdata[0]}<b><br>"
-                    + f"<b>Left Outer Diameter: {round(customdata[1], 6)}<b><br>"
-                    + f"<b>Left Inner Diameter: {round(customdata[2], 6)}<b><br>"
-                    + f"<b>Right Outer Diameter: {round(customdata[3], 6)}<b><br>"
-                    + f"<b>Right Inner Diameter: {round(customdata[4], 6)}<b><br>"
-                    + f"<b>Alpha Damp. Factor: {round(customdata[5], 6)}<b><br>"
-                    + f"<b>Beta Damp. Factor: {round(customdata[6], 6)}<b><br>"
-                    + f"<b>Element Length: {round(customdata[7], 6)}<b><br>"
-                    + f"<b>Material: {customdata[8]}<b><br>"
+                    f"Element Number: {customdata[0]}<br>"
+                    + f"Left Outer Diameter: {round(customdata[1], 6)}<br>"
+                    + f"Left Inner Diameter: {round(customdata[2], 6)}<br>"
+                    + f"Right Outer Diameter: {round(customdata[3], 6)}<br>"
+                    + f"Right Inner Diameter: {round(customdata[4], 6)}<br>"
+                    + f"Alpha Damp. Factor: {round(customdata[5], 6)}<br>"
+                    + f"Beta Damp. Factor: {round(customdata[6], 6)}<br>"
+                    + f"Element Length: {round(customdata[7], 6)}<br>"
+                    + f"Material: {customdata[8]}<br>"
                 )
             else:
                 customdata = [
@@ -935,13 +935,13 @@ class ShaftElement(Element):
                     self.material.name,
                 ]
                 hovertemplate = (
-                    f"<b>Element Number: {customdata[0]}<b><br>"
-                    + f"<b>Left Outer Diameter: {round(customdata[1], 6)}<b><br>"
-                    + f"<b>Left Inner Diameter: {round(customdata[2], 6)}<b><br>"
-                    + f"<b>Right Outer Diameter: {round(customdata[3], 6)}<b><br>"
-                    + f"<b>Right Inner Diameter: {round(customdata[4], 6)}<b><br>"
-                    + f"<b>Element Length: {round(customdata[5], 6)}<b><br>"
-                    + f"<b>Material: {customdata[6]}<b><br>"
+                    f"Element Number: {customdata[0]}<br>"
+                    + f"Left Outer Diameter: {round(customdata[1], 6)}<br>"
+                    + f"Left Inner Diameter: {round(customdata[2], 6)}<br>"
+                    + f"Right Outer Diameter: {round(customdata[3], 6)}<br>"
+                    + f"Right Inner Diameter: {round(customdata[4], 6)}<br>"
+                    + f"Element Length: {round(customdata[5], 6)}<br>"
+                    + f"Material: {customdata[6]}<br>"
                 )
         fig.add_trace(
             go.Scatter(

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -737,16 +737,16 @@ def test_freq_response_w_force(rotor4):
     mag = freq_resp.magnitude
     assert_allclose(mag[:4, :4], mag_exp)
 
-    freq_resp = rotor4.run_unbalance_response(2, 0.001, 0, frequency_range=omega)
+    freq_resp = rotor4.run_unbalance_response(2, 0.001, 0, frequency=omega)
     mag = freq_resp.magnitude
     assert_allclose(mag[:4, :4], mag_exp)
 
-    freq_resp = rotor4.run_unbalance_response(2, 0.001, 0, frequency_range=omega)
+    freq_resp = rotor4.run_unbalance_response(2, 0.001, 0, frequency=omega)
     mag = freq_resp.magnitude
     assert_allclose(mag[:4, :4], mag_exp)
 
     freq_resp = rotor4.run_unbalance_response(
-        [2, 3], [0.001, 0.001], [0.0, 0], frequency_range=omega
+        [2, 3], [0.001, 0.001], [0.0, 0], frequency=omega
     )
     mag = freq_resp.magnitude
     assert_allclose(mag[:4, :4], mag_exp_2_unb)

--- a/ross/tests/test_units.py
+++ b/ross/tests/test_units.py
@@ -15,11 +15,11 @@ def auxiliary_function():
     @check_units
     def func(E, G_s, rho, L, idl, idr, odl, odr, speed, frequency, m, mx, my, Ip, Id,
              width, i_d, o_d, kxx, kxy, kxz, kyx, kyy, kyz, kzx, kzy, kzz, cxx, cxy,
-             cxz, cyx, cyy, cyz, czx, czy, czz):
+             cxz, cyx, cyy, cyz, czx, czy, czz, unbalance_magnitude, unbalance_phase):
         return (
             E, G_s, rho, L, idl, idr, odl, odr, speed, frequency, m, mx, my, Ip, Id,
             width, i_d, o_d, kxx, kxy, kxz, kyx, kyy, kyz, kzx, kzy, kzz, cxx, cxy,
-            cxz, cyx, cyy, cyz, czx, czy, czz
+            cxz, cyx, cyy, cyz, czx, czy, czz, unbalance_magnitude, unbalance_phase
         )
     # fmt: on
     return func
@@ -31,14 +31,14 @@ def test_units(auxiliary_function):
         E=1, G_s=1, rho=1, L=1, idl=1, idr=1, odl=1, odr=1, speed=1, frequency=1,
         m=1, mx=1, my=1, Ip=1, Id=1, width=1, i_d=1, o_d=1, kxx=1, kxy=1, kxz=1, kyx=1,
         kyy=1, kyz=1, kzx=1, kzy=1, kzz=1, cxx=1, cxy=1, cxz=1, cyx=1, cyy=1, cyz=1,
-        czx=1, czy=1, czz=1,
+        czx=1, czy=1, czz=1, unbalance_magnitude=1, unbalance_phase=1
     )
     # check if all available units are tested
     assert len(results) == len(units)
 
     (E, G_s, rho, L, idl, idr, odl, odr, speed, frequency, m, mx, my, Ip, Id,
      width, i_d, o_d, kxx, kxy, kxz, kyx, kyy, kyz, kzx, kzy, kzz, cxx, cxy,
-     cxz, cyx, cyy, cyz, czx, czy, czz) = results
+     cxz, cyx, cyy, cyz, czx, czy, czz, unbalance_magnitude, unbalance_phase) = results
     # fmt: on
 
     assert E == 1
@@ -77,6 +77,8 @@ def test_units(auxiliary_function):
     assert czx == 1
     assert czy == 1
     assert czz == 1
+    assert unbalance_magnitude == 1
+    assert unbalance_phase == 1
 
 
 def test_unit_Q_(auxiliary_function):
@@ -117,6 +119,8 @@ def test_unit_Q_(auxiliary_function):
         czx=Q_(1, "N*s/m"),
         czy=Q_(1, "N*s/m"),
         czz=Q_(1, "N*s/m"),
+        unbalance_magnitude=Q_(1, "kg*m"),
+        unbalance_phase=Q_(1, "rad"),
     )
 
     # check if all available units are tested
@@ -124,7 +128,7 @@ def test_unit_Q_(auxiliary_function):
     # fmt: off
     (E, G_s, rho, L, idl, idr, odl, odr, speed, frequency, m, mx, my, Ip, Id,
      width, i_d, o_d, kxx, kxy, kxz, kyx, kyy, kyz, kzx, kzy, kzz, cxx, cxy,
-     cxz, cyx, cyy, cyz, czx, czy, czz) = results
+     cxz, cyx, cyy, cyz, czx, czy, czz, unbalance_magnitude, unbalance_phase) = results
     # fmt: on
 
     assert E == 1
@@ -163,6 +167,8 @@ def test_unit_Q_(auxiliary_function):
     assert czx == 1
     assert czy == 1
     assert czz == 1
+    unbalance_magnitude == 1
+    unbalance_phase == 1
 
 
 def test_unit_Q_conversion(auxiliary_function):
@@ -203,6 +209,8 @@ def test_unit_Q_conversion(auxiliary_function):
         czx=Q_(1, "lbf*s/in"),
         czy=Q_(1, "lbf*s/in"),
         czz=Q_(1, "lbf*s/in"),
+        unbalance_magnitude=Q_(1, "lb*in"),
+        unbalance_phase=Q_(1, "deg"),
     )
 
     # check if all available units are tested
@@ -211,7 +219,7 @@ def test_unit_Q_conversion(auxiliary_function):
     # fmt: off
     (E, G_s, rho, L, idl, idr, odl, odr, speed, frequency, m, mx, my, Ip, Id,
      width, i_d, o_d, kxx, kxy, kxz, kyx, kyy, kyz, kzx, kzy, kzz, cxx, cxy,
-     cxz, cyx, cyy, cyz, czx, czy, czz) = results
+     cxz, cyx, cyy, cyz, czx, czy, czz, unbalance_magnitude, unbalance_phase) = results
     # fmt: on
 
     assert E == 6894.7572931683635
@@ -250,6 +258,8 @@ def test_unit_Q_conversion(auxiliary_function):
     assert czx == 175.12683524647645
     assert czy == 175.12683524647645
     assert czz == 175.12683524647645
+    assert unbalance_magnitude == 0.011521246198000002
+    assert unbalance_phase == 0.017453292519943295
 
 
 # NOTE ABOUT TESTS BELOW

--- a/ross/units.py
+++ b/ross/units.py
@@ -36,6 +36,8 @@ units = {
     "width": "meter",
     "i_d": "meter",
     "o_d": "meter",
+    "unbalance_magnitude": "kg*m",
+    "unbalance_phase": "rad",
 }
 for i, unit in zip(["k", "c"], ["N/m", "N*s/m"]):
     for j in ["x", "y", "z"]:


### PR DESCRIPTION
This PR adds arguments to the plot functions so that the user can control the plot units.
As an example, for the unbalance response, now it is possible to call the plot function like this:
```python
unb = rotor.run_unbalance_response(
    node=23, unbalance_magnitude=0.60458, unbalance_phase=0, frequency=freq_range,
)
unb.plot(3, frequency_units='RPM')
```

This will automatically convert the frequency units from the default 'rad/s' to 'RPM'.

There are cases where we could have one argument controlling all quantities in the plot, like:

```python
def plot_deflected_shape_3d(
    self,
    speed,
    samples=101,
    length_units="m",
    fig=None,
    **kwargs,
):
```
The problem with this is that, if the user wanted to see the displacement in each node in `microns` the rotor length would also be changed to `microns`, and the plot would be strange since the displacement and the rotor length are not in the same order of magnitude.
To solve this, I have added two arguments to give the user more control:

```python
def plot_deflected_shape_3d(
    self,
    speed,
    samples=101,
    displacement_units="m",
    rotor_length_units="m",
    fig=None,
    **kwargs,
):
```

Closes #609.