### PR TITLE
Add save() and load() methods to manage ROSS results

### DIFF
--- a/ross/__init__.py
+++ b/ross/__init__.py
@@ -8,6 +8,7 @@ from .defects import *
 from .disk_element import *
 from .materials import *
 from .point_mass import *
+from .results import *
 from .rotor_assembly import *
 from .shaft_element import *
 from .utils import visualize_matrix

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -616,7 +616,7 @@ class Rotor(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             log_dec = 2 * np.pi * damping_ratio / np.sqrt(1 - damping_ratio ** 2)
-        lti = self._lti(speed)
+
         modal_results = ModalResults(
             speed,
             evalues,
@@ -625,7 +625,6 @@ class Rotor(object):
             wd,
             damping_ratio,
             log_dec,
-            lti,
             self.ndof,
             self.nodes,
             self.nodes_pos,
@@ -1749,8 +1748,8 @@ class Rotor(object):
         >>> rotor.time_response(speed, F, t) # doctest: +ELLIPSIS
         (array([0.        , 0.18518519, 0.37037037, ...
         """
-        modal = self.run_modal(speed=speed)
-        return signal.lsim(modal.lti, F, t, X0=ic)
+        lti = self._lti(speed)
+        return signal.lsim(lti, F, t, X0=ic)
 
     def plot_rotor(self, nodes=1, check_sld=False, length_units="m", **kwargs):
         """Plot a rotor object.
@@ -2469,7 +2468,7 @@ class Rotor(object):
         Parameters
         ----------
         **kwargs: dictionary
-        
+
             **kwargs receives:
                 dt : float
                     Time step.

--- a/ross/stochastic/__init__.py
+++ b/ross/stochastic/__init__.py
@@ -2,5 +2,6 @@ from .st_bearing_seal_element import *
 from .st_disk_element import *
 from .st_materials import *
 from .st_point_mass import *
+from .st_results import *
 from .st_rotor_assembly import *
 from .st_shaft_element import *

--- a/ross/stochastic/st_results.py
+++ b/ross/stochastic/st_results.py
@@ -2,7 +2,13 @@
 
 This module returns graphs for each type of analyses in st_rotor_assembly.py.
 """
+import inspect
+from abc import ABC
+from collections.abc import Iterable
+from pathlib import Path
+
 import numpy as np
+import toml
 from plotly import express as px
 from plotly import graph_objects as go
 from plotly import io as pio
@@ -16,8 +22,133 @@ pio.renderers.default = "browser"
 colors1 = px.colors.qualitative.Dark24
 colors2 = px.colors.qualitative.Light24
 
+__all__ = [
+    "ST_CampbellResults",
+    "ST_FrequencyResponseResults",
+    "ST_TimeResponseResults",
+    "ST_ForcedResponseResults",
+    "ST_Results",
+]
 
-class ST_CampbellResults:
+
+class ST_Results(ABC):
+    """Results class.
+
+    This class is a general abstract class to be implemented in other classes
+    for post-processing results, in order to add saving and loading data options.
+    """
+
+    def save(self, file):
+        """Save results in a .toml file.
+
+        This function will save the simulation results to a .toml file.
+        The file will have all the argument's names and values that are needed to
+        reinstantiate the class.
+
+        Parameters
+        ----------
+        file : str, pathlib.Path
+            The name of the file the results will be saved in.
+
+        Examples
+        --------
+        >>> # Example running a stochastic unbalance response
+        >>> from tempfile import tempdir
+        >>> from pathlib import Path
+        >>> import ross.stochastic as srs
+
+        >>> # Running an example
+        >>> rotors = srs.st_rotor_example()
+        >>> freq_range = np.linspace(0, 500, 31)
+        >>> n = 3
+        >>> m = np.random.uniform(0.001, 0.002, 10)
+        >>> p = 0.0
+        >>> results = rotors.run_unbalance_response(n, m, p, freq_range)
+
+        >>> # create path for a temporary file
+        >>> file = Path(tempdir) / 'results.toml'
+        >>> results.save(file)
+        """
+        # get __init__ arguments
+        signature = inspect.signature(self.__init__)
+        args_list = list(signature.parameters)
+        args = {arg: getattr(self, arg) for arg in args_list}
+        try:
+            data = toml.load(file)
+        except FileNotFoundError:
+            data = {}
+
+        data[f"{self.__class__.__name__}"] = args
+        with open(file, "w") as f:
+            toml.dump(data, f, encoder=toml.TomlNumpyEncoder())
+
+    @classmethod
+    def read_toml_data(cls, data):
+        """Read and parse data stored in a .toml file.
+
+        The data passed to this method needs to be according to the
+        format saved in the .toml file by the .save() method.
+
+        Parameters
+        ----------
+        data : dict
+            Dictionary obtained from toml.load().
+
+        Returns
+        -------
+        The result object.
+        """
+        return cls(**data)
+
+    @classmethod
+    def load(cls, file):
+        """Load results from a .toml file.
+
+        This function will load the simulation results from a .toml file.
+        The file must have all the argument's names and values that are needed to
+        reinstantiate the class.
+
+        Parameters
+        ----------
+        file : str, pathlib.Path
+            The name of the file the results will be loaded from.
+
+        Examples
+        --------
+        >>> # Example running a stochastic unbalance response
+        >>> from tempfile import tempdir
+        >>> from pathlib import Path
+        >>> import ross.stochastic as srs
+
+        >>> # Running an example
+        >>> rotors = srs.st_rotor_example()
+        >>> freq_range = np.linspace(0, 500, 31)
+        >>> n = 3
+        >>> m = np.random.uniform(0.001, 0.002, 10)
+        >>> p = 0.0
+        >>> results = rotors.run_unbalance_response(n, m, p, freq_range)
+
+        >>> # create path for a temporary file
+        >>> file = Path(tempdir) / 'results.toml'
+        >>> results.save(file)
+
+        >>> # Loading file
+        >>> results2 = srs.ST_ForcedResponseResults.load(file)
+        >>> results2.forced_resp.all() == results.forced_resp.all()
+        True
+        """
+        data = toml.load(file)
+        # extract single dictionary in the data
+        data = list(data.values())[0]
+        for key, value in data.items():
+            if isinstance(value, Iterable):
+                data[key] = np.array(value)
+                if data[key].dtype == np.dtype("<U49"):
+                    data[key] = np.array(value).astype(np.complex128)
+        return cls.read_toml_data(data)
+
+
+class ST_CampbellResults(ST_Results):
     """Store stochastic results and provide plots for Campbell Diagram.
 
     It's possible to visualize multiples harmonics in a single plot to check
@@ -349,7 +480,7 @@ class ST_CampbellResults:
         return subplots
 
 
-class ST_FrequencyResponseResults:
+class ST_FrequencyResponseResults(ST_Results):
     """Store stochastic results and provide plots for Frequency Response.
 
     Parameters
@@ -375,7 +506,11 @@ class ST_FrequencyResponseResults:
         self.phase = phase
 
     def plot_magnitude(
-        self, percentile=[], conf_interval=[], units="mic-pk-pk", **kwargs
+        self,
+        percentile=[],
+        conf_interval=[],
+        units="mic-pk-pk",
+        **kwargs,
     ):
         """Plot amplitude vs frequency.
 
@@ -611,7 +746,11 @@ class ST_FrequencyResponseResults:
         return fig
 
     def plot_polar_bode(
-        self, percentile=[], conf_interval=[], units="mic-pk-pk", **kwargs
+        self,
+        percentile=[],
+        conf_interval=[],
+        units="mic-pk-pk",
+        **kwargs,
     ):
         """Plot polar forced response using Plotly.
 
@@ -718,7 +857,7 @@ class ST_FrequencyResponseResults:
                     linecolor="black",
                     linewidth=2.5,
                 ),
-            )
+            ),
         )
 
         return fig
@@ -793,7 +932,7 @@ class ST_FrequencyResponseResults:
         return subplots
 
 
-class ST_TimeResponseResults:
+class ST_TimeResponseResults(ST_Results):
     """Store stochastic results and provide plots for Time Response and Orbit Response.
 
     Parameters
@@ -1167,12 +1306,12 @@ class ST_TimeResponseResults:
                 xaxis=dict(title=dict(text="<b>Rotor Length</b>"), showspikes=False),
                 yaxis=dict(title=dict(text="<b>Amplitude - X</b>"), showspikes=False),
                 zaxis=dict(title=dict(text="<b>Amplitude - Y</b>"), showspikes=False),
-            )
+            ),
         )
         return fig
 
 
-class ST_ForcedResponseResults:
+class ST_ForcedResponseResults(ST_Results):
     """Store stochastic results and provide plots for Forced Response.
 
     Parameters
@@ -1275,7 +1414,6 @@ class ST_ForcedResponseResults:
                 probe_resp[j] = np.sqrt((_probe_resp[0] * np.cos(angle)) ** 2 +
                                         (_probe_resp[1] * np.sin(angle)) ** 2)
             # fmt: on
-
             fig.add_trace(
                 go.Scatter(
                     x=self.frequency_range,
@@ -1644,7 +1782,7 @@ class ST_ForcedResponseResults:
             polar=dict(
                 radialaxis=fig2.layout.polar.radialaxis,
                 angularaxis=fig2.layout.polar.angularaxis,
-            )
+            ),
         )
 
         return fig

--- a/ross/tests/test_results.py
+++ b/ross/tests/test_results.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+from tempfile import tempdir
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
+
+from ross.rotor_assembly import *
+from ross.results import *
+
+
+@pytest.fixture
+def rotor1():
+    return rotor_example()
+
+
+def test_save_load_campbell(rotor1):
+    speed = np.linspace(0, 1000, 51)
+    response = rotor1.run_campbell(speed)
+
+    file = Path(tempdir) / "campbell.toml"
+    response.save(file)
+    response2 = CampbellResults.load(file)
+
+    assert response2.speed_range.all() == response.speed_range.all()
+    assert response2.wd.all() == response.wd.all()
+    assert response2.log_dec.all() == response.log_dec.all()
+    assert response2.whirl_values.all() == response.whirl_values.all()
+
+
+def test_save_load_criticalspeed(rotor1):
+    response = rotor1.run_critical_speed()
+
+    file = Path(tempdir) / "critical_speed.toml"
+    response.save(file)
+    response2 = CriticalSpeedResults.load(file)
+
+    assert response2.wn.all() == response.wn.all()
+    assert response2.wd.all() == response.wd.all()
+    assert response2.log_dec.all() == response.log_dec.all()
+    assert response2.damping_ratio.all() == response.damping_ratio.all()
+
+
+def test_save_load_modal(rotor1):
+    response = rotor1.run_modal(0)
+
+    file = Path(tempdir) / "modal.toml"
+    response.save(file)
+    response2 = ModalResults.load(file)
+
+    assert response2.speed == response.speed
+    assert response2.evalues.all() == response.evalues.all()
+    assert response2.evectors.all() == response.evectors.all()
+    assert response2.wn.all() == response.wn.all()
+    assert response2.wd.all() == response.wd.all()
+    assert response2.damping_ratio.all() == response.damping_ratio.all()
+    assert response2.log_dec.all() == response.log_dec.all()
+    assert response2.ndof == response.ndof
+    assert np.array(response2.nodes).all() == np.array(response.nodes).all()
+    assert np.array(response2.nodes_pos).all() == np.array(response.nodes_pos).all()
+    assert np.array(response2.shaft_elements_length).all() == np.array(response.shaft_elements_length).all()
+
+
+def test_save_load_freqresponse(rotor1):
+    speed = np.linspace(0, 1000, 51)
+    response = rotor1.run_freq_response(speed_range=speed)
+
+    file = Path(tempdir) / "frf.toml"
+    response.save(file)
+    response2 = FrequencyResponseResults.load(file)
+
+    assert response2.freq_resp.all() == response.freq_resp.all()
+    assert response2.speed_range.all() == response.speed_range.all()
+    assert response2.magnitude.all() == response.magnitude.all()
+    assert response2.phase.all() == response.phase.all()
+
+
+def test_save_load_unbalance_response(rotor1):
+    speed = np.linspace(0, 1000, 51)
+    response = rotor1.run_unbalance_response(3, 0.01, 0.0, speed)
+
+    file = Path(tempdir) / "unbalance.toml"
+    response.save(file)
+    response2 = ForcedResponseResults.load(file)
+
+    assert response2.rotor == response.rotor
+    assert response2.forced_resp.all() == response.forced_resp.all()
+    assert response2.speed_range.all() == response.speed_range.all()
+    assert response2.magnitude.all() == response.magnitude.all()
+    assert response2.phase.all() == response.phase.all()
+    assert response2.unbalance.all() == response.unbalance.all()
+
+
+def test_save_load_static(rotor1):
+    response = rotor1.run_static()
+
+    file = Path(tempdir) / "static.toml"
+    response.save(file)
+    response2 = StaticResults.load(file)
+
+    assert np.array(response2.deformation).all() == np.array(response.deformation).all()
+    assert np.array(response2.Vx).all() == np.array(response.Vx).all()
+    assert np.array(response2.Bm).all() == np.array(response.Bm).all()
+    assert np.array(response2.w_shaft).all() == np.array(response.w_shaft).all()
+    assert response2.disk_forces == response.disk_forces
+    assert response2.bearing_forces == response.bearing_forces
+    assert np.array(response2.nodes).all() == np.array(response.nodes).all()
+    assert np.array(response2.nodes_pos).all() == np.array(response.nodes_pos).all()
+    assert np.array(response2.Vx_axis).all() == np.array(response.Vx_axis).all()
+
+
+def test_save_load_convergence(rotor1):
+    response = rotor1.convergence()
+
+    file = Path(tempdir) / "convergence.toml"
+    response.save(file)
+    response2 = ConvergenceResults.load(file)
+
+    assert response2.el_num.all() == response.el_num.all()
+    assert response2.eigv_arr.all() == response.eigv_arr.all()
+    assert response2.error_arr.all() == response.error_arr.all()
+
+
+def test_save_load_timeresponse(rotor1):
+    speed = 500.0
+    size = 1000
+    node = 3
+    t = np.linspace(0, 10, size)
+    F = np.zeros((size, rotor1.ndof))
+    F[:, 4 * node] = 10 * np.cos(2 * t)
+    F[:, 4 * node + 1] = 10 * np.sin(2 * t)
+    response = rotor1.run_time_response(speed, F, t)
+
+    file = Path(tempdir) / "time.toml"
+    response.save(file)
+    response2 = TimeResponseResults.load(file)
+
+    assert response2.t.all() == response.t.all()
+    assert response2.yout.all() == response.yout.all()
+    assert response2.xout.all() == response.xout.all()
+    assert np.array(response2.nodes_list).all() == np.array(response.nodes_list).all()
+    assert np.array(response2.nodes_pos).all() == np.array(response.nodes_pos).all()
+    assert response2.number_dof == response.number_dof


### PR DESCRIPTION
This PR is a remake from PR #703. One can check the discussion history by accessing the previous link. 

Adds abstract classes "Results" and "ST_Results" that holds a generic save() and load() methods.
The other classes will inherit these methods from "Results" and "ST_Results". It avoids redundancies by repetition of functions with the same functionality.
The user will be able to save the results of a given analysis and load it later, avoiding the need to re-run the entire analysis, which could be costly.

Example of how to use it:

```python
        >>> # Example running a stochastic unbalance response
        >>> from tempfile import tempdir
        >>> from pathlib import Path
        >>> import ross.stochastic as srs

        >>> # Running an example
        >>> rotors = srs.st_rotor_example()
        >>> freq_range = np.linspace(0, 500, 31)
        >>> n = 3
        >>> m = np.random.uniform(0.001, 0.002, 10)
        >>> p = 0.0
        >>> results = rotors.run_unbalance_response(n, m, p, freq_range)

        >>> # create path for a temporary file
        >>> file = Path(tempdir) / 'results.toml'
        >>> results.save(file)

        >>> # Loading file
        >>> results2 = srs.ST_ForcedResponseResults.load(file)
        >>> results2.magnitude.all() == results.magnitude.all()
        True
```

