### PR TITLE
Change travis so we run black after_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - sudo apt-get install pandoc
 install:
 - pip install -e .[dev]
-before_script:
+after_script:
 - black --check ross
 - isort ross --check-only
 script:


### PR DESCRIPTION
If we have black running before_script we can have the ci failing before
running any tests. If black runs after, during a pull request review the
reviewer can at least see if all tests are passing.