### PR TITLE
Corrections to Major Axis calculation

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1660,16 +1660,14 @@ class ForcedResponseResults:
 
         return subplots
 
-    def _calculate_major_axis(self, speed, frequency_units="rad/s"):
+    def _calculate_major_axis(self, speed):
         """Calculate the major axis for each nodal orbit.
 
         Parameters
         ----------
         speed : optional, float
-            The rotor rotation speed.
-        frequency_units : str, optional
-            Frequency units.
-            Default is "rad/s"
+            The rotor rotation speed. Must be an element from the speed_range argument
+            passed to the class (rad/s).
 
         Returns
         -------
@@ -1684,7 +1682,6 @@ class ForcedResponseResults:
         nodes = self.rotor.nodes
         number_dof = self.rotor.number_dof
 
-        speed = Q_(speed, frequency_units).to("rad/s").m
         major_axis_vector = np.zeros((5, len(nodes)), dtype=complex)
         idx = np.where(np.isclose(self.speed_range, speed, atol=1e-6))[0][0]
 
@@ -1736,7 +1733,7 @@ class ForcedResponseResults:
 
         return major_axis_vector
 
-    def _calculate_bending_moment(self, speed, frequency_units="rad/s"):
+    def _calculate_bending_moment(self, speed):
         """Calculate the bending moment in X and Y directions.
 
         This method calculate forces and moments on nodal positions for a deflected
@@ -1745,10 +1742,8 @@ class ForcedResponseResults:
         Parameters
         ----------
         speed : float
-            The rotor rotation speed.
-        frequency_units : str, optional
-            Frequency units.
-            Default is "rad/s"
+            The rotor rotation speed. Must be an element from the speed_range argument
+            passed to the class (rad/s).
 
         Returns
         -------
@@ -1757,7 +1752,6 @@ class ForcedResponseResults:
         My : array
             Bending Moment on Y directon.
         """
-        speed = Q_(speed, frequency_units).to("rad/s").m
         idx = np.where(np.isclose(self.speed_range, speed, atol=1e-6))[0][0]
         mag = self.magnitude[:, idx]
         phase = self.phase[:, idx]
@@ -1790,7 +1784,7 @@ class ForcedResponseResults:
         ----------
         speed : float
             The rotor rotation speed. Must be an element from the speed_range argument
-            passed to the class.
+            passed to the class (rad/s).
         frequency_units : str, optional
             Frequency units.
             Default is "rad/s"
@@ -1812,7 +1806,6 @@ class ForcedResponseResults:
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
-        speed = Q_(speed, frequency_units).to("rad/s").m
         if not any(np.isclose(self.speed_range, speed, atol=1e-6)):
             raise ValueError("No data available for this speed value.")
 
@@ -1871,7 +1864,7 @@ class ForcedResponseResults:
         ----------
         speed : float
             The rotor rotation speed. Must be an element from the speed_range argument
-            passed to the class.
+            passed to the class (rad/s).
         samples : int, optional
             Number of samples to generate the orbit for each node.
             Default is 101.
@@ -1896,7 +1889,6 @@ class ForcedResponseResults:
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
-        speed = Q_(speed, frequency_units).to("rad/s").m
         if not any(np.isclose(self.speed_range, speed, atol=1e-6)):
             raise ValueError("No data available for this speed value.")
 
@@ -2043,7 +2035,7 @@ class ForcedResponseResults:
         ----------
         speed : float
             The rotor rotation speed. Must be an element from the speed_range argument
-            passed to the class.
+            passed to the class (rad/s).
         frequency_units : str, optional
             Frequency units.
             Default is "rad/s"
@@ -2065,7 +2057,6 @@ class ForcedResponseResults:
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
-        speed = Q_(speed, frequency_units).to("rad/s").m
         if not any(np.isclose(self.speed_range, speed, atol=1e-6)):
             raise ValueError("No data available for this speed value.")
 
@@ -2157,7 +2148,7 @@ class ForcedResponseResults:
         ----------
         speed : float
             The rotor rotation speed. Must be an element from the speed_range argument
-            passed to the class.
+            passed to the class (rad/s).
         samples : int, optional
             Number of samples to generate the orbit for each node.
             Default is 101.
@@ -2201,6 +2192,7 @@ class ForcedResponseResults:
         shape3d_kwargs = {} if shape3d_kwargs is None else copy.copy(shape3d_kwargs)
         bm_kwargs = {} if bm_kwargs is None else copy.copy(bm_kwargs)
         subplot_kwargs = {} if subplot_kwargs is None else copy.copy(subplot_kwargs)
+        speed_str = Q_(speed, "rad/s").to(frequency_units).m
 
         # fmt: off
         fig0 = self.plot_deflected_shape_2d(
@@ -2237,6 +2229,9 @@ class ForcedResponseResults:
                 xaxis=fig1.layout.scene.xaxis,
                 yaxis=fig1.layout.scene.yaxis,
                 zaxis=fig1.layout.scene.zaxis,
+            ),
+            title=dict(
+                text=f"Deflected Shape<br>Speed = {speed_str} {frequency_units}"
             ),
             **subplot_kwargs,
         )

--- a/ross/results.py
+++ b/ross/results.py
@@ -665,7 +665,7 @@ class ModalResults:
         fig.add_trace(
             go.Scatter(
                 x=Q_(zn, "m").to(length_units).m,
-                y=vn,
+                y=vn / vn[np.argmax(np.abs(vn))],
                 mode="lines",
                 line=dict(color=whirl_dir),
                 name="mode shape",
@@ -1716,8 +1716,6 @@ class ForcedResponseResults:
             # Adjusting points to the same quadrant
             if ang_maj_ax > np.pi:
                 ang_maj_ax -= np.pi
-            if ang_maj_ax > np.pi / 2:
-                ang_maj_ax -= np.pi / 2
 
             major_axis_vector[0, i] = fow
             major_axis_vector[1, i] = back
@@ -1730,7 +1728,10 @@ class ForcedResponseResults:
             major_axis_vector[0] * np.exp(1j * max_major_axis_angle) +
             major_axis_vector[1] * np.exp(-1j * max_major_axis_angle)
         )
-        major_axis_vector[4] = np.abs(major_axis_vector[3])
+        major_axis_vector[4] = np.abs(
+            major_axis_vector[0] * np.exp(1j * major_axis_vector[2]) +
+            major_axis_vector[1] * np.exp(-1j * major_axis_vector[2])
+        )
         # fmt: on
 
         return major_axis_vector


### PR DESCRIPTION
### Mode shape
We were having some issues regarding to the Major Axes calculation on Modal Analysis. Depending on the rotor model, ROSS could return us mode shape plots with some kind of "discontiuity" or "leap". for example:

![image](https://user-images.githubusercontent.com/45969994/93240494-8a70ff80-f75a-11ea-986e-de31e0bd9d11.png)

he 3D to 2D conversion is made by a rotation matrix, where the vector is projected on the YZ plane.

![image](https://user-images.githubusercontent.com/45969994/93241209-6bbf3880-f75b-11ea-88b7-b43dde1e457a.png)

Where the first row from Rv should be 0 and the second row should be the projection. The process was made for each node with it's own rotation matrix. So, what is important to us is the ![image](https://user-images.githubusercontent.com/45969994/93242106-ab3a5480-f75c-11ea-954e-d0b5566d9e6f.png) part

To remove this kind of bug, all the projections are now rotated with the same theta angle (since they are approximately the same) - as follow in [commit](https://github.com/ross-rotordynamics/ross/pull/666/commits/46389bd873390fb63c38e6a6da9827c1f0d49d11) from PR #666 - and divide it by the maximum major axis norm to make sure the values ranges between 0 and 1.

### Deflected shape
In deflected shape, the maximum absolute values for the Major Axes was being calulated based for the greatest major axis angle for plotting purposes. Why is that?
If we take the major axex with theirs respective angles, we may have a "broken" visualization, which could confuse more than help (see below):

![image](https://user-images.githubusercontent.com/45969994/93243124-218b8680-f75e-11ea-986d-828c628d3042.png)

Now, if we plot according to the the maximum angle, we have continuous-like curve that represents better the orbital shape:

![image](https://user-images.githubusercontent.com/45969994/93243355-74fdd480-f75e-11ea-8f59-a6ae3a113898.png)

Although it's useful for visualizing, it was being used to calculated the 2d curve (Major Axis Absolute Amplitude), which returns a fake result for the user.

![image](https://user-images.githubusercontent.com/45969994/93244041-78de2680-f75f-11ea-8b70-19682d73deaf.png)

This analysis should be driven using the respective angles for each major axis. And now, using the correct angles, we get:

![image](https://user-images.githubusercontent.com/45969994/93244126-9ca16c80-f75f-11ea-8d27-0b3e86ace2b6.png)
