### PR TITLE
Add loop to calculate frequency-depedent coefficients in from_fluid_flow()

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -1022,7 +1022,7 @@ class BearingElement(Element):
         ...                                p_out, radius_rotor, radius_stator,
         ...                                visc, rho, load=load) # doctest: +ELLIPSIS
         BearingElement(n=0, n_link=None,
-         kxx=[...
+         kxx=array([...
         """
         K = np.zeros((4, len(omega)))
         C = np.zeros((4, len(omega)))


### PR DESCRIPTION
Users will be able to input as many frequency values as needed and `from_fluid_flow()` will run a loop calculating a set of coefficients for each given frequency.
Now, `omega` argument must be a list of frequencies.
It also changes the main function used to calculate the coefficients. `calculate_stiffness_and_damping_coefficients()` is now used to do it numerically.
