### PR TITLE
Fix dependency issue

### DIFF
--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -8,6 +8,8 @@ echo "Building and deploying ross-website version $ROSS_VERSION"
 set -e # Exit with nonzero exit code if anything fails
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$ROSS_VERSION" ]; then
+    echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
+    echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
     echo "Skipping documentation deployment. This is done only on current released version."
     exit 0
 fi

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ EXTRAS = {
         "sphinx",
         "sphinx_bootstrap_theme",
         "nbsphinx",
-        "numpydoc",
+        "numpydoc=0.9.2",
         "sphinxcontrib-bibtex",
         "black",
         "isort",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ EXTRAS = {
         "sphinx",
         "sphinx_bootstrap_theme",
         "nbsphinx",
-        "numpydoc=0.9.2",
+        "numpydoc==0.9.2",
         "sphinxcontrib-bibtex",
         "black",
         "isort",


### PR DESCRIPTION
Recent numpydoc versions (>1.0) would break the build process for our
docs. For some reason the relabel_references function from numpydoc
causes an exception and the build process stops.

I have checked the function, and it looks like the problem is in
the assert len(prefix) == HASH_LEN + 1.

Our prefix, in this case friswell2010dynamics, has a higher len than
HASH_LEN + 1, since the value for HASH_LEN is 12 in the code.

I suspect this might be related to our use of sphinxcontrib-bibtex.

For now I am going to fix this dependency version to 0.9.2 and
latter we can check this.