### PR TITLE
Fix _calculate_bending_moment() code

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1756,16 +1756,39 @@ class ForcedResponseResults:
         mag = self.magnitude[:, idx]
         phase = self.phase[:, idx]
         number_dof = self.rotor.number_dof
-        ndof = self.rotor.ndof
+        nodes = self.rotor.nodes
 
-        disp = np.zeros(ndof)
-        for i in range(number_dof):
-            disp[i::number_dof] = mag[i::number_dof] * np.cos(-phase[i::number_dof])
+        Mx = np.zeros_like(nodes, dtype=np.float64)
+        My = np.zeros_like(nodes, dtype=np.float64)
+        mag = mag * np.cos(-phase)
 
-        nodal_forces = self.rotor.K(speed) @ disp
+        # fmt: off
+        for i, el in enumerate(self.rotor.shaft_elements):
+            x = (-el.material.E * el.Ie / el.L ** 2) * np.array([
+                [-6, +6, -4 * el.L, -2 * el.L],
+                [+6, -6, +2 * el.L, +4 * el.L],
+            ])
+            response_x = np.array([
+                [mag[number_dof * el.n_l + 0]],
+                [mag[number_dof * el.n_r + 0]],
+                [mag[number_dof * el.n_l + 3]],
+                [mag[number_dof * el.n_r + 3]],
+            ])
 
-        Mx = np.cumsum(nodal_forces[2::number_dof])
-        My = np.cumsum(nodal_forces[3::number_dof])
+            Mx[[el.n_l, el.n_r]] += (x @ response_x).flatten()
+
+            y = (-el.material.E * el.Ie / el.L ** 2) * np.array([
+                [-6, +6, +4 * el.L, +2 * el.L],
+                [+6, -6, -2 * el.L, -4 * el.L],
+            ])
+            response_y = np.array([
+                [mag[number_dof * el.n_l + 1]],
+                [mag[number_dof * el.n_r + 1]],
+                [mag[number_dof * el.n_l + 2]],
+                [mag[number_dof * el.n_r + 2]],
+            ])
+            My[[el.n_l, el.n_r]] += (y @ response_y).flatten()
+        # fmt: on
 
         return Mx, My
 


### PR DESCRIPTION
These changes fix the bending moment calculation for a deflected shape configuration.
The old code was not calculating the correct values.

If we take a closer look to the bending moment diagram, we can see that in both end, the moment is numerically zero (which is supposed to be, since the rotor is simply supported). And in this symmetrical example, we have a symmetrical response (as it also supposed to be

![image](https://user-images.githubusercontent.com/45969994/93885615-bb04ec00-fcba-11ea-821d-fd2236f411c2.png)

The new algorithm is based on [1] (section 6.12)

[1] _Friswell M. I., Penny J. E. T., Garvey S. D., and Lees A. W. Dynamics of Rotating Machines. Cambridge University Press, 2010._