### PR TITLE
Improving deflected shape layout

### DIFF
--- a/ross/plotly_theme.py
+++ b/ross/plotly_theme.py
@@ -1,3 +1,4 @@
+"""Plotly theme to ROSS - Rotordynamic Open Source Sofware."""
 from plotly import graph_objects as go
 from plotly import io as pio
 
@@ -115,6 +116,11 @@ pio.templates["ross"] = go.layout.Template(
                 "ticks": "",
                 "zerolinecolor": "#EBF0F8",
                 "showspikes": False,
+            },
+            "camera": {
+                "up": {"x": 0, "y": 0, "z": 1},
+                "center": {"x": 0, "y": 0, "z": 0},
+                "eye": {"x": 2.0, "y": 2.0, "z": 2.0},
             },
         },
         "shapedefaults": {"line": {"color": "#2a3f5f"}},

--- a/ross/results.py
+++ b/ross/results.py
@@ -2229,10 +2229,20 @@ class ForcedResponseResults:
                 xaxis=fig1.layout.scene.xaxis,
                 yaxis=fig1.layout.scene.yaxis,
                 zaxis=fig1.layout.scene.zaxis,
+                domain=dict(x=[0.47, 1]),
             ),
             title=dict(
-                text=f"Deflected Shape<br>Speed = {speed_str} {frequency_units}"
+                text=f"Deflected Shape<br>Speed = {speed_str} {frequency_units}",
             ),
+            legend=dict(
+                orientation="h",
+                xanchor="center",
+                yanchor="bottom",
+                x=0.5,
+                y=-0.3,
+            ),
+            width=800,
+            height=600,
             **subplot_kwargs,
         )
 


### PR DESCRIPTION
Related to Issue #675 

- Increase the figure size to a better fit of the images.
- Move the legend to the bottom
- Increase the deflected shape 3D domain in the subplot
- Changes the default values for `layout.scene.eye`. The new values zoom the view out.