### PR TITLE
Formatting __str__methods to include units

### DIFF
--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -123,6 +123,30 @@ class DiskElement(Element):
             f"n={self.n}, tag={self.tag!r})"
         )
 
+    def __str__(self):
+        """Convert object into string.
+
+        Returns
+        -------
+        The object's parameters translated to strings
+
+        Example
+        -------
+        >>> print(DiskElement(n=0, m=32, Id=0.223, Ip=0.31223, tag="Disk"))
+        Tag:                      Disk
+        Node:                     0
+        Mass           (kg):      32.0
+        Diam. inertia  (kg*m**2): 0.223
+        Polar. inertia (kg*m**2): 0.31223
+        """
+        return (
+            f"Tag:                      {self.tag}"
+            f"\nNode:                     {self.n}"
+            f"\nMass           (kg):      {self.m:{2}.{5}}"
+            f"\nDiam. inertia  (kg*m**2): {self.Id:{2}.{5}}"
+            f"\nPolar. inertia (kg*m**2): {self.Ip:{2}.{5}}"
+        )
+
     def __hash__(self):
         return hash(self.tag)
 

--- a/ross/materials.py
+++ b/ross/materials.py
@@ -144,18 +144,18 @@ class Material:
         >>> print(rs.Material.use_material('Steel'))
         Steel
         -----------------------------------
-        Density         (N/m**3): 7810.0
-        Young`s modulus (N/m**2): 2.11e+11
-        Shear modulus   (N/m**2): 8.12e+10
-        Poisson coefficient     : 0.29926108
+        Density         (kg/m**3): 7810.0
+        Young`s modulus (N/m**2):  2.11e+11
+        Shear modulus   (N/m**2):  8.12e+10
+        Poisson coefficient     :  0.29926108
         """
         return (
             f"{self.name}"
             f'\n{35*"-"}'
-            f"\nDensity         (N/m**3): {self.rho:{2}.{8}}"
-            f"\nYoung`s modulus (N/m**2): {self.E:{2}.{8}}"
-            f"\nShear modulus   (N/m**2): {self.G_s:{2}.{8}}"
-            f"\nPoisson coefficient     : {self.Poisson:{2}.{8}}"
+            f"\nDensity         (kg/m**3): {self.rho:{2}.{8}}"
+            f"\nYoung`s modulus (N/m**2):  {self.E:{2}.{8}}"
+            f"\nShear modulus   (N/m**2):  {self.G_s:{2}.{8}}"
+            f"\nPoisson coefficient     :  {self.Poisson:{2}.{8}}"
         )
 
     @staticmethod

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -113,6 +113,28 @@ class PointMass(Element):
             f" my={self.my:{0}.{5}}, tag={self.tag!r})"
         )
 
+    def __str__(self):
+        """Convert object into string.
+
+        Returns
+        -------
+        The object's parameters translated to strings
+
+        Example
+        -------
+        >>> print(PointMass(n=0, mx=2.5, my=3.25, tag="PointMass"))
+        Tag:              PointMass
+        Node:             0
+        Mass X dir. (kg): 2.5
+        Mass Y dir. (kg): 3.25
+        """
+        return (
+            f"Tag:              {self.tag}"
+            f"\nNode:             {self.n}"
+            f"\nMass X dir. (kg): {self.mx:{2}.{5}}"
+            f"\nMass Y dir. (kg): {self.my:{2}.{5}}"
+        )
+
     def M(self):
         """Mass matrix for an instance of a point mass element.
 

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -365,14 +365,31 @@ class ShaftElement(Element):
         Returns
         -------
         The object's parameters translated to strings
+
+        Example
+        -------
+        >>> print(ShaftElement(L=0.25, idl=0, odl=0.05, odr=0.08, material=steel))
+        Element Number:             None
+        Element Lenght   (m):       0.25
+        Left Int. Diam.  (m):        0.0
+        Left Out. Diam.  (m):       0.05
+        Right Int. Diam. (m):        0.0
+        Right Out. Diam. (m):       0.08
+        -----------------------------------
+        Steel
+        -----------------------------------
+        Density         (kg/m**3): 7810.0
+        Young`s modulus (N/m**2):  2.11e+11
+        Shear modulus   (N/m**2):  8.12e+10
+        Poisson coefficient     :  0.29926108
         """
         return (
-            f"\nElem. N:    {self.n}"
-            f"\nLenght:     {self.L:{10}.{5}}"
-            f"\nLeft Int. Diam.: {self.idl:{10}.{5}}"
-            f"\nLeft Out. Diam.: {self.odl:{10}.{5}}"
-            f"\nRight Int. Diam.: {self.idr:{10}.{5}}"
-            f"\nRight Out. Diam.: {self.odr:{10}.{5}}"
+            f"Element Number:             {self.n}"
+            f"\nElement Lenght   (m): {self.L:{10}.{5}}"
+            f"\nLeft Int. Diam.  (m): {self.idl:{10}.{5}}"
+            f"\nLeft Out. Diam.  (m): {self.odl:{10}.{5}}"
+            f"\nRight Int. Diam. (m): {self.idr:{10}.{5}}"
+            f"\nRight Out. Diam. (m): {self.odr:{10}.{5}}"
             f'\n{35*"-"}'
             f"\n{self.material}"
             f"\n"
@@ -1438,16 +1455,35 @@ class ShaftElement6DoF(ShaftElement):
         Returns
         -------
         The object's parameters translated to strings
+
+        Example
+        -------
+        >>> print(ShaftElement6DoF(L=0.25, idl=0, odl=0.05, odr=0.08, material=steel))
+        Element Number:             None
+        Element Lenght   (m):       0.25
+        Left Int. Diam.  (m):        0.0
+        Left Out. Diam.  (m):       0.05
+        Right Int. Diam. (m):        0.0
+        Right Out. Diam. (m):       0.08
+        Alpha damp. factor:          0.0
+        Beta damp. factor:           0.0
+        -----------------------------------
+        Steel
+        -----------------------------------
+        Density         (kg/m**3): 7810.0
+        Young`s modulus (N/m**2):  2.11e+11
+        Shear modulus   (N/m**2):  8.12e+10
+        Poisson coefficient     :  0.29926108
         """
         return (
-            f"\nElem. N:    {self.n}"
-            f"\nLenght:     {self.L:{10}.{5}}"
-            f"\nLeft Int. Diam.: {self.idl:{10}.{5}}"
-            f"\nLeft Out. Diam.: {self.odl:{10}.{5}}"
-            f"\nRight Int. Diam.: {self.idr:{10}.{5}}"
-            f"\nRight Out. Diam.: {self.odr:{10}.{5}}"
-            f"\nAlpha damp. factor: {self.alpha:{10}.{5}}"
-            f"\nBeta damp. factor: {self.beta:{10}.{5}}"
+            f"Element Number:             {self.n}"
+            f"\nElement Lenght   (m): {self.L:{10}.{5}}"
+            f"\nLeft Int. Diam.  (m): {self.idl:{10}.{5}}"
+            f"\nLeft Out. Diam.  (m): {self.odl:{10}.{5}}"
+            f"\nRight Int. Diam. (m): {self.idr:{10}.{5}}"
+            f"\nRight Out. Diam. (m): {self.odr:{10}.{5}}"
+            f"\nAlpha damp. factor:   {self.alpha:{10}.{5}}"
+            f"\nBeta damp. factor:    {self.beta:{10}.{5}}"
             f'\n{35*"-"}'
             f"\n{self.material}"
             f"\n"

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -392,7 +392,6 @@ class ShaftElement(Element):
             f"\nRight Out. Diam. (m): {self.odr:{10}.{5}}"
             f'\n{35*"-"}'
             f"\n{self.material}"
-            f"\n"
         )
 
     def __hash__(self):
@@ -1486,7 +1485,6 @@ class ShaftElement6DoF(ShaftElement):
             f"\nBeta damp. factor:    {self.beta:{10}.{5}}"
             f'\n{35*"-"}'
             f"\n{self.material}"
-            f"\n"
         )
 
     def save(self, file):


### PR DESCRIPTION
`__str__` methods will highlight the unit system ROSS is using.
Since it's automatically converted to the SI, it's important to show the user, what exactly are the units.

- class `Material` - fix `__str__` unit indication
- class `ShaftElement`- format `__str__` output and add unit indication
- class `DiskElement`- add `__str__` method with unit indication
- class `PointMass`- add `__str__` method with unit indication

class `BearingElement `is not included yet. As the parameters are not floats or ints, but list, I need to work around it to convert them to string format.