### PR TITLE
Create script to generate plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ env.bak/
 venv.bak/
 pip-selfcheck.json
 
+/tools/plots/*.html
+!/tools/plots/index.html

--- a/tools/data/c123701
+++ b/tools/data/c123701
@@ -1,0 +1,1363 @@
+[parameters]
+
+["ShaftElement_ShaftElement 0"]
+L = 0.01
+idl = 0.0
+odl = 0.112
+idr = 0.0
+odr = 0.112
+n = 0
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 0"
+
+["ShaftElement_ShaftElement 1"]
+L = 0.0195
+idl = 0.0
+odl = 0.051000000000000004
+idr = 0.0
+odr = 0.051000000000000004
+n = 1
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 1"
+
+["ShaftElement_ShaftElement 2"]
+L = 0.0195
+idl = 0.051000000000000004
+odl = 0.08
+idr = 0.051000000000000004
+odr = 0.08
+n = 1
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 2"
+
+["ShaftElement_ShaftElement 3"]
+L = 0.025
+idl = 0.0
+odl = 0.056
+idr = 0.0
+odr = 0.056
+n = 2
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 3"
+
+["ShaftElement_ShaftElement 4"]
+L = 0.025
+idl = 0.056
+odl = 0.08
+idr = 0.056
+odr = 0.08
+n = 2
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 4"
+
+["ShaftElement_ShaftElement 5"]
+L = 0.006
+idl = 0.0
+odl = 0.0505
+idr = 0.0
+odr = 0.0505
+n = 3
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 5"
+
+["ShaftElement_ShaftElement 6"]
+L = 0.0185
+idl = 0.0
+odl = 0.06089
+idr = 0.0
+odr = 0.06089
+n = 4
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 6"
+
+["ShaftElement_ShaftElement 7"]
+L = 0.0185
+idl = 0.06089
+odl = 0.08
+idr = 0.06089
+odr = 0.08
+n = 4
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 7"
+
+["ShaftElement_ShaftElement 8"]
+L = 0.032
+idl = 0.0
+odl = 0.061810000000000004
+idr = 0.0
+odr = 0.061810000000000004
+n = 5
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 8"
+
+["ShaftElement_ShaftElement 9"]
+L = 0.032
+idl = 0.061810000000000004
+odl = 0.1778
+idr = 0.061810000000000004
+odr = 0.1778
+n = 5
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 9"
+
+["ShaftElement_ShaftElement 10"]
+L = 0.006
+idl = 0.0
+odl = 0.0635
+idr = 0.0
+odr = 0.0635
+n = 6
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 10"
+
+["ShaftElement_ShaftElement 11"]
+L = 0.006
+idl = 0.0635
+odl = 0.08
+idr = 0.0635
+odr = 0.08
+n = 6
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 11"
+
+["ShaftElement_ShaftElement 12"]
+L = 0.0495
+idl = 0.0
+odl = 0.079
+idr = 0.0
+odr = 0.079
+n = 7
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 12"
+
+["ShaftElement_ShaftElement 13"]
+L = 0.045
+idl = 0.0
+odl = 0.09
+idr = 0.0
+odr = 0.09
+n = 8
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 13"
+
+["ShaftElement_ShaftElement 14"]
+L = 0.046
+idl = 0.0
+odl = 0.09
+idr = 0.0
+odr = 0.09
+n = 9
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 14"
+
+["ShaftElement_ShaftElement 15"]
+L = 0.011
+idl = 0.0
+odl = 0.09
+idr = 0.0
+odr = 0.09
+n = 10
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 15"
+
+["ShaftElement_ShaftElement 16"]
+L = 0.0405
+idl = 0.0
+odl = 0.092
+idr = 0.0
+odr = 0.092
+n = 11
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 16"
+
+["ShaftElement_ShaftElement 17"]
+L = 0.02
+idl = 0.0
+odl = 0.095
+idr = 0.0
+odr = 0.095
+n = 12
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 17"
+
+["ShaftElement_ShaftElement 18"]
+L = 0.0045000000000000005
+idl = 0.0
+odl = 0.091
+idr = 0.0
+odr = 0.091
+n = 13
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 18"
+
+["ShaftElement_ShaftElement 19"]
+L = 0.015
+idl = 0.0
+odl = 0.098
+idr = 0.0
+odr = 0.098
+n = 14
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 19"
+
+["ShaftElement_ShaftElement 20"]
+L = 0.085
+idl = 0.0
+odl = 0.1
+idr = 0.0
+odr = 0.1
+n = 15
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 20"
+
+["ShaftElement_ShaftElement 21"]
+L = 0.078
+idl = 0.0
+odl = 0.116
+idr = 0.0
+odr = 0.116
+n = 16
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 21"
+
+["ShaftElement_ShaftElement 22"]
+L = 0.078
+idl = 0.116
+odl = 0.124
+idr = 0.116
+odr = 0.124
+n = 16
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 22"
+
+["ShaftElement_ShaftElement 23"]
+L = 0.02
+idl = 0.0
+odl = 0.135
+idr = 0.0
+odr = 0.135
+n = 17
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 23"
+
+["ShaftElement_ShaftElement 24"]
+L = 0.02
+idl = 0.135
+odl = 0.15
+idr = 0.135
+odr = 0.15
+n = 17
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 24"
+
+["ShaftElement_ShaftElement 25"]
+L = 0.005
+idl = 0.0
+odl = 0.13
+idr = 0.0
+odr = 0.13
+n = 18
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 25"
+
+["ShaftElement_ShaftElement 26"]
+L = 0.211
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 19
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 26"
+
+["ShaftElement_ShaftElement 27"]
+L = 0.211
+idl = 0.14
+odl = 0.15
+idr = 0.14
+odr = 0.15
+n = 19
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 27"
+
+["ShaftElement_ShaftElement 28"]
+L = 0.0175
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 20
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 28"
+
+["ShaftElement_ShaftElement 29"]
+L = 0.0175
+idl = 0.14
+odl = 0.15
+idr = 0.14
+odr = 0.15
+n = 20
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 29"
+
+["ShaftElement_ShaftElement 30"]
+L = 0.031120000000000002
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 21
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 30"
+
+["ShaftElement_ShaftElement 31"]
+L = 0.02888
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 22
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 31"
+
+["ShaftElement_ShaftElement 32"]
+L = 0.01
+idl = 0.0
+odl = 0.15
+idr = 0.0
+odr = 0.15
+n = 23
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 32"
+
+["ShaftElement_ShaftElement 33"]
+L = 0.1375
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 24
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 33"
+
+["ShaftElement_ShaftElement 34"]
+L = 0.1375
+idl = 0.14
+odl = 0.15580000000000002
+idr = 0.14
+odr = 0.15580000000000002
+n = 24
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 34"
+
+["ShaftElement_ShaftElement 35"]
+L = 0.0175
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 25
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 35"
+
+["ShaftElement_ShaftElement 36"]
+L = 0.0175
+idl = 0.14
+odl = 0.15580000000000002
+idr = 0.14
+odr = 0.15580000000000002
+n = 25
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 36"
+
+["ShaftElement_ShaftElement 37"]
+L = 0.03233
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 26
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 37"
+
+["ShaftElement_ShaftElement 38"]
+L = 0.032670000000000005
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 27
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 38"
+
+["ShaftElement_ShaftElement 39"]
+L = 0.011
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 28
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 39"
+
+["ShaftElement_ShaftElement 40"]
+L = 0.0317
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 29
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 40"
+
+["ShaftElement_ShaftElement 41"]
+L = 0.012400000000000001
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 30
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 41"
+
+["ShaftElement_ShaftElement 42"]
+L = 0.0114
+idl = 0.0
+odl = 0.14
+idr = 0.0
+odr = 0.14
+n = 31
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 42"
+
+["ShaftElement_ShaftElement 43"]
+L = 0.005
+idl = 0.0
+odl = 0.13
+idr = 0.0
+odr = 0.13
+n = 32
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 43"
+
+["ShaftElement_ShaftElement 44"]
+L = 0.025
+idl = 0.0
+odl = 0.135
+idr = 0.0
+odr = 0.135
+n = 33
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 44"
+
+["ShaftElement_ShaftElement 45"]
+L = 0.025
+idl = 0.135
+odl = 0.17
+idr = 0.135
+odr = 0.17
+n = 33
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 45"
+
+["ShaftElement_ShaftElement 46"]
+L = 0.074
+idl = 0.0
+odl = 0.116
+idr = 0.0
+odr = 0.116
+n = 34
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 46"
+
+["ShaftElement_ShaftElement 47"]
+L = 0.074
+idl = 0.116
+odl = 0.124
+idr = 0.116
+odr = 0.124
+n = 34
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 47"
+
+["ShaftElement_ShaftElement 48"]
+L = 0.085
+idl = 0.0
+odl = 0.1
+idr = 0.0
+odr = 0.1
+n = 35
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 48"
+
+["ShaftElement_ShaftElement 49"]
+L = 0.015
+idl = 0.0
+odl = 0.098
+idr = 0.0
+odr = 0.098
+n = 36
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 49"
+
+["ShaftElement_ShaftElement 50"]
+L = 0.0045000000000000005
+idl = 0.0
+odl = 0.091
+idr = 0.0
+odr = 0.091
+n = 37
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 50"
+
+["ShaftElement_ShaftElement 51"]
+L = 0.02
+idl = 0.0
+odl = 0.095
+idr = 0.0
+odr = 0.095
+n = 38
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 51"
+
+["ShaftElement_ShaftElement 52"]
+L = 0.0405
+idl = 0.0
+odl = 0.092
+idr = 0.0
+odr = 0.092
+n = 39
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 52"
+
+["ShaftElement_ShaftElement 53"]
+L = 0.045
+idl = 0.0
+odl = 0.09
+idr = 0.0
+odr = 0.09
+n = 40
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 53"
+
+["ShaftElement_ShaftElement 54"]
+L = 0.05
+idl = 0.0
+odl = 0.09
+idr = 0.0
+odr = 0.09
+n = 41
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 54"
+
+["ShaftElement_ShaftElement 55"]
+L = 0.015
+idl = 0.0
+odl = 0.09
+idr = 0.0
+odr = 0.09
+n = 42
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 55"
+
+["ShaftElement_ShaftElement 56"]
+L = 0.01
+idl = 0.0
+odl = 0.07
+idr = 0.0
+odr = 0.07
+n = 43
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 56"
+
+["ShaftElement_ShaftElement 57"]
+L = 0.036000000000000004
+idl = 0.0
+odl = 0.0691
+idr = 0.0
+odr = 0.0691
+n = 44
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 57"
+
+["ShaftElement_ShaftElement 58"]
+L = 0.048
+idl = 0.0
+odl = 0.067
+idr = 0.0
+odr = 0.067
+n = 45
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 58"
+
+["DiskElement_Impeller 1"]
+n = 22
+m = 18.49
+Id = 0.15
+Ip = 0.29
+tag = "Impeller 1"
+scale_factor = 0.5
+color = "Firebrick"
+
+["DiskElement_Impeller 2"]
+n = 27
+m = 19.74
+Id = 0.16
+Ip = 0.3
+tag = "Impeller 2"
+scale_factor = 0.5
+color = "Firebrick"
+
+["DiskElement_Piston 1"]
+n = 31
+m = 11.38
+Id = 0.03
+Ip = 0.1
+tag = "Piston 1"
+scale_factor = 0.5
+color = "Firebrick"
+
+["DiskElement_Piston 2"]
+n = 44
+m = 10.0
+Id = 0.035
+Ip = 0.1
+tag = "Piston 2"
+scale_factor = 0.5
+color = "Firebrick"
+
+["BearingElement_Bearing 0"]
+n = 8
+kxx = [ 35700000.0, 49000000.0, 62700000.0, 75500000.0, 87300000.0, 98200000.0, 108000000.0, 118000000.0, 124000000.0, 126000000.0, 134000000.0, 142000000.0, 149000000.0, 156000000.0, 162000000.0, 168000000.0, 174000000.0, 180000000.0, 185000000.0, 190000000.0, 195000000.0, 200000000.0, 204000000.0, 208000000.0, 213000000.0, 217000000.0, 220000000.0, 224000000.0, 228000000.0, 231000000.0, 235000000.0,]
+cxx = [ 220000.0, 164000.0, 143000.0, 131000.0, 122000.0, 115000.0, 109000.0, 104000.0, 101000.0, 99400.0, 95400.0, 91900.0, 88600.0, 85700.0, 83000.0, 80500.0, 78200.0, 76000.0, 74000.0, 72200.0, 70400.0, 68700.0, 67100.0, 65700.0, 64200.0, 62900.0, 61600.0, 60400.0, 59200.0, 58100.0, 57100.0,]
+kyy = [ 50900000.0, 59700000.0, 71300000.0, 82800000.0, 93800000.0, 104000000.0, 114000000.0, 123000000.0, 130000000.0, 131000000.0, 139000000.0, 146000000.0, 153000000.0, 160000000.0, 166000000.0, 172000000.0, 178000000.0, 183000000.0, 189000000.0, 194000000.0, 198000000.0, 203000000.0, 207000000.0, 212000000.0, 216000000.0, 220000000.0, 224000000.0, 227000000.0, 231000000.0, 234000000.0, 238000000.0,]
+kxy = [ 0.00461, 0.00263, 0.00187, 0.00148, 0.00125, 0.00109, 0.000981, 0.000897, 0.000929, 0.000832, 0.000781, 0.000737, 0.000701, 0.00067, 0.000645, 0.000623, 0.000603, 0.000582, 0.00057, 0.000557, 0.000543, 0.000533, 0.000521, 0.000515, 0.0005, 0.000495, 0.000487, 0.000481, 0.000473, 0.000471, 0.000462,]
+kyx = [ 0.00461, 0.00263, 0.00187, 0.00148, 0.00125, 0.00109, 0.000981, 0.000897, 0.000929, 0.000832, 0.000781, 0.000737, 0.000701, 0.00067, 0.000645, 0.000623, 0.000603, 0.000582, 0.00057, 0.000557, 0.000543, 0.000533, 0.000521, 0.000515, 0.0005, 0.000495, 0.000487, 0.000481, 0.000473, 0.000471, 0.000462,]
+cyy = [ 293000.0, 191000.0, 158000.0, 140000.0, 129000.0, 120000.0, 113000.0, 107000.0, 105000.0, 102000.0, 97600.0, 93800.0, 90300.0, 87200.0, 84300.0, 81700.0, 79300.0, 77100.0, 75000.0, 73000.0, 71200.0, 69500.0, 67900.0, 66300.0, 64900.0, 63500.0, 62200.0, 60900.0, 59800.0, 58600.0, 57500.0,]
+cxy = [ 2e-5, 6.09e-6, 2.94e-6, 1.76e-6, 1.19e-6, 8.66e-7, 6.67e-7, 5.34e-7, 5.09e-7, 4.4e-7, 3.72e-7, 3.19e-7, 2.78e-7, 2.45e-7, 2.19e-7, 1.98e-7, 1.79e-7, 1.62e-7, 1.51e-7, 1.4e-7, 1.29e-7, 1.21e-7, 1.13e-7, 1.07e-7, 9.96e-8, 9.52e-8, 9.01e-8, 8.58e-8, 8.06e-8, 7.85e-8, 7.38e-8,]
+cyx = [ 2e-5, 6.09e-6, 2.94e-6, 1.76e-6, 1.19e-6, 8.66e-7, 6.67e-7, 5.34e-7, 5.09e-7, 4.4e-7, 3.72e-7, 3.19e-7, 2.78e-7, 2.45e-7, 2.19e-7, 1.98e-7, 1.79e-7, 1.62e-7, 1.51e-7, 1.4e-7, 1.29e-7, 1.21e-7, 1.13e-7, 1.07e-7, 9.96e-8, 9.52e-8, 9.01e-8, 8.58e-8, 8.06e-8, 7.85e-8, 7.38e-8,]
+tag = "Bearing 0"
+scale_factor = 0.3
+frequency = [ 104.71975511965977, 209.43951023931953, 314.1592653589793, 418.87902047863906, 523.5987755982989, 628.3185307179587, 733.0382858376183, 837.7580409572781, 905.8258817850569, 942.4777960769379, 1047.1975511965977, 1151.9173063162575, 1256.6370614359173, 1361.3568165555769, 1466.0765716752367, 1570.7963267948965, 1675.5160819145563, 1780.235837034216, 1884.9555921538758, 1989.6753472735356, 2094.3951023931954, 2199.114857512855, 2303.834612632515, 2408.5543677521746, 2513.2741228718346, 2617.993877991494, 2722.7136331111537, 2827.4333882308138, 2932.1531433504733, 3036.8728984701334, 3141.592653589793,]
+
+["BearingElement_Bearing 1"]
+n = 40
+kxx = [ 39000000.0, 51200000.0, 64400000.0, 76900000.0, 88500000.0, 99200000.0, 109000000.0, 118000000.0, 123000000.0, 127000000.0, 135000000.0, 143000000.0, 150000000.0, 157000000.0, 163000000.0, 169000000.0, 175000000.0, 180000000.0, 186000000.0, 191000000.0, 196000000.0, 200000000.0, 205000000.0, 209000000.0, 213000000.0, 217000000.0, 221000000.0, 225000000.0, 228000000.0, 232000000.0, 235000000.0,]
+cxx = [ 234000.0, 169000.0, 146000.0, 133000.0, 123000.0, 116000.0, 110000.0, 104000.0, 101000.0, 99800.0, 95800.0, 92200.0, 88900.0, 85900.0, 83200.0, 80700.0, 78400.0, 76200.0, 74200.0, 72300.0, 70500.0, 68800.0, 67200.0, 65700.0, 64300.0, 63000.0, 61700.0, 60500.0, 59300.0, 58200.0, 57100.0,]
+kyy = [ 57600000.0, 64500000.0, 75100000.0, 86100000.0, 96600000.0, 107000000.0, 116000000.0, 125000000.0, 128000000.0, 133000000.0, 141000000.0, 148000000.0, 155000000.0, 162000000.0, 168000000.0, 174000000.0, 180000000.0, 185000000.0, 190000000.0, 195000000.0, 200000000.0, 204000000.0, 209000000.0, 213000000.0, 217000000.0, 221000000.0, 225000000.0, 228000000.0, 232000000.0, 235000000.0, 239000000.0,]
+kxy = [ 0.00486, 0.00284, 0.00203, 0.00162, 0.00136, 0.00119, 0.00107, 0.000977, 0.000853, 0.000906, 0.00085, 0.000802, 0.000763, 0.00073, 0.000702, 0.000675, 0.000655, 0.000636, 0.000616, 0.000603, 0.000591, 0.000576, 0.000563, 0.000553, 0.000546, 0.000535, 0.00053, 0.000522, 0.000511, 0.000503, 0.000496,]
+kyx = [ 0.00486, 0.00284, 0.00203, 0.00162, 0.00136, 0.00119, 0.00107, 0.000977, 0.000853, 0.000906, 0.00085, 0.000802, 0.000763, 0.00073, 0.000702, 0.000675, 0.000655, 0.000636, 0.000616, 0.000603, 0.000591, 0.000576, 0.000563, 0.000553, 0.000546, 0.000535, 0.00053, 0.000522, 0.000511, 0.000503, 0.000496,]
+cyy = [ 322000.0, 202000.0, 164000.0, 144000.0, 131000.0, 122000.0, 114000.0, 108000.0, 104000.0, 103000.0, 98600.0, 94600.0, 91100.0, 87800.0, 84900.0, 82200.0, 79800.0, 77500.0, 75400.0, 73400.0, 71500.0, 69800.0, 68200.0, 66600.0, 65100.0, 63800.0, 62400.0, 61200.0, 60000.0, 58800.0, 57700.0,]
+cxy = [ 2.06e-5, 6.5e-6, 3.17e-6, 1.9e-6, 1.29e-6, 9.38e-7, 7.22e-7, 5.79e-7, 4.69e-7, 4.77e-7, 4.03e-7, 3.46e-7, 3.02e-7, 2.66e-7, 2.39e-7, 2.14e-7, 1.95e-7, 1.78e-7, 1.62e-7, 1.51e-7, 1.41e-7, 1.31e-7, 1.22e-7, 1.15e-7, 1.09e-7, 1.02e-7, 9.8e-8, 9.27e-8, 8.67e-8, 8.3e-8, 7.89e-8,]
+cyx = [ 2.06e-5, 6.5e-6, 3.17e-6, 1.9e-6, 1.29e-6, 9.38e-7, 7.22e-7, 5.79e-7, 4.69e-7, 4.77e-7, 4.03e-7, 3.46e-7, 3.02e-7, 2.66e-7, 2.39e-7, 2.14e-7, 1.95e-7, 1.78e-7, 1.62e-7, 1.51e-7, 1.41e-7, 1.31e-7, 1.22e-7, 1.15e-7, 1.09e-7, 1.02e-7, 9.8e-8, 9.27e-8, 8.67e-8, 8.3e-8, 7.89e-8,]
+tag = "Bearing 1"
+scale_factor = 0.3
+frequency = [ 104.71975511965977, 209.43951023931953, 314.1592653589793, 418.87902047863906, 523.5987755982989, 628.3185307179587, 733.0382858376183, 837.7580409572781, 905.8258817850569, 942.4777960769379, 1047.1975511965977, 1151.9173063162575, 1256.6370614359173, 1361.3568165555769, 1466.0765716752367, 1570.7963267948965, 1675.5160819145563, 1780.235837034216, 1884.9555921538758, 1989.6753472735356, 2094.3951023931954, 2199.114857512855, 2303.834612632515, 2408.5543677521746, 2513.2741228718346, 2617.993877991494, 2722.7136331111537, 2827.4333882308138, 2932.1531433504733, 3036.8728984701334, 3141.592653589793,]
+
+["ShaftElement_ShaftElement 0".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 1".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 2".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 3".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 4".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 5".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 6".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 7".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 8".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 9".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 10".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 11".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 12".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 13".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 14".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 15".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 16".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 17".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 18".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 19".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 20".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 21".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 22".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 23".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 24".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 25".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 26".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 27".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 28".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 29".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 30".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 31".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 32".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 33".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 34".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 35".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 36".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 37".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 38".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 39".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 40".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 41".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 42".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 43".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 44".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 45".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 46".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 47".material]
+name = "Shaft_mass_only"
+rho = 7833.0
+E = 1.0
+G_s = 1.0
+color = "blue"
+
+["ShaftElement_ShaftElement 48".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 49".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 50".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 51".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 52".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 53".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 54".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 55".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 56".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 57".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 58".material]
+name = "Shaft"
+rho = 7833.0
+E = 200000000000.0
+G_s = 80000000000.0
+color = "#525252"

--- a/tools/data/injection
+++ b/tools/data/injection
@@ -1,0 +1,2094 @@
+[parameters]
+
+["ShaftElement_ShaftElement 0"]
+L = 0.035500000000000004
+idl = 0.1409954
+odl = 0.151003
+idr = 0.1409954
+odr = 0.151003
+n = 0
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 0"
+
+["ShaftElement_ShaftElement 1"]
+L = 0.036000000000000004
+idl = 0.1409954
+odl = 0.151003
+idr = 0.1409954
+odr = 0.151003
+n = 1
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 1"
+
+["ShaftElement_ShaftElement 2"]
+L = 0.054000000000000006
+idl = 0.0
+odl = 0.08
+idr = 0.0
+odr = 0.08
+n = 2
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 2"
+
+["ShaftElement_ShaftElement 3"]
+L = 0.043000000000000003
+idl = 0.0
+odl = 0.08
+idr = 0.0
+odr = 0.08
+n = 3
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 3"
+
+["ShaftElement_ShaftElement 4"]
+L = 0.0165
+idl = 0.0
+odl = 0.088
+idr = 0.0
+odr = 0.088
+n = 4
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 4"
+
+["ShaftElement_ShaftElement 5"]
+L = 0.014
+idl = 0.0
+odl = 0.088
+idr = 0.0
+odr = 0.088
+n = 5
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 5"
+
+["ShaftElement_ShaftElement 6"]
+L = 0.036500000000000005
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 6
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 6"
+
+["ShaftElement_ShaftElement 7"]
+L = 0.051
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 7
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 7"
+
+["ShaftElement_ShaftElement 8"]
+L = 0.025
+idl = 0.0
+odl = 0.103
+idr = 0.0
+odr = 0.103
+n = 8
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 8"
+
+["ShaftElement_ShaftElement 9"]
+L = 0.025
+idl = 0.103
+odl = 0.13799999999999998
+idr = 0.103
+odr = 0.13799999999999998
+n = 8
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 9"
+
+["ShaftElement_ShaftElement 10"]
+L = 0.016
+idl = 0.0
+odl = 0.085
+idr = 0.0
+odr = 0.085
+n = 9
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 10"
+
+["ShaftElement_ShaftElement 11"]
+L = 0.016
+idl = 0.085
+odl = 0.13799999999999998
+idr = 0.085
+odr = 0.13799999999999998
+n = 9
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 11"
+
+["ShaftElement_ShaftElement 12"]
+L = 0.0242
+idl = 0.0
+odl = 0.104
+idr = 0.0
+odr = 0.104
+n = 10
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 12"
+
+["ShaftElement_ShaftElement 13"]
+L = 0.0242
+idl = 0.104
+odl = 0.174
+idr = 0.104
+odr = 0.174
+n = 10
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 13"
+
+["ShaftElement_ShaftElement 14"]
+L = 0.0045000000000000005
+idl = 0.0
+odl = 0.0982
+idr = 0.0
+odr = 0.0982
+n = 11
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 14"
+
+["ShaftElement_ShaftElement 15"]
+L = 0.0045000000000000005
+idl = 0.0982
+odl = 0.174
+idr = 0.0982
+odr = 0.174
+n = 11
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 15"
+
+["ShaftElement_ShaftElement 16"]
+L = 0.01257
+idl = 0.0
+odl = 0.104
+idr = 0.0
+odr = 0.104
+n = 12
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 16"
+
+["ShaftElement_ShaftElement 17"]
+L = 0.01257
+idl = 0.104
+odl = 0.174
+idr = 0.104
+odr = 0.174
+n = 12
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 17"
+
+["ShaftElement_ShaftElement 18"]
+L = 0.02
+idl = 0.0
+odl = 0.10600000000000001
+idr = 0.0
+odr = 0.10600000000000001
+n = 13
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 18"
+
+["ShaftElement_ShaftElement 19"]
+L = 0.02
+idl = 0.10600000000000001
+odl = 0.184
+idr = 0.10600000000000001
+odr = 0.184
+n = 13
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 19"
+
+["ShaftElement_ShaftElement 20"]
+L = 0.06273000000000001
+idl = 0.0
+odl = 0.10800000000000001
+idr = 0.0
+odr = 0.10800000000000001
+n = 14
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 20"
+
+["ShaftElement_ShaftElement 21"]
+L = 0.06273000000000001
+idl = 0.10800000000000001
+odl = 0.184
+idr = 0.10800000000000001
+odr = 0.184
+n = 14
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 21"
+
+["ShaftElement_ShaftElement 22"]
+L = 0.038
+idl = 0.0
+odl = 0.11
+idr = 0.0
+odr = 0.11
+n = 15
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 22"
+
+["ShaftElement_ShaftElement 23"]
+L = 0.038
+idl = 0.11
+odl = 0.184
+idr = 0.11
+odr = 0.184
+n = 15
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 23"
+
+["ShaftElement_ShaftElement 24"]
+L = 0.038
+idl = 0.0
+odl = 0.122
+idr = 0.0
+odr = 0.122
+n = 16
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 24"
+
+["ShaftElement_ShaftElement 25"]
+L = 0.038
+idl = 0.122
+odl = 0.13899999999999998
+idr = 0.122
+odr = 0.13899999999999998
+n = 16
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 25"
+
+["ShaftElement_ShaftElement 26"]
+L = 0.030000000000000002
+idl = 0.0
+odl = 0.135
+idr = 0.0
+odr = 0.135
+n = 17
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 26"
+
+["ShaftElement_ShaftElement 27"]
+L = 0.030000000000000002
+idl = 0.135
+odl = 0.175
+idr = 0.135
+odr = 0.175
+n = 17
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 27"
+
+["ShaftElement_ShaftElement 28"]
+L = 0.053000000000000005
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 18
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 28"
+
+["ShaftElement_ShaftElement 29"]
+L = 0.053000000000000005
+idl = 0.11770000000000001
+odl = 0.1965
+idr = 0.11770000000000001
+odr = 0.1965
+n = 18
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 29"
+
+["ShaftElement_ShaftElement 30"]
+L = 0.01949
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 19
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 30"
+
+["ShaftElement_ShaftElement 31"]
+L = 0.01949
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 19
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 31"
+
+["ShaftElement_ShaftElement 32"]
+L = 0.013510000000000003
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 20
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 32"
+
+["ShaftElement_ShaftElement 33"]
+L = 0.013510000000000003
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 20
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 33"
+
+["ShaftElement_ShaftElement 34"]
+L = 0.0495
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 21
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 34"
+
+["ShaftElement_ShaftElement 35"]
+L = 0.01959
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 22
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 35"
+
+["ShaftElement_ShaftElement 36"]
+L = 0.01959
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 22
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 36"
+
+["ShaftElement_ShaftElement 37"]
+L = 0.012410000000000001
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 23
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 37"
+
+["ShaftElement_ShaftElement 38"]
+L = 0.012410000000000001
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 23
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 38"
+
+["ShaftElement_ShaftElement 39"]
+L = 0.049
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 24
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 39"
+
+["ShaftElement_ShaftElement 40"]
+L = 0.019700000000000002
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 25
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 40"
+
+["ShaftElement_ShaftElement 41"]
+L = 0.019700000000000002
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 25
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 41"
+
+["ShaftElement_ShaftElement 42"]
+L = 0.0123
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 26
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 42"
+
+["ShaftElement_ShaftElement 43"]
+L = 0.0123
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 26
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 43"
+
+["ShaftElement_ShaftElement 44"]
+L = 0.0495
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 27
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 44"
+
+["ShaftElement_ShaftElement 45"]
+L = 0.019829999999999997
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 28
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 45"
+
+["ShaftElement_ShaftElement 46"]
+L = 0.019829999999999997
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 28
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 46"
+
+["ShaftElement_ShaftElement 47"]
+L = 0.011670000000000002
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 29
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 47"
+
+["ShaftElement_ShaftElement 48"]
+L = 0.011670000000000002
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 29
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 48"
+
+["ShaftElement_ShaftElement 49"]
+L = 0.0495
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 30
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 49"
+
+["ShaftElement_ShaftElement 50"]
+L = 0.01998
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 31
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 50"
+
+["ShaftElement_ShaftElement 51"]
+L = 0.01998
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 31
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 51"
+
+["ShaftElement_ShaftElement 52"]
+L = 0.01202
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 32
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 52"
+
+["ShaftElement_ShaftElement 53"]
+L = 0.01202
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 32
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 53"
+
+["ShaftElement_ShaftElement 54"]
+L = 0.0495
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 33
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 54"
+
+["ShaftElement_ShaftElement 55"]
+L = 0.020100000000000003
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 34
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 55"
+
+["ShaftElement_ShaftElement 56"]
+L = 0.020100000000000003
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 34
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 56"
+
+["ShaftElement_ShaftElement 57"]
+L = 0.012399999999999998
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 35
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 57"
+
+["ShaftElement_ShaftElement 58"]
+L = 0.012399999999999998
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 35
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 58"
+
+["ShaftElement_ShaftElement 59"]
+L = 0.056999999999999995
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 36
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 59"
+
+["ShaftElement_ShaftElement 60"]
+L = 0.026
+idl = 0.0
+odl = 0.135
+idr = 0.0
+odr = 0.135
+n = 37
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 60"
+
+["ShaftElement_ShaftElement 61"]
+L = 0.026
+idl = 0.135
+odl = 0.175
+idr = 0.135
+odr = 0.175
+n = 37
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 61"
+
+["ShaftElement_ShaftElement 62"]
+L = 0.038
+idl = 0.0
+odl = 0.122
+idr = 0.0
+odr = 0.122
+n = 38
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 62"
+
+["ShaftElement_ShaftElement 63"]
+L = 0.038
+idl = 0.122
+odl = 0.13899999999999998
+idr = 0.122
+odr = 0.13899999999999998
+n = 38
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 63"
+
+["ShaftElement_ShaftElement 64"]
+L = 0.038
+idl = 0.0
+odl = 0.11
+idr = 0.0
+odr = 0.11
+n = 39
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 64"
+
+["ShaftElement_ShaftElement 65"]
+L = 0.038
+idl = 0.11
+odl = 0.184
+idr = 0.11
+odr = 0.184
+n = 39
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 65"
+
+["ShaftElement_ShaftElement 66"]
+L = 0.06273000000000001
+idl = 0.0
+odl = 0.10800000000000001
+idr = 0.0
+odr = 0.10800000000000001
+n = 40
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 66"
+
+["ShaftElement_ShaftElement 67"]
+L = 0.06273000000000001
+idl = 0.10800000000000001
+odl = 0.184
+idr = 0.10800000000000001
+odr = 0.184
+n = 40
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 67"
+
+["ShaftElement_ShaftElement 68"]
+L = 0.02
+idl = 0.0
+odl = 0.10600000000000001
+idr = 0.0
+odr = 0.10600000000000001
+n = 41
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 68"
+
+["ShaftElement_ShaftElement 69"]
+L = 0.02
+idl = 0.10600000000000001
+odl = 0.184
+idr = 0.10600000000000001
+odr = 0.184
+n = 41
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 69"
+
+["ShaftElement_ShaftElement 70"]
+L = 0.01257
+idl = 0.0
+odl = 0.104
+idr = 0.0
+odr = 0.104
+n = 42
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 70"
+
+["ShaftElement_ShaftElement 71"]
+L = 0.01257
+idl = 0.104
+odl = 0.174
+idr = 0.104
+odr = 0.174
+n = 42
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 71"
+
+["ShaftElement_ShaftElement 72"]
+L = 0.0045000000000000005
+idl = 0.0
+odl = 0.0982
+idr = 0.0
+odr = 0.0982
+n = 43
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 72"
+
+["ShaftElement_ShaftElement 73"]
+L = 0.0045000000000000005
+idl = 0.0982
+odl = 0.174
+idr = 0.0982
+odr = 0.174
+n = 43
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 73"
+
+["ShaftElement_ShaftElement 74"]
+L = 0.0242
+idl = 0.0
+odl = 0.104
+idr = 0.0
+odr = 0.104
+n = 44
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 74"
+
+["ShaftElement_ShaftElement 75"]
+L = 0.0242
+idl = 0.104
+odl = 0.174
+idr = 0.104
+odr = 0.174
+n = 44
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 75"
+
+["ShaftElement_ShaftElement 76"]
+L = 0.016
+idl = 0.0
+odl = 0.085
+idr = 0.0
+odr = 0.085
+n = 45
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 76"
+
+["ShaftElement_ShaftElement 77"]
+L = 0.016
+idl = 0.085
+odl = 0.13799999999999998
+idr = 0.085
+odr = 0.13799999999999998
+n = 45
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 77"
+
+["ShaftElement_ShaftElement 78"]
+L = 0.025
+idl = 0.0
+odl = 0.103
+idr = 0.0
+odr = 0.103
+n = 46
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 78"
+
+["ShaftElement_ShaftElement 79"]
+L = 0.025
+idl = 0.103
+odl = 0.13799999999999998
+idr = 0.103
+odr = 0.13799999999999998
+n = 46
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 79"
+
+["ShaftElement_ShaftElement 80"]
+L = 0.051
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 47
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 80"
+
+["ShaftElement_ShaftElement 81"]
+L = 0.050499999999999996
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 48
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 81"
+
+["ShaftElement_ShaftElement 82"]
+L = 0.036375000000000005
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 49
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 82"
+
+["ShaftElement_ShaftElement 83"]
+L = 0.036375000000000005
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 50
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 83"
+
+["ShaftElement_ShaftElement 84"]
+L = 0.013500000000000002
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 51
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 84"
+
+["ShaftElement_ShaftElement 85"]
+L = 0.034999999999999996
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 52
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 85"
+
+["ShaftElement_ShaftElement 86"]
+L = 0.034999999999999996
+idl = 0.09000000000000001
+odl = 0.245
+idr = 0.09000000000000001
+odr = 0.245
+n = 52
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 86"
+
+["ShaftElement_ShaftElement 87"]
+L = 0.024
+idl = 0.0
+odl = 0.0872
+idr = 0.0
+odr = 0.0872
+n = 53
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 87"
+
+["ShaftElement_ShaftElement 88"]
+L = 0.024
+idl = 0.0872
+odl = 0.112
+idr = 0.0872
+odr = 0.112
+n = 53
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 88"
+
+["ShaftElement_ShaftElement 89"]
+L = 0.032
+idl = 0.0
+odl = 0.085
+idr = 0.0
+odr = 0.085
+n = 54
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 89"
+
+["ShaftElement_ShaftElement 90"]
+L = 0.032
+idl = 0.085
+odl = 0.113
+idr = 0.085
+odr = 0.113
+n = 54
+axial_force = 0.0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 90"
+
+["DiskElement_Disk 0"]
+n = 3
+m = 15.119982018530925
+Id = 0.0
+Ip = 0.0
+tag = "Disk 0"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 1"]
+n = 20
+m = 6.909991782278354
+Id = 0.024999843771375
+Ip = 0.046999706290185
+tag = "Disk 1"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 2"]
+n = 23
+m = 6.929991758493341
+Id = 0.024999843771375
+Ip = 0.046999706290185
+tag = "Disk 2"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 3"]
+n = 26
+m = 6.94999173470833
+Id = 0.024999843771375
+Ip = 0.04799970004104
+tag = "Disk 3"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 4"]
+n = 29
+m = 6.979991699030812
+Id = 0.024999843771375
+Ip = 0.04799970004104
+tag = "Disk 4"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 5"]
+n = 32
+m = 6.939991746600836
+Id = 0.024999843771375
+Ip = 0.04799970004104
+tag = "Disk 5"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 6"]
+n = 35
+m = 6.959991722815824
+Id = 0.024999843771375
+Ip = 0.04799970004104
+tag = "Disk 6"
+scale_factor = 1
+color = "Firebrick"
+
+["BearingElement_Bearing 0"]
+n = 7
+kxx = [ 51697442.27838528, 66373071.217845604, 81153776.25949776, 96022044.71964313, 110977876.59828168, 119961883.335684, 126003759.2117148, 141064667.1925452, 156178113.22447154, 169260087.9473556, 171309071.9400965, 177403485.8672232, 186510081.390516, 201570989.3713464, 216807024.1891632, 231867932.1699936, 247103966.9878104, 262340001.8056272, 277400909.7864576, 292636944.6042744, 307872979.4220912,]
+cxx = [ 113955.0328270505, 110662.64829170617, 108788.79113595169, 107632.95401184144, 106897.42129649856, 106617.21835732032, 106372.04078553936, 106004.27442786792, 105741.58417238832, 105566.45733540192, 105548.94465170329, 105478.89391690871, 105391.33049841551, 105268.74171252505, 105163.6656103332, 105093.61487553865, 105023.5641407441, 104988.53877334681, 104936.00072225089, 104900.97535485361, 104865.94998745632,]
+kyy = [ 72590073.9308628, 81889308.97484064, 93395142.16484712, 106109350.53005977, 119506553.55951937, 127877616.36746928, 133394111.73254089, 147596898.21213794, 161992324.21242002, 174601456.4754408, 176527851.6822912, 182482164.1398288, 191238505.9891488, 205949160.2960064, 220834941.43985042, 235720722.5836944, 250606503.7275384, 265667411.7083688, 280553192.8522128, 295614100.8330432, 310675008.8138736,]
+kxy = [ 35904.50411895173, 63924.798036775726, 99969.40362531658, 144090.8589356702, 196290.91523620643, 230971.28276462326, 256539.80096463766, 324930.3333445666, 401441.4971555549, 474131.39338349993, 486031.2619567258, 522891.9586056233, 578811.7089237507, 679761.822836191, 788832.568179691, 906141.2799350308, 1031701.9682491701, 1165402.5519464372, 1307302.5741514077, 1457603.4307266152, 1616003.9035124446,]
+kyx = [ -35834.45338415717, -63849.493496871575, -99894.09908541242, -144020.80820087565, -196220.8645014119, -231661.28250234964, -256480.25784006226, -324870.7902199912, -401380.20276260964, -474080.60660077387, -485980.47517399973, -522851.6794331164, -578771.4297512438, -679732.0512739033, -788801.0453490333, -906122.0159829624, -1031701.9682491701, -1165302.729649355, -1307402.3964484897, -1457603.4307266152, -1616003.9035124446,]
+cyy = [ 147666.9489469325, 129786.49889062105, 120995.13167390376, 116074.06755458591, 113044.3732747212, 111748.43468102186, 111065.4400167749, 109681.93800458232, 108718.74040115712, 108070.77110430745, 107983.20768581425, 107738.03011403329, 107422.80180745776, 107002.49739869041, 106652.2437247176, 106389.553469238, 106161.8885811557, 105986.76174416929, 105829.14759088152, 105706.55880499104, 105583.97001910055,]
+cxy = [ -36.9517626041304, -49.210641193178404, -61.4695197822264, -73.7283983712744, -86.1624037973088, -92.9923504397784, -98.42128238635681, -110.85528781239121, -123.464420075412, -134.14715713158242, -135.8984255014464, -140.977103774052, -148.5075577644672, -161.116690027488, -173.7258222905088, -186.33495455352963, -198.9440868165504, -211.72834591655763, -224.5126050165648, -237.296864116572, -250.0811232165792,]
+cyx = [ 36.6015089301576, 48.86038751920561, 61.29439294524, 73.553271534288, 85.9872769603224, 93.51773095073762, 98.42128238635681, 110.85528781239121, 123.2892932384256, 134.14715713158242, 135.8984255014464, 140.977103774052, 148.5075577644672, 160.94156319050163, 173.5506954535224, 186.33495455352963, 198.9440868165504, 211.72834591655763, 224.5126050165648, 237.296864116572, 250.0811232165792,]
+tag = "Bearing 0"
+scale_factor = 0.5
+frequency = [ 314.1592653591, 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 796.4984574404382, 837.7580409576, 942.4777960773, 1047.197551197, 1137.7801393755406, 1151.9173063167, 1194.6429664055377, 1256.6370614364, 1361.3568165561, 1466.0765716757999, 1570.7963267955, 1675.5160819152, 1780.2358370349, 1884.9555921546, 1989.6753472743, 2094.395102394,]
+
+["BearingElement_Bearing 1"]
+n = 48
+kxx = [ 51732467.64578256, 66408096.58524288, 81188801.62689504, 96057070.08704041, 110995389.28198032, 120101984.80527313, 126021271.89541344, 141082179.87624386, 156195625.90817016, 169277600.63105425, 171326584.62379512, 177578612.7042096, 186510081.390516, 201570989.3713464, 216807024.1891632, 232043059.00698, 247103966.9878104, 262340001.8056272, 277400909.7864576, 292636944.6042744, 307872979.4220912,]
+cxx = [ 114025.08356184505, 110715.18634280209, 108823.81650334896, 107667.97937923872, 106914.93398019721, 106564.6803062244, 106389.553469238, 106021.78711156656, 105759.09685608697, 105583.97001910055, 105548.94465170329, 105496.40660060736, 105408.84318211416, 105286.2543962237, 105181.17829403185, 105093.61487553865, 105041.07682444272, 104988.53877334681, 104936.00072225089, 104900.97535485361, 104865.94998745632,]
+kyy = [ 72835251.50264376, 82064435.81182705, 93552756.31813489, 106231939.31595024, 119611629.6617112, 127982692.46966113, 133499187.83473273, 147684461.63063112, 162079887.6309132, 174671507.21023536, 176702978.5192776, 182657290.9768152, 191238505.9891488, 206124287.1329928, 220834941.43985042, 235720722.5836944, 250781630.5645248, 265667411.7083688, 280728319.6891992, 295614100.8330432, 310675008.8138736,]
+kxy = [ 35902.75285058186, 63924.798036775726, 99969.40362531658, 144090.8589356702, 196290.91523620643, 231850.419486295, 256539.80096463766, 324930.3333445666, 401441.4971555549, 474131.39338349993, 486031.2619567258, 522891.9586056233, 578811.7089237507, 679761.822836191, 788832.568179691, 906141.2799350308, 1031701.9682491701, 1165402.5519464372, 1307302.5741514077, 1457603.4307266152, 1616003.9035124446,]
+kyx = [ -35832.70211578731, -63847.74222850171, -99892.34781704257, -144020.80820087565, -196220.8645014119, -231790.8763617196, -256480.25784006226, -324870.7902199912, -401380.20276260964, -474080.60660077387, -485980.47517399973, -522851.6794331164, -578771.4297512438, -679732.0512739033, -788801.0453490333, -906122.0159829624, -1031701.9682491701, -1165302.729649355, -1307402.3964484897, -1457603.4307266152, -1616003.9035124446,]
+cyy = [ 148052.22798830256, 130014.16377870337, 121152.74582719152, 116196.6563404764, 113114.42400951576, 111818.48541581641, 111117.9780678708, 109734.47605567824, 108753.76576855441, 108105.79647170471, 108018.23305321152, 107773.05548143057, 107457.82717485505, 107037.5227660877, 106687.26909211489, 106407.06615293665, 106179.40126485431, 106004.27442786792, 105846.66027458016, 105706.55880499104, 105601.4827027992,]
+cxy = [ -36.9517626041304, -49.210641193178404, -61.4695197822264, -73.7283983712744, -86.1624037973088, -93.51773095073762, -98.42128238635681, -110.85528781239121, -123.464420075412, -134.14715713158242, -135.8984255014464, -140.977103774052, -148.5075577644672, -161.116690027488, -173.7258222905088, -186.33495455352963, -198.9440868165504, -211.72834591655763, -224.5126050165648, -237.296864116572, -250.0811232165792,]
+cyx = [ 36.6015089301576, 48.86038751920561, 61.29439294524, 73.553271534288, 85.9872769603224, 93.51773095073762, 98.42128238635681, 110.85528781239121, 123.2892932384256, 134.14715713158242, 135.8984255014464, 140.977103774052, 148.5075577644672, 160.94156319050163, 173.5506954535224, 186.33495455352963, 198.9440868165504, 211.72834591655763, 224.5126050165648, 237.296864116572, 250.0811232165792,]
+tag = "Bearing 1"
+scale_factor = 0.5
+frequency = [ 314.1592653591, 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 796.4984574404382, 837.7580409576, 942.4777960773, 1047.197551197, 1137.7801393755406, 1151.9173063167, 1194.6429664055377, 1256.6370614364, 1361.3568165561, 1466.0765716757999, 1570.7963267955, 1675.5160819152, 1780.2358370349, 1884.9555921546, 1989.6753472743, 2094.395102394,]
+
+["ShaftElement_ShaftElement 0".material]
+name = "shaft_mat_3"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 1".material]
+name = "shaft_mat_3"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 2".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 3".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 4".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 5".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 6".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 7".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 8".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 9".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 10".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 11".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 12".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 13".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 14".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 15".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 16".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 17".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 18".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 19".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 20".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 21".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 22".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 23".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 24".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 25".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 26".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 27".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 28".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 29".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 30".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 31".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 32".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 33".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 34".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 35".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 36".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 37".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 38".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 39".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 40".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 41".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 42".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 43".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 44".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 45".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 46".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 47".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 48".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 49".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 50".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 51".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 52".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 53".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 54".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 55".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 56".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 57".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 58".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 59".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 60".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 61".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 62".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 63".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 64".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 65".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 66".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 67".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 68".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 69".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 70".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 71".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 72".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 73".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 74".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 75".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 76".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 77".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 78".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 79".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 80".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 81".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 82".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 83".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 84".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 85".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 86".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 87".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 88".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"
+
+["ShaftElement_ShaftElement 89".material]
+name = "shaft_mat_1"
+rho = 7833.412831999999
+E = 206842710000.0
+G_s = 82737084000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 90".material]
+name = "shaft_mat_2"
+rho = 7833.412831999999
+E = 6894.757
+G_s = 6894.757
+color = "#525252"

--- a/tools/data/rotor_example
+++ b/tools/data/rotor_example
@@ -1,0 +1,179 @@
+[parameters]
+
+["ShaftElement_ShaftElement 0"]
+L = 0.25
+idl = 0.0
+odl = 0.05
+idr = 0.0
+odr = 0.05
+n = 0
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 0"
+
+["ShaftElement_ShaftElement 1"]
+L = 0.25
+idl = 0.0
+odl = 0.05
+idr = 0.0
+odr = 0.05
+n = 1
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 1"
+
+["ShaftElement_ShaftElement 2"]
+L = 0.25
+idl = 0.0
+odl = 0.05
+idr = 0.0
+odr = 0.05
+n = 2
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 2"
+
+["ShaftElement_ShaftElement 3"]
+L = 0.25
+idl = 0.0
+odl = 0.05
+idr = 0.0
+odr = 0.05
+n = 3
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 3"
+
+["ShaftElement_ShaftElement 4"]
+L = 0.25
+idl = 0.0
+odl = 0.05
+idr = 0.0
+odr = 0.05
+n = 4
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 4"
+
+["ShaftElement_ShaftElement 5"]
+L = 0.25
+idl = 0.0
+odl = 0.05
+idr = 0.0
+odr = 0.05
+n = 5
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 5"
+
+["DiskElement_Disk 0"]
+n = 2
+m = 32.58972765304033
+Id = 0.17808928257067666
+Ip = 0.32956362089137037
+tag = "Disk 0"
+scale_factor = 1.0
+color = "Firebrick"
+
+["DiskElement_Disk 1"]
+n = 4
+m = 32.58972765304033
+Id = 0.17808928257067666
+Ip = 0.32956362089137037
+tag = "Disk 1"
+scale_factor = 1.0
+color = "Firebrick"
+
+["BearingElement_Bearing 0"]
+n = 0
+kxx = [ 1000000.0, 1000000.0,]
+cxx = [ 0.0, 0.0,]
+kyy = [ 800000.0, 800000.0,]
+kxy = [ 0.0, 0.0,]
+kyx = [ 0.0, 0.0,]
+cyy = [ 0.0, 0.0,]
+cxy = [ 0.0, 0.0,]
+cyx = [ 0.0, 0.0,]
+tag = "Bearing 0"
+scale_factor = 1
+frequency = [ 0.0, 1000.0,]
+
+["BearingElement_Bearing 1"]
+n = 6
+kxx = [ 1000000.0, 1000000.0,]
+cxx = [ 0.0, 0.0,]
+kyy = [ 800000.0, 800000.0,]
+kxy = [ 0.0, 0.0,]
+kyx = [ 0.0, 0.0,]
+cyy = [ 0.0, 0.0,]
+cxy = [ 0.0, 0.0,]
+cyx = [ 0.0, 0.0,]
+tag = "Bearing 1"
+scale_factor = 1
+frequency = [ 0.0, 1000.0,]
+
+["ShaftElement_ShaftElement 0".material]
+name = "Steel"
+rho = 7810.0
+E = 211000000000.0
+G_s = 81200000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 1".material]
+name = "Steel"
+rho = 7810.0
+E = 211000000000.0
+G_s = 81200000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 2".material]
+name = "Steel"
+rho = 7810.0
+E = 211000000000.0
+G_s = 81200000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 3".material]
+name = "Steel"
+rho = 7810.0
+E = 211000000000.0
+G_s = 81200000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 4".material]
+name = "Steel"
+rho = 7810.0
+E = 211000000000.0
+G_s = 81200000000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 5".material]
+name = "Steel"
+rho = 7810.0
+E = 211000000000.0
+G_s = 81200000000.0
+color = "#525252"

--- a/tools/generate_comparison_plots.py
+++ b/tools/generate_comparison_plots.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+import numpy as np
+import plotly.io as pio
+from jinja2 import Environment, FileSystemLoader
+
+import ross as rs
+
+dir_path = Path(__file__).parent
+rotors = {
+    k: rs.Rotor.load((dir_path / "data" / k))
+    for k in ["rotor_example", "c123701", "injection"]
+}
+
+env = Environment(loader=FileSystemLoader(dir_path / "plots/templates/"))
+template = env.get_template("template.html")
+
+
+# plot_rotor
+kwargs = {
+    rotor: pio.to_html(
+        rotors[rotor].plot_rotor(), include_plotlyjs=False, full_html=False
+    )
+    for rotor in rotors
+}
+output = template.render(**kwargs)
+
+with open(f"{dir_path}/plots/plot_rotor.html", "w") as f:
+    f.write(output)
+
+# plot_ucs
+kwargs = {
+    rotor: pio.to_html(
+        rotors[rotor].plot_ucs(), include_plotlyjs=False, full_html=False
+    )
+    for rotor in rotors
+}
+output = template.render(**kwargs)
+
+with open(f"{dir_path}/plots/plot_ucs.html", "w") as f:
+    f.write(output)
+
+    # plot_mode_2d
+    kwargs = {
+        rotor: pio.to_html(
+            rotors[rotor].run_modal(speed=100).plot_mode_2d(0),
+            include_plotlyjs=False,
+            full_html=False,
+        )
+        for rotor in rotors
+    }
+    output = template.render(**kwargs)
+
+    with open(f"{dir_path}/plots/plot_mode_2d.html", "w") as f:
+        f.write(output)
+
+# plot_mode_3d
+kwargs = {
+    rotor: pio.to_html(
+        rotors[rotor].run_modal(speed=100).plot_mode_3d(0),
+        include_plotlyjs=False,
+        full_html=False,
+    )
+    for rotor in rotors
+}
+output = template.render(**kwargs)
+
+with open(f"{dir_path}/plots/plot_mode_3d.html", "w") as f:
+    f.write(output)
+
+# unbalance.plot
+kwargs = {
+    rotor: pio.to_html(
+        rotors[rotor]
+        .run_unbalance_response(
+            node=0,
+            unbalance_magnitude=0.5,
+            unbalance_phase=0,
+            frequency=np.linspace(0, 2000),
+        )
+        .plot(0),
+        include_plotlyjs=False,
+        full_html=False,
+    )
+    for rotor in rotors
+}
+output = template.render(**kwargs)
+
+with open(f"{dir_path}/plots/plot_unbalance.html", "w") as f:
+    f.write(output)
+
+# campbell.plot
+kwargs = {
+    rotor: pio.to_html(
+        rotors[rotor].run_campbell(speed_range=np.linspace(0, 2000)).plot(),
+        include_plotlyjs=False,
+        full_html=False,
+    )
+    for rotor in rotors
+}
+output = template.render(**kwargs)
+
+with open(f"{dir_path}/plots/plot_campbell.html", "w") as f:
+    f.write(output)
+
+# static.plot_deformation
+kwargs = {
+    rotor: pio.to_html(
+        rotors[rotor].run_static().plot_deformation(),
+        include_plotlyjs=False,
+        full_html=False,
+    )
+    for rotor in rotors
+}
+output = template.render(**kwargs)
+
+with open(f"{dir_path}/plots/plot_deformation.html", "w") as f:
+    f.write(output)

--- a/tools/plots/index.html
+++ b/tools/plots/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ROSS Plots</title>
+</head>
+<body>
+<a href="plot_rotor.html">plot_rotor</a><br>
+<a href="plot_ucs.html">plot_ucs</a><br>
+<a href="plot_mode_2d.html">plot_mode_2d</a><br>
+<a href="plot_mode_3d.html">plot_mode_3d</a><br>
+<a href="plot_unbalance.html">plot_unbalance</a><br>
+<a href="plot_campbell.html">plot_campbell</a><br>
+<a href="plot_deformation.html">plot_deformation</a><br>
+</body>
+</html>

--- a/tools/plots/templates/template.html
+++ b/tools/plots/templates/template.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>ross-bott report</title>
+        <link rel="stylesheet" href="static/bootstrap-sphinx.css" type="text/css" />
+        <link rel="stylesheet" href="static/pygments.css" type="text/css" />
+        <link rel="stylesheet" type="text/css" href="static/style.css" />
+
+        <script src="https://cdn.plot.ly/plotly-latest.min.js"></script> 
+        
+    <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    /* Create two equal columns that floats next to each other */
+    .column {
+      float: left;
+      width: 33.33%;
+      padding: 10px;
+      height: 300px; /* Should be removed. Only for demonstration */
+    }
+
+    /* Clear floats after the columns */
+    .row:after {
+      content: "";
+      display: table;
+      clear: both;
+    }
+    </style>
+    </head>
+    <body>
+    <br>
+    <div class="row">
+        <div class="column">
+        {{ rotor_example }}
+        </div>
+        <div class="column">
+        {{ c123701 }}
+        </div>
+        <div class="column">
+        {{ injection }}
+        </div>
+    </div>
+    </body>
+</html>


### PR DESCRIPTION
This adds a script that generates some plots for 3 different rotor
models. This helps to solve a problem we had when we changed some
property to improve the plot for a specific model, and later we would
notice that at the end the modification would be detrimental to other
models.
This, together with the plotly_theme style, closes #580.
Now we should try to make all plot modifications on the plotly_theme.py
file, and we should run the generate_comparison_plots.py script and
check the output.
After running the script, we can open the index.html file and click each
link to check the specific plot for the three models.
I have added this script to a tools directory inside the repository.
The tools directory will store some utility used for the
development of our code. This is the same structure that other projects
such as numpy use.
I have added the generated html files to the .gitignore files, since
the script should always generate them (except for
the index.html file).