### PR TITLE
Add probe argument to ForcedResponseResults

### DIFF
--- a/ross/api_report.py
+++ b/ross/api_report.py
@@ -780,8 +780,8 @@ class Report:
 
         for node in nodes:
             dof = 4 * node + 1
-            mag_plot = response.plot_magnitude(dof)
-            phs_plot = response.plot_phase(dof)
+            mag_plot = response.plot_magnitude([(node, np.pi / 2)])
+            phs_plot = response.plot_phase([(node, np.pi / 2)])
 
         magnitude = mag[dof]
         idx_max = argrelextrema(magnitude, np.greater)[0].tolist()

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1638,7 +1638,9 @@ class Rotor(object):
         (61,)
 
         plot unbalance response:
-        >>> fig = response.plot(dof=13)
+        >>> probe_node = 3
+        >>> probe_angle = np.pi / 2
+        >>> fig = response.plot(probe=[(probe_node, probe_angle)])
 
         plot deflected shape configuration
         >>> value = 600


### PR DESCRIPTION
- Replace `dof` by `probe `argument
- probe is a list of tuples. Each tuple refers to a probe, which must include de node and the orientation.
- The orientation units is set by `probe_units` argument.
- in `plot()` method, `data.showlegend` is turn off to avoid repetitive legend marks on graphs