### PR TITLE
Updating Stochastic ROSS plotting methods

### DIFF
--- a/ross/element.py
+++ b/ross/element.py
@@ -36,7 +36,7 @@ class Element(ABC):
         >>> from tempfile import tempdir
         >>> from pathlib import Path
         >>> from ross.disk_element import disk_example
-        >>> # create path for a temporary file 
+        >>> # create path for a temporary file
         >>> file = Path(tempdir) / 'disk.toml'
         >>> disk = disk_example()
         >>> disk.save(file)
@@ -77,7 +77,7 @@ class Element(ABC):
         >>> from pathlib import Path
         >>> from ross.bearing_seal_element import bearing_example
         >>> from ross.bearing_seal_element import BearingElement
-        >>> # create path for a temporary file 
+        >>> # create path for a temporary file
         >>> file = Path(tempdir) / 'bearing1.toml'
         >>> bearing1 = bearing_example()
         >>> bearing1.save(file)

--- a/ross/fluid_flow/fluid_flow.py
+++ b/ross/fluid_flow/fluid_flow.py
@@ -359,28 +359,18 @@ class FluidFlow:
                 for i in range(0, self.nz):
                     for j in range(0, self.ntheta):
                         self.p_mat_analytical[i, j] = (
-                            (
-                                6
-                                * self.viscosity
-                                * self.omega
-                                * (self.radius_rotor / self.radial_clearance) ** 2
-                                * self.eccentricity_ratio
-                                * np.sin(self.dtheta * j)
-                                * (
-                                    2
-                                    + self.eccentricity_ratio * np.cos(self.dtheta * j)
-                                )
-                            )
-                            / (
-                                (2 + self.eccentricity_ratio ** 2)
-                                * (
-                                    1
-                                    + self.eccentricity_ratio * np.cos(self.dtheta * j)
-                                )
-                                ** 2
-                            )
-                            + self.p_in
-                        )
+                            6
+                            * self.viscosity
+                            * self.omega
+                            * (self.radius_rotor / self.radial_clearance) ** 2
+                            * self.eccentricity_ratio
+                            * np.sin(self.dtheta * j)
+                            * (2 + self.eccentricity_ratio * np.cos(self.dtheta * j))
+                        ) / (
+                            (2 + self.eccentricity_ratio ** 2)
+                            * (1 + self.eccentricity_ratio * np.cos(self.dtheta * j))
+                            ** 2
+                        ) + self.p_in
                         if self.p_mat_analytical[i, j] < 0:
                             self.p_mat_analytical[i, j] = 0
         elif self.bearing_type == "medium_size":

--- a/ross/fluid_flow/fluid_flow_coefficients.py
+++ b/ross/fluid_flow/fluid_flow_coefficients.py
@@ -13,14 +13,17 @@ from ross.fluid_flow.fluid_flow_geometry import (move_rotor_center,
 
 
 def calculate_oil_film_force(fluid_flow_object, force_type=None):
-    """This function calculates the forces of the oil film in the N and T directions, ie in the
-    opposite direction to the eccentricity and in the tangential direction.
+    """This function calculates the forces of the oil film in the N and T directions,
+    ie in the opposite direction to the eccentricity and in the tangential direction.
+
     Parameters
     ----------
     fluid_flow_object: A FluidFlow object.
     force_type: str
-        If set, calculates the oil film force matrix analytically considering the chosen type: 'short' or 'long'.
+        If set, calculates the oil film force matrix analytically considering the chosen
+        type: 'short' or 'long'.
         If set to 'numerical', calculates the oil film force numerically.
+
     Returns
     -------
     radial_force: float
@@ -31,6 +34,7 @@ def calculate_oil_film_force(fluid_flow_object, force_type=None):
         Components of forces in the x direction
     f_y: float
         Components of forces in the y direction
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -152,22 +156,24 @@ def calculate_oil_film_force(fluid_flow_object, force_type=None):
 
 def calculate_stiffness_and_damping_coefficients(fluid_flow_object):
     """This function calculates the bearing stiffness and damping matrices numerically.
-        Parameters
-        ----------
-        fluid_flow_object: A FluidFlow object.
-        Returns
-        -------
-        Two lists of floats
-            A list of length four including stiffness floats in this order: kxx, kxy, kyx, kyy.
-            And another list of length four including damping floats in this order: cxx, cxy, cyx, cyy.
-            And
-        Examples
-        --------
-        >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
-        >>> my_fluid_flow = fluid_flow_example()
-        >>> calculate_stiffness_and_damping_coefficients(my_fluid_flow)  # doctest: +ELLIPSIS
-        ([428...
-        """
+
+    Parameters
+    ----------
+    fluid_flow_object: A FluidFlow object.
+
+    Returns
+    -------
+    Two lists of floats
+        A list of length four including stiffness floats in this order: kxx, kxy, kyx, kyy.
+        And another list of length four including damping floats in this order: cxx, cxy, cyx, cyy.
+
+    Examples
+    --------
+    >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
+    >>> my_fluid_flow = fluid_flow_example()
+    >>> calculate_stiffness_and_damping_coefficients(my_fluid_flow)  # doctest: +ELLIPSIS
+    ([428...
+    """
     N = 6
     t = np.linspace(0, 2 * np.pi / fluid_flow_object.omegap, N)
     fluid_flow_object.xp = fluid_flow_object.radial_clearance * 0.0001
@@ -262,13 +268,16 @@ def calculate_stiffness_and_damping_coefficients(fluid_flow_object):
 
 def calculate_short_stiffness_matrix(fluid_flow_object):
     """This function calculates the stiffness matrix for the short bearing.
+
     Parameters
     ----------
     fluid_flow_object: A FluidFlow object.
+
     Returns
     -------
     list of floats
         A list of length four including stiffness floats in this order: kxx, kxy, kyx, kyy
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -340,13 +349,16 @@ def calculate_short_stiffness_matrix(fluid_flow_object):
 
 def calculate_short_damping_matrix(fluid_flow_object):
     """This function calculates the damping matrix for the short bearing.
+
     Parameters
     -------
     fluid_flow_object: A FluidFlow object.
+
     Returns
     -------
     list of floats
         A list of length four including damping floats in this order: cxx, cxy, cyx, cyy
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -375,14 +387,14 @@ def calculate_short_damping_matrix(fluid_flow_object):
 def find_equilibrium_position(fluid_flow_object, print_equilibrium_position=False):
     """This function finds the equilibrium position of the rotor such that the fluid flow
     forces match the applied load.
+
     Parameters
     ----------
     fluid_flow_object: A FluidFlow object.
     print_equilibrium_position: bool, optional
         If True, prints the equilibrium position.
-    Returns
-    -------
-    None
+
+    Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example2
     >>> my_fluid_flow = fluid_flow_example2()
@@ -394,12 +406,14 @@ def find_equilibrium_position(fluid_flow_object, print_equilibrium_position=Fals
     def residuals(x, *args):
         """Calculates x component of the forces of the oil film and the
         difference between the y component and the load.
+
         Parameters
         ----------
         x: array
             Rotor center coordinates
         *args : dict
             Dictionary instantiating the ross.FluidFlow class.
+
         Returns
         -------
         array
@@ -414,7 +428,12 @@ def find_equilibrium_position(fluid_flow_object, print_equilibrium_position=Fals
         )
         bearing.geometry_description()
         bearing.calculate_pressure_matrix_numerical()
-        (_, _, fx, fy,) = calculate_oil_film_force(bearing, force_type="numerical")
+        (
+            _,
+            _,
+            fx,
+            fy,
+        ) = calculate_oil_film_force(bearing, force_type="numerical")
         return np.array([fx, (bearing.load - fy)])
 
     if fluid_flow_object.load is None:
@@ -423,9 +442,12 @@ def find_equilibrium_position(fluid_flow_object, print_equilibrium_position=Fals
     move_rotor_center_abs(fluid_flow_object, x0[0], x0[1])
     fluid_flow_object.geometry_description()
     fluid_flow_object.calculate_pressure_matrix_numerical()
-    (_, _, fx, fy,) = calculate_oil_film_force(
-        fluid_flow_object, force_type="numerical"
-    )
+    (
+        _,
+        _,
+        fx,
+        fy,
+    ) = calculate_oil_film_force(fluid_flow_object, force_type="numerical")
     result = least_squares(
         residuals,
         x0,

--- a/ross/fluid_flow/fluid_flow_geometry.py
+++ b/ross/fluid_flow/fluid_flow_geometry.py
@@ -5,15 +5,18 @@ from scipy.optimize import least_squares, root
 def calculate_attitude_angle(eccentricity_ratio):
     """Calculates the attitude angle based on the eccentricity ratio.
     Suitable only for short bearings.
+
     Parameters
     ----------
     eccentricity_ratio: float
         The ratio between the journal displacement, called just eccentricity, and
         the radial clearance.
+
     Returns
     -------
     float
         Attitude angle
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -30,6 +33,7 @@ def internal_radius_function(gama, attitude_angle, radius_rotor, eccentricity):
     """This function calculates the x and y of the internal radius of the rotor,
     as well as its distance from the origin, given the distance in the theta-axis,
     the attitude angle, the radius of the rotor and the eccentricity.
+
     Parameters
     ----------
     gama: float
@@ -40,6 +44,7 @@ def internal_radius_function(gama, attitude_angle, radius_rotor, eccentricity):
         The radius of the journal.
     eccentricity: float
         The journal displacement from the center of the stator.
+
     Returns
     -------
     radius_internal: float
@@ -48,6 +53,7 @@ def internal_radius_function(gama, attitude_angle, radius_rotor, eccentricity):
         The position x of the returned internal radius.
     yri: float
         The position y of the returned internal radius.
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -73,14 +79,17 @@ def internal_radius_function(gama, attitude_angle, radius_rotor, eccentricity):
 
 
 def external_radius_function(gama, radius_stator):
-    """This function returns the x and y of the radius of the stator, as well as its distance from the
-    origin, given the distance in the theta-axis and the radius of the bearing.
+    """This function returns the x and y of the radius of the stator, as well as its
+    distance from the origin, given the distance in the theta-axis and the radius of
+    the bearing.
+
     Parameters
     ----------
     gama: float
         Gama is the distance in the theta-axis. It should range from 0 to 2*np.pi.
     radius_stator : float
         The external radius of the bearing.
+
     Returns
     -------
     radius_external: float
@@ -89,6 +98,7 @@ def external_radius_function(gama, radius_stator):
         The position x of the returned external radius.
     yre: float
         The position y of the returned external radius.
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -106,40 +116,46 @@ def external_radius_function(gama, radius_stator):
 
 
 def reynolds_number(density, characteristic_speed, radial_clearance, viscosity):
-    """Returns the reynolds number based on the characteristic speed.
-    This number denotes the ratio between fluid inertia (advection) forces and viscous-shear forces.
-        Parameters
-        ----------
-        density: float
-            Fluid density(Kg/m^3).
-        characteristic_speed: float
-            Characteristic fluid speeds.
-        radial_clearance: float
-            Difference between both stator and rotor radius, regardless of eccentricity.
-        viscosity: float
-            Viscosity (Pa.s).
-        Returns
-        -------
-        float
-            The reynolds number.
-        Examples
-        --------
-        >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
-        >>> my_fluid_flow = fluid_flow_example()
-        >>> density = my_fluid_flow.density
-        >>> characteristic_speed = my_fluid_flow.characteristic_speed
-        >>> radial_clearance = my_fluid_flow.radial_clearance
-        >>> viscosity = my_fluid_flow.viscosity
-        >>> reynolds_number(density, characteristic_speed, radial_clearance, viscosity) # doctest: +ELLIPSIS
-        24.01...
-        """
+    """Return the reynolds number based on the characteristic speed.
+
+    This number denotes the ratio between fluid inertia (advection) forces and
+    viscous-shear forces.
+
+    Parameters
+    ----------
+    density: float
+        Fluid density(Kg/m^3).
+    characteristic_speed: float
+        Characteristic fluid speeds.
+    radial_clearance: float
+        Difference between both stator and rotor radius, regardless of eccentricity.
+    viscosity: float
+        Viscosity (Pa.s).
+
+    Returns
+    -------
+    float
+        The reynolds number.
+
+    Examples
+    --------
+    >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
+    >>> my_fluid_flow = fluid_flow_example()
+    >>> density = my_fluid_flow.density
+    >>> characteristic_speed = my_fluid_flow.characteristic_speed
+    >>> radial_clearance = my_fluid_flow.radial_clearance
+    >>> viscosity = my_fluid_flow.viscosity
+    >>> reynolds_number(density, characteristic_speed, radial_clearance, viscosity) # doctest: +ELLIPSIS
+    24.01...
+    """
     return (density * characteristic_speed * radial_clearance) / viscosity
 
 
 def modified_sommerfeld_number(
     radius_stator, omega, viscosity, length, load, radial_clearance
 ):
-    """Returns the modified sommerfeld number.
+    """Return the modified sommerfeld number.
+
     Parameters
     ----------
     radius_stator : float
@@ -159,6 +175,7 @@ def modified_sommerfeld_number(
     -------
     float
         The modified sommerfeld number.
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -179,7 +196,8 @@ def modified_sommerfeld_number(
 
 
 def sommerfeld_number(modified_s, radius_stator, length):
-    """Returns the sommerfeld number, based on the modified sommerfeld number.
+    """Return the sommerfeld number, based on the modified sommerfeld number.
+
     Parameters
     ----------
     modified_s: float
@@ -192,6 +210,7 @@ def sommerfeld_number(modified_s, radius_stator, length):
     -------
     float
         The sommerfeld number.
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -212,15 +231,19 @@ def sommerfeld_number(modified_s, radius_stator, length):
 
 def calculate_eccentricity_ratio(modified_s):
     """Calculate the eccentricity ratio for a given load using the sommerfeld number.
+
     Suitable only for short bearings.
+
     Parameters
     ----------
     modified_s: float
         The modified sommerfeld number.
+
     Returns
     -------
     float
         The eccentricity ratio.
+
     Examples
     --------
     >>> modified_s = 6.329494061103412
@@ -239,14 +262,17 @@ def calculate_eccentricity_ratio(modified_s):
 
     def f(x):
         """Fourth degree polynomial whose root is the square of the eccentricity ratio.
+
         Parameters
         ----------
         x: float
             Fourth degree polynomial coefficients.
+
         Returns
         -------
         float
-            Polynomial value f at x."""
+            Polynomial value f at x.
+        """
         c = coefficients
         return (
             c[0] * x ** 4
@@ -266,8 +292,10 @@ def calculate_eccentricity_ratio(modified_s):
 def calculate_rotor_load(
     radius_stator, omega, viscosity, length, radial_clearance, eccentricity_ratio
 ):
-    """Returns the load applied to the rotor, based on the eccentricity ratio.
+    """Return the load applied to the rotor, based on the eccentricity ratio.
+
     Suitable only for short bearings.
+
     Parameters
     ----------
     radius_stator : float
@@ -283,10 +311,12 @@ def calculate_rotor_load(
     eccentricity_ratio: float
         The ratio between the journal displacement, called just eccentricity, and
         the radial clearance.
+
     Returns
     -------
     float
         Load applied to the rotor.
+
     Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
@@ -316,9 +346,8 @@ def calculate_rotor_load(
 
 
 def move_rotor_center(fluid_flow_object, dx, dy):
-    """For a given step on x or y axis,
-    moves the rotor center and calculates new eccentricity, attitude angle,
-    and rotor center.
+    """For a given step on x or y axis, moves the rotor center and calculates new
+    eccentricity, attitude angle, and rotor center.
 
     Parameters
     ----------
@@ -327,9 +356,8 @@ def move_rotor_center(fluid_flow_object, dx, dy):
         The step on x axis.
     dy: float
         The step on y axis.
-    Returns
-    -------
-    None
+
+    Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example2
     >>> my_fluid_flow = fluid_flow_example2()
@@ -353,6 +381,7 @@ def move_rotor_center(fluid_flow_object, dx, dy):
 def move_rotor_center_abs(fluid_flow_object, x, y):
     """Moves the rotor center to the coordinates (x, y) and calculates new eccentricity,
     attitude angle, and rotor center.
+
     Parameters
     ----------
     fluid_flow_object: A FluidFlow object.
@@ -360,9 +389,8 @@ def move_rotor_center_abs(fluid_flow_object, x, y):
         Coordinate along x axis.
     y: float
         Coordinate along y axis.
-    Returns
-    -------
-    None
+
+    Examples
     --------
     >>> from ross.fluid_flow.fluid_flow import fluid_flow_example
     >>> my_fluid_flow = fluid_flow_example()

--- a/ross/stochastic/st_disk_element.py
+++ b/ross/stochastic/st_disk_element.py
@@ -56,7 +56,14 @@ class ST_DiskElement:
     """
 
     def __init__(
-        self, n, m, Id, Ip, tag=None, color="Firebrick", is_random=None,
+        self,
+        n,
+        m,
+        Id,
+        Ip,
+        tag=None,
+        color="Firebrick",
+        is_random=None,
     ):
         attribute_dict = dict(n=n, m=m, Id=Id, Ip=Ip, tag=tag, color=color)
 
@@ -218,7 +225,9 @@ class ST_DiskElement:
         >>> # fig.show()
         """
         label = dict(
-            m="Mass", Id="Diametral moment of inertia", Ip="Polar moment of inertia",
+            m="Mass",
+            Id="Diametral moment of inertia",
+            Ip="Polar moment of inertia",
         )
         if var_list is None:
             var_list = self.is_random
@@ -235,7 +244,14 @@ class ST_DiskElement:
 
     @classmethod
     def from_geometry(
-        cls, n, material, width, i_d, o_d, tag=None, is_random=None,
+        cls,
+        n,
+        material,
+        width,
+        i_d,
+        o_d,
+        tag=None,
+        is_random=None,
     ):
         """Random disk element.
 
@@ -297,7 +313,12 @@ class ST_DiskElement:
             o_d = np.array(o_d)
 
         attribute_dict = dict(
-            n=n, material=material, width=width, i_d=i_d, o_d=o_d, tag=tag,
+            n=n,
+            material=material,
+            width=width,
+            i_d=i_d,
+            o_d=o_d,
+            tag=tag,
         )
         size = len(attribute_dict[is_random[0]])
 
@@ -340,6 +361,10 @@ def st_disk_example():
     2
     """
     elm = ST_DiskElement(
-        n=1, m=[30, 40], Id=[0.2, 0.3], Ip=[0.5, 0.7], is_random=["m", "Id", "Ip"],
+        n=1,
+        m=[30, 40],
+        Id=[0.2, 0.3],
+        Ip=[0.5, 0.7],
+        is_random=["m", "Id", "Ip"],
     )
     return elm

--- a/ross/stochastic/st_materials.py
+++ b/ross/stochastic/st_materials.py
@@ -91,7 +91,12 @@ class ST_Material:
             Poisson = np.asarray(Poisson)
 
         attribute_dict = dict(
-            name=name, rho=rho, E=E, G_s=G_s, Poisson=Poisson, color=color,
+            name=name,
+            rho=rho,
+            E=E,
+            G_s=G_s,
+            Poisson=Poisson,
+            color=color,
         )
         self.is_random = is_random
         self.attribute_dict = attribute_dict

--- a/ross/stochastic/st_point_mass.py
+++ b/ross/stochastic/st_point_mass.py
@@ -57,9 +57,23 @@ class ST_PointMass:
     """
 
     def __init__(
-        self, n, m=None, mx=None, my=None, tag=None, color="DarkSalmon", is_random=None,
+        self,
+        n,
+        m=None,
+        mx=None,
+        my=None,
+        tag=None,
+        color="DarkSalmon",
+        is_random=None,
     ):
-        attribute_dict = dict(n=n, m=m, mx=mx, my=my, tag=tag, color=color,)
+        attribute_dict = dict(
+            n=n,
+            m=m,
+            mx=mx,
+            my=my,
+            tag=tag,
+            color=color,
+        )
 
         self.is_random = is_random
         self.attribute_dict = attribute_dict
@@ -217,7 +231,9 @@ class ST_PointMass:
         >>> # fig.show()
         """
         label = dict(
-            mx="Mass on the X direction", my="Mass on the Y direction", m="Mass",
+            mx="Mass on the X direction",
+            my="Mass on the Y direction",
+            m="Mass",
         )
         if var_list is None:
             var_list = self.is_random

--- a/ross/stochastic/st_results.py
+++ b/ross/stochastic/st_results.py
@@ -7,6 +7,7 @@ from plotly import express as px
 from plotly import graph_objects as go
 from plotly import io as pio
 from plotly.subplots import make_subplots
+
 from ross.plotly_theme import tableau_colors
 
 pio.renderers.default = "browser"

--- a/ross/stochastic/st_rotor_assembly.py
+++ b/ross/stochastic/st_rotor_assembly.py
@@ -593,11 +593,11 @@ class ST_Rotor(object):
 
         # Plotting Time Response 1D, 2D and 3D
 
-        >>> fig = results.plot(plot_type="1d", dof=dof, conf_interval=[90])
+        >>> fig = results.plot_1d(probe=[(3, np.pi / 2)], conf_interval=[90])
         >>> # fig.show()
-        >>> fig = results.plot(plot_type="2d", node=node, conf_interval=[90])
+        >>> fig = results.plot_2d(node=node, conf_interval=[90])
         >>> # fig.show()
-        >>> fig = results.plot(plot_type="3d", conf_interval=[90])
+        >>> fig = results.plot_3d(conf_interval=[90])
         >>> # fig.show()
         """
         t_size = len(time_range)

--- a/ross/stochastic/st_rotor_assembly.py
+++ b/ross/stochastic/st_rotor_assembly.py
@@ -737,6 +737,7 @@ class ST_Rotor(object):
             frequency_range=frequency_range,
             magnitude=mag_resp,
             phase=phs_resp,
+            number_dof=self.number_dof,
         )
 
         return results

--- a/ross/stochastic/st_rotor_assembly.py
+++ b/ross/stochastic/st_rotor_assembly.py
@@ -683,12 +683,11 @@ class ST_Rotor(object):
         >>> n = 3
         >>> m = np.random.uniform(0.001, 0.002, 10)
         >>> p = 0.0
-        >>> dof = 13
         >>> results = rotors.run_unbalance_response(n, m, p, freq_range)
 
         # Plotting Frequency Response with Plotly
 
-        >>> fig = results.plot(dof, conf_interval=[90])
+        >>> fig = results.plot(probe=[(3, np.pi / 2)], conf_interval=[90])
         >>> # fig.show()
         """
         RV_size = self.RV_size

--- a/ross/stochastic/st_shaft_element.py
+++ b/ross/stochastic/st_shaft_element.py
@@ -338,6 +338,10 @@ def st_shaft_example():
     from ross.materials import steel
 
     elm = ST_ShaftElement(
-        L=[1.0, 1.1], idl=0.0, odl=[0.1, 0.2], material=steel, is_random=["L", "odl"],
+        L=[1.0, 1.1],
+        idl=0.0,
+        odl=[0.1, 0.2],
+        material=steel,
+        is_random=["L", "odl"],
     )
     return elm

--- a/ross/tests/test_fluid_flow.py
+++ b/ross/tests/test_fluid_flow.py
@@ -318,7 +318,12 @@ def test_plots():
 
 def test_find_equilibrium_position():
     bearing = fluid_flow_example2()
-    (n, t, force_x, force_y,) = calculate_oil_film_force(bearing)
+    (
+        n,
+        t,
+        force_x,
+        force_y,
+    ) = calculate_oil_film_force(bearing)
     assert math.isclose(force_x, 0, abs_tol=1e-4)
     assert math.isclose(force_y, bearing.load, abs_tol=1e-2)
 

--- a/ross/tests/test_materials.py
+++ b/ross/tests/test_materials.py
@@ -7,7 +7,11 @@ from ross.materials import *
 @pytest.fixture
 def AISI4140():
     return Material(
-        name="AISI4140", rho=7850, E=203200000000.0, G_s=80000000000.0, color="#525252",
+        name="AISI4140",
+        rho=7850,
+        E=203200000000.0,
+        G_s=80000000000.0,
+        color="#525252",
     )
 
 

--- a/ross/tests/test_stochastic_elements.py
+++ b/ross/tests/test_stochastic_elements.py
@@ -33,7 +33,11 @@ def rand_shaft():
 @pytest.fixture
 def rand_disk_from_inertia():
     elm = ST_DiskElement(
-        n=1, m=[30, 40], Id=[0.2, 0.3], Ip=[0.5, 0.7], is_random=["m", "Id", "Ip"],
+        n=1,
+        m=[30, 40],
+        Id=[0.2, 0.3],
+        Ip=[0.5, 0.7],
+        is_random=["m", "Id", "Ip"],
     )
     return elm
 

--- a/ross/tests/test_stochastic_rotor_assembly.py
+++ b/ross/tests/test_stochastic_rotor_assembly.py
@@ -48,7 +48,11 @@ def rotor1():
 ###############################################################################
 def test_st_shaft_elements_odd_length():
     tim0 = ST_ShaftElement(
-        L=[1, 1.1], idl=0, odl=[0.1, 0.2], material=steel, is_random=["L", "odl"],
+        L=[1, 1.1],
+        idl=0,
+        odl=[0.1, 0.2],
+        material=steel,
+        is_random=["L", "odl"],
     )
     tim1 = ST_ShaftElement(
         L=[1, 1.1, 1.2],
@@ -78,17 +82,33 @@ def test_st_disk_elements_odd_length():
 
 
 def test_st_bearing_elements_odd_length():
-    tim0 = ShaftElement(L=0.25, idl=0, odl=0.05, material=steel,)
-    tim1 = ShaftElement(L=0.25, idl=0, odl=0.05, material=steel,)
+    tim0 = ShaftElement(
+        L=0.25,
+        idl=0,
+        odl=0.05,
+        material=steel,
+    )
+    tim1 = ShaftElement(
+        L=0.25,
+        idl=0,
+        odl=0.05,
+        material=steel,
+    )
     shaft_elm = [tim0, tim1]
 
     disk0 = DiskElement(n=1, m=20, Id=1, Ip=1)
 
     brg0 = ST_BearingElement(
-        n=0, kxx=[1e6, 2e6], cxx=[1e3, 2e3], is_random=["kxx", "cxx"],
+        n=0,
+        kxx=[1e6, 2e6],
+        cxx=[1e3, 2e3],
+        is_random=["kxx", "cxx"],
     )
     brg1 = ST_BearingElement(
-        n=2, kxx=[1e6, 2e6, 3e6], cxx=[1e3, 2e3, 3e3], is_random=["kxx", "cxx"],
+        n=2,
+        kxx=[1e6, 2e6, 3e6],
+        cxx=[1e3, 2e3, 3e3],
+        is_random=["kxx", "cxx"],
     )
 
     with pytest.raises(ValueError) as ex:
@@ -118,7 +138,11 @@ def test_st_point_mass_elements_odd_length():
 
 def test_elements_odd_length():
     tim0 = ST_ShaftElement(
-        L=[1, 1.1], idl=0, odl=[0.1, 0.2], material=steel, is_random=["L", "odl"],
+        L=[1, 1.1],
+        idl=0,
+        odl=[0.1, 0.2],
+        material=steel,
+        is_random=["L", "odl"],
     )
     shaft_elm = [tim0, tim0]
 
@@ -127,10 +151,16 @@ def test_elements_odd_length():
     disks = [disk0, disk1]
 
     brg0 = ST_BearingElement(
-        n=0, kxx=[1e6, 2e6], cxx=[1e3, 2e3], is_random=["kxx", "cxx"],
+        n=0,
+        kxx=[1e6, 2e6],
+        cxx=[1e3, 2e3],
+        is_random=["kxx", "cxx"],
     )
     brg1 = ST_BearingElement(
-        n=2, kxx=[1e6, 2e6], cxx=[1e3, 2e3], is_random=["kxx", "cxx"],
+        n=2,
+        kxx=[1e6, 2e6],
+        cxx=[1e3, 2e3],
+        is_random=["kxx", "cxx"],
     )
     bearings = [brg0, brg1]
 


### PR DESCRIPTION
This PR bring some modifications to `st_results.py`. These changes aims to match what have commited to `results.py` file.

- Adds the concept of probes to `ST_TimeResponseResults`, as it's done in ROSS.
- Removes the plot() method where the user should choose one of the 3 available plotting options. Now the user calls for `plot_1d()`, `plot_2d()` or `plot_3d()` method (same syntax than `TimeResponseResults`).
- In `plot_1d()` the color schemes are removed; Plotly will auto pick the colors to avoid repeated colors when plotting several traces.
- Remove command lines updating `xaxes` and `yaxes` from Plotly. It will use ROSS plotting theme now.