### PR TITLE
Add prefix for peak to peak units

### DIFF
--- a/ross/new_units.txt
+++ b/ross/new_units.txt
@@ -1,3 +1,6 @@
 RPM = rpm * 1
 Hz = rps
 hour = 60 * minute = h = hr
+
+# prefixes
+pkpk_- = 0.5

--- a/ross/results.py
+++ b/ross/results.py
@@ -928,7 +928,8 @@ class FrequencyResponseResults:
             Default is "rad/s"
         amplitude_units : str, optional
             Units for the y axis.
-            Default is "m/N"
+            Default is "m/N" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         mag_kwargs : optional
@@ -1072,7 +1073,8 @@ class FrequencyResponseResults:
             Default is "rad/s"
         amplitude_units : str, optional
             Units for the y axis.
-            Default is "m/N"
+            Default is "m/N" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
         phase_units : str, optional
             Units for the x axis.
             Default is "rad"
@@ -1168,7 +1170,8 @@ class FrequencyResponseResults:
             Default is "rad/s"
         amplitude_units : str, optional
             Units for the y axis.
-            Default is "m/N"
+            Default is "m/N" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
         phase_units : str, optional
             Units for the x axis.
             Default is "rad"
@@ -1298,7 +1301,8 @@ class ForcedResponseResults:
             Default is "rad/s"
         amplitude_units : str, optional
             Units for the y axis.
-            Default is "m"
+            Default is "m" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         kwargs : optional
@@ -1469,7 +1473,8 @@ class ForcedResponseResults:
             Default is "rad/s"
         amplitude_units : str, optional
             Units for the y axis.
-            Default is "m"
+            Default is "m" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
         phase_units : str, optional
             Units for the x axis.
             Default is "rad"
@@ -1586,7 +1591,8 @@ class ForcedResponseResults:
             Default is "rad/s"
         amplitude_units : str, optional
             Amplitude units.
-            Default is "m/N"
+            Default is "m/N" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
         phase_units : str, optional
             Phase units.
             Default is "rad"


### PR DESCRIPTION
This adds the prefix `pkpk_` to our unit registry.
The user can now use this in plots as:

```python
import ross as rs
import numpy as np

rotor = rs.rotor_example()
speed = np.linspace(0, 1000, 101)
response = rotor.run_unbalance_response(node=3,
                                        unbalance_magnitude=.001,
                                        unbalance_phase=0.0,
                                        frequency=speed)

response.plot([(0, 45)], amplitude_units='pkpk_micron')
```
Since this is a prefix, we can use it with any length units: `pkpk_m`, `pkpk_inch`, etc.

Closes #710.