### PR TITLE
Add probe argument to TimeResponseResults

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -3016,7 +3016,7 @@ class TimeResponseResults:
         displacement_units="m",
         time_units="s",
         fig=None,
-        **kwargs
+        **kwargs,
     ):
         """Plot time response for a single DoF using Plotly.
 
@@ -3311,4 +3311,3 @@ class TimeResponseResults:
             )
         else:
             raise ValueError(f"{plot_type} is not a valid plot type.")
-

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2273,17 +2273,18 @@ class Rotor(object):
         >>> speed = 500.0
         >>> size = 1000
         >>> node = 3
-        >>> dof = 13
+        >>> probe1 = (3, 0)
         >>> t = np.linspace(0, 10, size)
         >>> F = np.zeros((size, rotor.ndof))
         >>> F[:, 4 * node] = 10 * np.cos(2 * t)
         >>> F[:, 4 * node + 1] = 10 * np.sin(2 * t)
         >>> response = rotor.run_time_response(speed, F, t)
+        >>> dof = 13
         >>> response.yout[:, dof] # doctest: +ELLIPSIS
         array([ 0.00000000e+00,  1.86686693e-07,  8.39130663e-07, ...
 
         # plot time response for a single DoF:
-        >>> fig1 = response.plot(plot_type="1d", dof=dof)
+        >>> fig1 = response.plot(plot_type="1d", probe=[probe1])
 
         # plot orbit response - plotting 2D nodal orbit:
         >>> fig2 = response.plot(plot_type="2d", node=node)


### PR DESCRIPTION
When plot_type="1d", users will have an option to add a list of probes (node, orientation) to return the time response for each one.
It's similar to the ForcedResponseResults.

It follows the same ideas than PR #635.
