### PR TITLE
Add minor and major axes to response plots

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1467,7 +1467,7 @@ class ForcedResponseResults(Results):
             angle = Q_(p[1], probe_units).to("rad").m
             vector = self._calculate_major_axis_per_node(node=p[0], angle=angle)
             try:
-                probe_tag = p[2] + f" - Node {p[0]}"
+                probe_tag = p[2]
             except IndexError:
                 probe_tag = f"Probe {i+1} - Node {p[0]}"
 
@@ -1552,7 +1552,7 @@ class ForcedResponseResults(Results):
             probe_phase = Q_(probe_phase, "rad").to(phase_units).m
 
             try:
-                probe_tag = p[2] + f" - Node {p[0]}"
+                probe_tag = p[2]
             except IndexError:
                 probe_tag = f"Probe {i+1} - Node {p[0]}"
 
@@ -1645,7 +1645,7 @@ class ForcedResponseResults(Results):
                 polar_theta_unit = "degrees"
 
             try:
-                probe_tag = p[2] + f" - Node {p[0]}"
+                probe_tag = p[2]
             except IndexError:
                 probe_tag = f"Probe {i+1} - Node {p[0]}"
 
@@ -3336,7 +3336,7 @@ class TimeResponseResults(Results):
             probe_resp = Q_(probe_resp, "m").to(displacement_units).m
 
             try:
-                probe_tag = p[2] + f" - Node {p[0]}"
+                probe_tag = p[2]
             except IndexError:
                 probe_tag = f"Probe {i+1} - Node {p[0]}"
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1663,7 +1663,8 @@ class Rotor(object):
 
         Examples
         --------
-        >>> rotor = rotor_example()
+        >>> import ross as rs
+        >>> rotor = rs.rotor_example()
         >>> speed = np.linspace(0, 1000, 101)
         >>> response = rotor.run_unbalance_response(node=3,
         ...                                         unbalance_magnitude=10.0,
@@ -1685,7 +1686,8 @@ class Rotor(object):
         plot unbalance response:
         >>> probe_node = 3
         >>> probe_angle = np.pi / 2
-        >>> fig = response.plot(probe=[(probe_node, probe_angle)])
+        >>> probe_tag = "my_probe"  # Tag is optional
+        >>> fig = response.plot(probe=[(probe_node, probe_angle, probe_tag)])
 
         plot deflected shape configuration
         >>> value = 600

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1689,6 +1689,18 @@ class Rotor(object):
         >>> probe_tag = "my_probe"  # Tag is optional
         >>> fig = response.plot(probe=[(probe_node, probe_angle, probe_tag)])
 
+        plot response for major axis:
+        >>> probe_node = 3
+        >>> probe_angle = "major"   # for major axis
+        >>> probe_tag = "my_probe"  # optional
+        >>> fig = response.plot(probe=[(probe_node, probe_angle, probe_tag)])
+
+        plot response for minor axis:
+        >>> probe_node = 3
+        >>> probe_angle = "minor"   # for minor axis
+        >>> probe_tag = "my_probe"  # optional
+        >>> fig = response.plot(probe=[(probe_node, probe_angle, probe_tag)])
+
         plot deflected shape configuration
         >>> value = 600
         >>> fig = response.plot_deflected_shape(speed=value)


### PR DESCRIPTION
- New method in `ForcedResponseResults`: `_calculate_major_axis_per_node()` calculates the major and minor axes at a given node for all frequencies in `speed_range` array. Plotting methods will use this function to simplify and clear their codes.
- New option to add tags to probes in unbalance and time response. Users Will be able to name probes. If nothing is passed, it uses a default tag enumerating the probes.

An example of how these features works is shown in Issue #714.