### PR TITLE
Add units to stochastic ross module

### DIFF
--- a/ross/stochastic/st_bearing_seal_element.py
+++ b/ross/stochastic/st_bearing_seal_element.py
@@ -10,6 +10,7 @@ from ross.fluid_flow import fluid_flow as flow
 from ross.fluid_flow.fluid_flow_coefficients import \
     calculate_stiffness_and_damping_coefficients
 from ross.stochastic.st_results_elements import plot_histogram
+from ross.units import check_units
 
 # fmt: on
 
@@ -110,6 +111,7 @@ class ST_BearingElement:
     5
     """
 
+    @check_units
     def __init__(
         self,
         n,
@@ -485,6 +487,7 @@ class ST_BearingElement:
         attribute_dict = locals()
         attribute_dict.pop("cls")
         attribute_dict.pop("omega")
+        attribute_dict.pop("is_random")
         size = len(attribute_dict[is_random[0]])
         args_dict = {
             "kxx": np.zeros((len(omega), size)),

--- a/ross/stochastic/st_disk_element.py
+++ b/ross/stochastic/st_disk_element.py
@@ -8,6 +8,7 @@ import numpy as np
 from ross.disk_element import DiskElement
 from ross.stochastic.st_materials import ST_Material
 from ross.stochastic.st_results_elements import plot_histogram
+from ross.units import check_units
 
 __all__ = ["ST_DiskElement", "st_disk_example"]
 
@@ -55,7 +56,17 @@ class ST_DiskElement:
     5
     """
 
-    def __init__(self, n, m, Id, Ip, tag=None, color="Firebrick", is_random=None):
+    @check_units
+    def __init__(
+        self,
+        n,
+        m,
+        Id,
+        Ip,
+        tag=None,
+        color="Firebrick",
+        is_random=None,
+    ):
         attribute_dict = dict(n=n, m=m, Id=Id, Ip=Ip, tag=tag, color=color)
 
         self.is_random = is_random
@@ -216,7 +227,9 @@ class ST_DiskElement:
         >>> # fig.show()
         """
         label = dict(
-            m="Mass", Id="Diametral moment of inertia", Ip="Polar moment of inertia"
+            m="Mass",
+            Id="Diametral moment of inertia",
+            Ip="Polar moment of inertia",
         )
         if var_list is None:
             var_list = self.is_random
@@ -232,7 +245,17 @@ class ST_DiskElement:
         )
 
     @classmethod
-    def from_geometry(cls, n, material, width, i_d, o_d, tag=None, is_random=None):
+    @check_units
+    def from_geometry(
+        cls,
+        n,
+        material,
+        width,
+        i_d,
+        o_d,
+        tag=None,
+        is_random=None,
+    ):
         """Random disk element.
 
         Creates an object containing a list with random instances of
@@ -293,7 +316,12 @@ class ST_DiskElement:
             o_d = np.array(o_d)
 
         attribute_dict = dict(
-            n=n, material=material, width=width, i_d=i_d, o_d=o_d, tag=tag
+            n=n,
+            material=material,
+            width=width,
+            i_d=i_d,
+            o_d=o_d,
+            tag=tag,
         )
         size = len(attribute_dict[is_random[0]])
 
@@ -336,6 +364,10 @@ def st_disk_example():
     2
     """
     elm = ST_DiskElement(
-        n=1, m=[30, 40], Id=[0.2, 0.3], Ip=[0.5, 0.7], is_random=["m", "Id", "Ip"]
+        n=1,
+        m=[30, 40],
+        Id=[0.2, 0.3],
+        Ip=[0.5, 0.7],
+        is_random=["m", "Id", "Ip"],
     )
     return elm

--- a/ross/stochastic/st_materials.py
+++ b/ross/stochastic/st_materials.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ross.materials import Material
 from ross.stochastic.st_results_elements import plot_histogram
+from ross.units import check_units
 
 __all__ = ["ST_Material"]
 
@@ -60,6 +61,7 @@ class ST_Material:
     5
     """
 
+    @check_units
     def __init__(
         self, name, rho, E=None, G_s=None, Poisson=None, color="#525252", **kwargs
     ):
@@ -91,7 +93,12 @@ class ST_Material:
             Poisson = np.asarray(Poisson)
 
         attribute_dict = dict(
-            name=name, rho=rho, E=E, G_s=G_s, Poisson=Poisson, color=color
+            name=name,
+            rho=rho,
+            E=E,
+            G_s=G_s,
+            Poisson=Poisson,
+            color=color,
         )
         self.is_random = is_random
         self.attribute_dict = attribute_dict

--- a/ross/stochastic/st_point_mass.py
+++ b/ross/stochastic/st_point_mass.py
@@ -5,6 +5,7 @@ analysis.
 """
 from ross.point_mass import PointMass
 from ross.stochastic.st_results_elements import plot_histogram
+from ross.units import check_units
 
 __all__ = ["ST_PointMass", "st_pointmass_example"]
 
@@ -56,10 +57,25 @@ class ST_PointMass:
     5
     """
 
+    @check_units
     def __init__(
-        self, n, m=None, mx=None, my=None, tag=None, color="DarkSalmon", is_random=None
+        self,
+        n,
+        m=None,
+        mx=None,
+        my=None,
+        tag=None,
+        color="DarkSalmon",
+        is_random=None,
     ):
-        attribute_dict = dict(n=n, m=m, mx=mx, my=my, tag=tag, color=color)
+        attribute_dict = dict(
+            n=n,
+            m=m,
+            mx=mx,
+            my=my,
+            tag=tag,
+            color=color,
+        )
 
         self.is_random = is_random
         self.attribute_dict = attribute_dict
@@ -217,7 +233,9 @@ class ST_PointMass:
         >>> # fig.show()
         """
         label = dict(
-            mx="Mass on the X direction", my="Mass on the Y direction", m="Mass"
+            mx="Mass on the X direction",
+            my="Mass on the Y direction",
+            m="Mass",
         )
         if var_list is None:
             var_list = self.is_random

--- a/ross/stochastic/st_results.py
+++ b/ross/stochastic/st_results.py
@@ -2,6 +2,7 @@
 
 This module returns graphs for each type of analyses in st_rotor_assembly.py.
 """
+import copy
 import inspect
 from abc import ABC
 from collections.abc import Iterable
@@ -11,12 +12,10 @@ import numpy as np
 import toml
 from plotly import express as px
 from plotly import graph_objects as go
-from plotly import io as pio
 from plotly.subplots import make_subplots
 
 from ross.plotly_theme import tableau_colors
-
-pio.renderers.default = "browser"
+from ross.units import Q_
 
 # set Plotly palette of colors
 colors1 = px.colors.qualitative.Dark24
@@ -176,7 +175,14 @@ class ST_CampbellResults(ST_Results):
         self.wd = wd
         self.log_dec = log_dec
 
-    def plot_nat_freq(self, percentile=[], conf_interval=[], harmonics=[1], **kwargs):
+    def plot_nat_freq(
+        self,
+        percentile=[],
+        conf_interval=[],
+        harmonics=[1],
+        frequency_units="rad/s",
+        **kwargs,
+    ):
         """Plot the damped natural frequencies vs frequency.
 
         Parameters
@@ -190,9 +196,12 @@ class ST_CampbellResults(ST_Results):
         harmonics: list, optional
             List withe the harmonics to be plotted.
             The default is to plot 1x.
+        frequency_units : str, optional
+            Frequency units.
+            Default is "rad/s"
         kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
 
         Returns
@@ -200,65 +209,62 @@ class ST_CampbellResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
-        default_values = dict(mode="lines")
+        wd = Q_(self.wd, "rad/s").to(frequency_units).m
+        speed_range = Q_(self.speed_range, "rad/s").to(frequency_units).m
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
 
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
-
         fig = go.Figure()
-        x = np.concatenate((self.speed_range, self.speed_range[::-1]))
+        x = np.concatenate((speed_range, speed_range[::-1]))
 
         for j, h in enumerate(harmonics):
             fig.add_trace(
                 go.Scatter(
-                    x=self.speed_range,
-                    y=self.speed_range * h,
-                    opacity=1.0,
+                    x=speed_range,
+                    y=speed_range * h,
+                    mode="lines",
                     name="{}x speed".format(h),
                     line=dict(width=3, color=colors1[j], dash="dashdot"),
                     legendgroup="speed{}".format(j),
                     hovertemplate=("Frequency: %{x:.3f}<br>" + "Frequency: %{y:.3f}"),
-                    **kwargs,
                 )
             )
 
-        for j in range(self.wd.shape[0]):
+        for j in range(wd.shape[0]):
             fig.add_trace(
                 go.Scatter(
-                    x=self.speed_range,
-                    y=np.mean(self.wd[j], axis=1),
-                    opacity=1.0,
+                    x=speed_range,
+                    y=np.mean(wd[j], axis=1),
                     name="Mean - Mode {}".format(j + 1),
+                    mode="lines",
                     line=dict(width=3, color=colors1[j]),
                     legendgroup="mean{}".format(j),
                     hovertemplate=("Frequency: %{x:.3f}<br>" + "Frequency: %{y:.3f}"),
-                    **kwargs,
                 )
             )
             for i, p in enumerate(percentile):
                 fig.add_trace(
                     go.Scatter(
-                        x=self.speed_range,
-                        y=np.percentile(self.wd[j], p, axis=1),
+                        x=speed_range,
+                        y=np.percentile(wd[j], p, axis=1),
                         opacity=0.6,
+                        mode="lines",
                         line=dict(width=2.5, color=colors2[j]),
                         name="percentile: {}%".format(p),
                         legendgroup="percentile{}{}".format(j, i),
                         hovertemplate=(
                             "Frequency: %{x:.3f}<br>" + "Frequency: %{y:.3f}"
                         ),
-                        **kwargs,
                     )
                 )
             for i, p in enumerate(conf_interval):
-                p1 = np.percentile(self.wd[j], 50 + p / 2, axis=1)
-                p2 = np.percentile(self.wd[j], 50 - p / 2, axis=1)
+                p1 = np.percentile(wd[j], 50 + p / 2, axis=1)
+                p2 = np.percentile(wd[j], 50 - p / 2, axis=1)
                 fig.add_trace(
                     go.Scatter(
                         x=x,
                         y=np.concatenate((p1, p2[::-1])),
+                        mode="lines",
                         line=dict(width=1, color=colors1[j]),
                         fill="toself",
                         fillcolor=colors1[j],
@@ -268,46 +274,30 @@ class ST_CampbellResults(ST_Results):
                         hovertemplate=(
                             "Frequency: %{x:.3f}<br>" + "Frequency: %{y:.3f}"
                         ),
-                        **kwargs,
                     )
                 )
 
         fig.update_xaxes(
-            title_text="<b>Rotor speed</b>",
-            title_font=dict(family="Arial", size=20),
-            tickfont=dict(size=16),
-            gridcolor="lightgray",
-            showline=True,
-            linewidth=2.5,
-            linecolor="black",
-            mirror=True,
+            title_text=f"Frequency ({frequency_units})",
+            range=[np.min(speed_range), np.max(speed_range)],
+            exponentformat="none",
         )
         fig.update_yaxes(
-            title_text="<b>Damped Natural Frequencies</b>",
-            title_font=dict(family="Arial", size=20),
-            tickfont=dict(size=16),
-            gridcolor="lightgray",
-            showline=True,
-            linewidth=2.5,
-            linecolor="black",
-            mirror=True,
+            title_text=f"Natural Frequencies ({frequency_units})",
+            range=[0, 1.1 * np.max(wd)],
         )
-        fig.update_layout(
-            width=1200,
-            height=900,
-            plot_bgcolor="white",
-            legend=dict(
-                font=dict(family="sans-serif", size=14),
-                bgcolor="white",
-                bordercolor="black",
-                borderwidth=2,
-            ),
-        )
+        fig.update_layout(**kwargs)
 
         return fig
 
-    def plot_log_dec(self, percentile=[], conf_interval=[], harmonics=[1], **kwargs):
-        """Plot the log_dec vs frequency.
+    def plot_log_dec(
+        self,
+        percentile=[],
+        conf_interval=[],
+        frequency_units="rad/s",
+        **kwargs,
+    ):
+        """Plot the log. decrement vs frequency.
 
         Parameters
         ----------
@@ -315,14 +305,14 @@ class ST_CampbellResults(ST_Results):
             Sequence of percentiles to compute, which must be between
             0 and 100 inclusive.
         conf_interval : list, optional
-            Sequence of confidence intervals to compute, which must be
-            between 0 and 100 inclusive.
-        harmonics: list, optional
-            List withe the harmonics to be plotted.
-            The default is to plot 1x.
+            Sequence of confidence intervals to compute, which must be between
+            0 and 100 inclusive.
+        frequency_units : str, optional
+            Frequency units.
+            Default is "rad/s"
         kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
 
         Returns
@@ -330,20 +320,17 @@ class ST_CampbellResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
-        default_values = dict(mode="lines")
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
-
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
+        speed_range = Q_(self.speed_range, "rad/s").to(frequency_units).m
 
         fig = go.Figure()
-        x = np.concatenate((self.speed_range, self.speed_range[::-1]))
+        x = np.concatenate((speed_range, speed_range[::-1]))
 
         for j in range(self.log_dec.shape[0]):
             fig.add_trace(
                 go.Scatter(
-                    x=self.speed_range,
+                    x=speed_range,
                     y=np.mean(self.log_dec[j], axis=1),
                     opacity=1.0,
                     name="Mean - Mode {}".format(j + 1),
@@ -357,7 +344,7 @@ class ST_CampbellResults(ST_Results):
             for i, p in enumerate(percentile):
                 fig.add_trace(
                     go.Scatter(
-                        x=self.speed_range,
+                        x=speed_range,
                         y=np.percentile(self.log_dec[j], p, axis=1),
                         opacity=0.6,
                         line=dict(width=2.5, color=colors2[j]),
@@ -387,40 +374,27 @@ class ST_CampbellResults(ST_Results):
                 )
 
         fig.update_xaxes(
-            title_text="<b>Rotor speed</b>",
-            title_font=dict(family="Arial", size=20),
-            tickfont=dict(size=16),
-            gridcolor="lightgray",
-            showline=True,
-            linewidth=2.5,
-            linecolor="black",
-            mirror=True,
+            title_text=f"Frequency ({frequency_units})",
+            range=[np.min(speed_range), np.max(speed_range)],
+            exponentformat="none",
         )
         fig.update_yaxes(
-            title_text="<b>Logarithmic decrement</b>",
-            title_font=dict(family="Arial", size=20),
-            tickfont=dict(size=16),
-            gridcolor="lightgray",
-            showline=True,
-            linewidth=2.5,
-            linecolor="black",
-            mirror=True,
+            title_text="Logarithmic decrement",
         )
-        fig.update_layout(
-            plot_bgcolor="white",
-            width=1200,
-            height=900,
-            legend=dict(
-                font=dict(family="sans-serif", size=14),
-                bgcolor="white",
-                bordercolor="black",
-                borderwidth=2,
-            ),
-        )
+        fig.update_layout(**kwargs)
 
         return fig
 
-    def plot(self, percentile=[], conf_interval=[], *args, **kwargs):
+    def plot(
+        self,
+        percentile=[],
+        conf_interval=[],
+        harmonics=[1],
+        frequency_units="rad/s",
+        freq_kwargs=None,
+        logdec_kwargs=None,
+        fig_kwargs=None,
+    ):
         """Plot Campbell Diagram.
 
         This method plots Campbell Diagram.
@@ -433,51 +407,56 @@ class ST_CampbellResults(ST_Results):
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be between
             0 and 100 inclusive.
-        args: optional
-            harmonics : list, optional
-                List with the harmonics to be plotted.
-                The default is to plot 1x.
-        kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
+        harmonics: list, optional
+            List withe the harmonics to be plotted.
+            The default is to plot 1x.
+        frequency_units : str, optional
+            Frequency units.
+            Default is "rad/s"
+        freq_kwargs : dict, optional
+            Additional key word arguments can be passed to change the natural frequency
+            vs frequency plot layout only (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
+        logdec_kwargs : dict, optional
+            Additional key word arguments can be passed to change the log. decrement
+            vs frequency plot layout only (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+        fig_kwargs : dict, optional
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...). This kwargs override "freq_kwargs",
+            "logdec_kwargs" dictionaries.
+            *See Plotly Python make_subplots Reference for more information.
 
         Returns
         -------
         subplots : Plotly graph_objects.make_subplots()
             Plotly figure with diagrams for frequency and log dec.
         """
-        fig0 = self.plot_nat_freq(percentile, conf_interval, *args, **kwargs)
+        freq_kwargs = {} if freq_kwargs is None else copy.copy(freq_kwargs)
+        logdec_kwargs = {} if logdec_kwargs is None else copy.copy(logdec_kwargs)
+        fig_kwargs = {} if fig_kwargs is None else copy.copy(fig_kwargs)
 
-        default_values = dict(showlegend=False)
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
-
-        fig1 = self.plot_log_dec(percentile, conf_interval, *args, **kwargs)
-
-        subplots = make_subplots(rows=1, cols=2)
-        for data in fig0["data"]:
-            subplots.add_trace(data, 1, 1)
-        for data in fig1["data"]:
-            subplots.add_trace(data, 1, 2)
-
-        subplots.update_xaxes(fig0.layout.xaxis, row=1, col=1)
-        subplots.update_yaxes(fig1.layout.yaxis, row=1, col=1)
-        subplots.update_xaxes(fig0.layout.xaxis, row=1, col=2)
-        subplots.update_yaxes(fig1.layout.yaxis, row=1, col=2)
-        subplots.update_layout(
-            plot_bgcolor="white",
-            width=1800,
-            height=900,
-            legend=dict(
-                font=dict(family="sans-serif", size=14),
-                bgcolor="white",
-                bordercolor="black",
-                borderwidth=2,
-            ),
+        fig0 = self.plot_nat_freq(
+            percentile, conf_interval, harmonics, frequency_units, **freq_kwargs
+        )
+        fig1 = self.plot_log_dec(
+            percentile, conf_interval, frequency_units, **logdec_kwargs
         )
 
-        return subplots
+        fig = make_subplots(rows=1, cols=2)
+        for data in fig0["data"]:
+            fig.add_trace(data, 1, 1)
+        for data in fig1["data"]:
+            data.showlegend = False
+            fig.add_trace(data, 1, 2)
+
+        fig.update_xaxes(fig0.layout.xaxis, row=1, col=1)
+        fig.update_yaxes(fig0.layout.yaxis, row=1, col=1)
+        fig.update_xaxes(fig1.layout.xaxis, row=1, col=2)
+        fig.update_yaxes(fig1.layout.yaxis, row=1, col=2)
+        fig.update_layout(**fig_kwargs)
+
+        return fig
 
 
 class ST_FrequencyResponseResults(ST_Results):
@@ -500,22 +479,29 @@ class ST_FrequencyResponseResults(ST_Results):
         Plotly figure with amplitude vs frequency phase angle vs frequency.
     """
 
-    def __init__(self, speed_range, magnitude, phase):
+    def __init__(self, speed_range, freq_resp, velc_resp, accl_resp):
         self.speed_range = speed_range
-        self.magnitude = magnitude
-        self.phase = phase
+        self.freq_resp = freq_resp
+        self.velc_resp = velc_resp
+        self.accl_resp = accl_resp
 
     def plot_magnitude(
         self,
         percentile=[],
         conf_interval=[],
-        units="mic-pk-pk",
+        frequency_units="rad/s",
+        amplitude_units="m/N",
+        fig=None,
         **kwargs,
     ):
-        """Plot amplitude vs frequency.
+        """Plot stochastic frequency response (magnitude) using Plotly.
 
         This method plots the frequency response magnitude given an output and
         an input using Plotly.
+        It is possible to plot displacement, velocity and accelaration responses,
+        depending on the unit entered in 'amplitude_units'. If '[length]/[force]',
+        it displays the displacement; If '[speed]/[force]', it displays the velocity;
+        If '[acceleration]/[force]', it displays the acceleration.
 
         Parameters
         ----------
@@ -525,243 +511,20 @@ class ST_FrequencyResponseResults(ST_Results):
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be between
             0% and 100% inclusive.
-        units : str, optional
-            Unit system
-            Default is "mic-pk-pk".
-        kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
-            *See Plotly Python Figure Reference for more information.
-
-        Returns
-        -------
+        frequency_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units are:
+                '[length]/[force]' - Displays the displacement;
+                '[speed]/[force]' - Displays the velocity;
+                '[acceleration]/[force]' - Displays the acceleration.
+            Default is "m/N" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m/N)
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
-        """
-        if units == "m":
-            y_axis_label = "<b>Amplitude (m)</b>"
-        elif units == "mic-pk-pk":
-            y_axis_label = "<b>Amplitude (μ pk-pk)</b>"
-        else:
-            y_axis_label = "<b>Amplitude (dB)</b>"
-
-        default_values = dict(mode="lines")
-        conf_interval = np.sort(conf_interval)
-        percentile = np.sort(percentile)
-
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
-
-        fig = go.Figure()
-
-        fig.add_trace(
-            go.Scatter(
-                x=self.speed_range,
-                y=np.mean(self.magnitude, axis=1),
-                opacity=1.0,
-                name="Mean",
-                line=dict(width=3, color="black"),
-                legendgroup="mean",
-                hovertemplate=("Frequency: %{x:.2f}<br>" + "Amplitude: %{y:.2e}"),
-                **kwargs,
-            )
-        )
-        for i, p in enumerate(percentile):
-            fig.add_trace(
-                go.Scatter(
-                    x=self.speed_range,
-                    y=np.percentile(self.magnitude, p, axis=1),
-                    opacity=0.6,
-                    line=dict(width=2.5, color=colors2[i]),
-                    name="percentile: {}%".format(p),
-                    legendgroup="percentile{}".format(i),
-                    hovertemplate=("Frequency: %{x:.2f}<br>" + "Amplitude: %{y:.2e}"),
-                    **kwargs,
-                )
-            )
-
-        x = np.concatenate((self.speed_range, self.speed_range[::-1]))
-        for i, p in enumerate(conf_interval):
-            p1 = np.percentile(self.magnitude, 50 + p / 2, axis=1)
-            p2 = np.percentile(self.magnitude, 50 - p / 2, axis=1)
-            fig.add_trace(
-                go.Scatter(
-                    x=x,
-                    y=np.concatenate((p1, p2[::-1])),
-                    line=dict(width=1, color=colors1[i]),
-                    fill="toself",
-                    fillcolor=colors1[i],
-                    opacity=0.5,
-                    name="confidence interval: {}%".format(p),
-                    legendgroup="conf{}".format(i),
-                    hovertemplate=("Frequency: %{x:.2f}<br>" + "Amplitude: %{y:.2e}"),
-                    **kwargs,
-                )
-            )
-
-        fig.update_xaxes(
-            title_text="<b>Frequency</b>",
-            title_font=dict(family="Arial", size=20),
-            tickfont=dict(size=16),
-            gridcolor="lightgray",
-            showline=True,
-            linewidth=2.5,
-            linecolor="black",
-            mirror=True,
-        )
-        fig.update_yaxes(
-            title_text=y_axis_label,
-            title_font=dict(family="Arial", size=20),
-            tickfont=dict(size=16),
-            gridcolor="lightgray",
-            showline=True,
-            linewidth=2.5,
-            linecolor="black",
-            mirror=True,
-        )
-        fig.update_layout(
-            plot_bgcolor="white",
-            width=1200,
-            height=900,
-            legend=dict(
-                font=dict(family="sans-serif", size=14),
-                bgcolor="white",
-                bordercolor="black",
-                borderwidth=2,
-            ),
-        )
-
-        return fig
-
-    def plot_phase(self, percentile=[], conf_interval=[], **kwargs):
-        """Plot phase angle response.
-
-        This method plots the phase response given an output and an input
-        using bokeh.
-
-        Parameters
-        ----------
-        percentile : list, optional
-            Sequence of percentiles to compute, which must be between
-            0 and 100 inclusive.
-        conf_interval : list, optional
-            Sequence of confidence intervals to compute, which must be between
-            0 and 100 inclusive.
         kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
-            *See Plotly Python Figure Reference for more information.
-
-        Returns
-        -------
-        fig : Plotly graph_objects.Figure()
-            The figure object with the plot.
-        """
-        default_values = dict(mode="lines")
-        conf_interval = np.sort(conf_interval)
-        percentile = np.sort(percentile)
-
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
-
-        fig = go.Figure()
-
-        fig.add_trace(
-            go.Scatter(
-                x=self.speed_range,
-                y=np.mean(self.phase, axis=1),
-                opacity=1.0,
-                name="Mean",
-                line=dict(width=3, color="black"),
-                legendgroup="mean",
-                hovertemplate=("Frequency: %{x:.2f}<br>" + "Phase: %{y:.2f}"),
-                **kwargs,
-            )
-        )
-        for i, p in enumerate(percentile):
-            fig.add_trace(
-                go.Scatter(
-                    x=self.speed_range,
-                    y=np.percentile(self.phase, p, axis=1),
-                    opacity=0.6,
-                    line=dict(width=2.5, color=colors2[i]),
-                    name="percentile: {}%".format(p),
-                    legendgroup="percentile{}".format(i),
-                    hovertemplate=("Frequency: %{x:.2f}<br>" + "Phase: %{y:.2f}"),
-                    **kwargs,
-                )
-            )
-
-        x = np.concatenate((self.speed_range, self.speed_range[::-1]))
-        for i, p in enumerate(conf_interval):
-            p1 = np.percentile(self.phase, 50 + p / 2, axis=1)
-            p2 = np.percentile(self.phase, 50 - p / 2, axis=1)
-            fig.add_trace(
-                go.Scatter(
-                    x=x,
-                    y=np.concatenate((p1, p2[::-1])),
-                    line=dict(width=1, color=colors1[i]),
-                    fill="toself",
-                    fillcolor=colors1[i],
-                    opacity=0.5,
-                    name="confidence interval: {}%".format(p),
-                    legendgroup="conf{}".format(i),
-                    hovertemplate=("Frequency: %{x:.2f}<br>" + "Phase: %{y:.2f}"),
-                    **kwargs,
-                )
-            )
-
-        fig.update_xaxes(
-            title_text="<b>Frequency</b>",
-            title_font=dict(family="Arial", size=20),
-            tickfont=dict(size=16),
-            gridcolor="lightgray",
-            showline=True,
-            linewidth=2.5,
-            linecolor="black",
-            mirror=True,
-        )
-        fig.update_yaxes(
-            title_text="<b>Phase Angle</b>",
-            title_font=dict(family="Arial", size=20),
-            tickfont=dict(size=16),
-            gridcolor="lightgray",
-            showline=True,
-            linewidth=2.5,
-            linecolor="black",
-            mirror=True,
-        )
-        fig.update_layout(
-            plot_bgcolor="white",
-            width=1200,
-            height=900,
-            legend=dict(
-                font=dict(family="sans-serif", size=14),
-                bgcolor="white",
-                bordercolor="black",
-                borderwidth=2,
-            ),
-        )
-
-        return fig
-
-    def plot_polar_bode(
-        self,
-        percentile=[],
-        conf_interval=[],
-        units="mic-pk-pk",
-        **kwargs,
-    ):
-        """Plot polar forced response using Plotly.
-
-        Parameters
-        ----------
-        dof : int
-            Degree of freedom.
-        units : str
-            Magnitude unit system.
-            Default is "mic-pk-pk"
-        polar_kwargs : optional
             Additional key word arguments can be passed to change the plot layout only
             (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
@@ -771,27 +534,306 @@ class ST_FrequencyResponseResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
-        default_values = dict(mode="lines")
+        speed_range = Q_(self.speed_range, "rad/s").to(frequency_units).m
+
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
 
-        if units == "m":
-            r_axis_label = "<b>Amplitude (m)</b>"
-        elif units == "mic-pk-pk":
-            r_axis_label = "<b>Amplitude (μ pk-pk)</b>"
+        dummy_var = Q_(1, amplitude_units)
+        if dummy_var.check("[length]/[force]"):
+            mag = np.abs(self.freq_resp)
+            mag = Q_(mag, "m/N").to(amplitude_units).m
+            y_label = "Displacement"
+        elif dummy_var.check("[speed]/[force]"):
+            mag = np.abs(self.velc_resp)
+            mag = Q_(mag, "m/s/N").to(amplitude_units).m
+            y_label = "Velocity"
+        elif dummy_var.check("[acceleration]/[force]"):
+            mag = np.abs(self.accl_resp)
+            mag = Q_(mag, "m/s**2/N").to(amplitude_units).m
+            y_label = "Acceleration"
         else:
-            r_axis_label = "<b>Amplitude (dB)</b>"
+            raise ValueError(
+                "Not supported unit. Options are '[length]/[force]', '[speed]/[force]', '[acceleration]/[force]'"
+            )
 
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
+        if fig is None:
+            fig = go.Figure()
+
+        fig.add_trace(
+            go.Scatter(
+                x=speed_range,
+                y=np.mean(mag, axis=1),
+                mode="lines",
+                name="Mean",
+                line=dict(width=3, color="black"),
+                legendgroup="mean",
+                hovertemplate=("Frequency: %{x:.2f}<br>" + "Amplitude: %{y:.2e}"),
+            )
+        )
+        for i, p in enumerate(percentile):
+            fig.add_trace(
+                go.Scatter(
+                    x=speed_range,
+                    y=np.percentile(mag, p, axis=1),
+                    mode="lines",
+                    opacity=0.6,
+                    line=dict(width=2.5, color=colors2[i]),
+                    name="percentile: {}%".format(p),
+                    legendgroup="percentile{}".format(i),
+                    hovertemplate=("Frequency: %{x:.2f}<br>" + "Amplitude: %{y:.2e}"),
+                )
+            )
+
+        x = np.concatenate((speed_range, speed_range[::-1]))
+        for i, p in enumerate(conf_interval):
+            p1 = np.percentile(mag, 50 + p / 2, axis=1)
+            p2 = np.percentile(mag, 50 - p / 2, axis=1)
+            fig.add_trace(
+                go.Scatter(
+                    x=x,
+                    y=np.concatenate((p1, p2[::-1])),
+                    mode="lines",
+                    line=dict(width=1, color=colors1[i]),
+                    fill="toself",
+                    fillcolor=colors1[i],
+                    opacity=0.5,
+                    name="confidence interval: {}%".format(p),
+                    legendgroup="conf{}".format(i),
+                    hovertemplate=("Frequency: %{x:.2f}<br>" + "Amplitude: %{y:.2e}"),
+                )
+            )
+
+        fig.update_xaxes(
+            title_text=f"Frequency ({frequency_units})",
+            range=[np.min(speed_range), np.max(speed_range)],
+        )
+        fig.update_yaxes(title_text=f"{y_label} ({amplitude_units})")
+        fig.update_layout(**kwargs)
+
+        return fig
+
+    def plot_phase(
+        self,
+        percentile=[],
+        conf_interval=[],
+        frequency_units="rad/s",
+        amplitude_units="m/N",
+        phase_units="rad",
+        fig=None,
+        **kwargs,
+    ):
+        """Plot stochastic frequency response (phase) using Plotly.
+
+        This method plots the phase response given an output and an input
+        using Plotly.
+        It is possible to plot displacement, velocity and accelaration responses,
+        depending on the unit entered in 'amplitude_units'. If '[length]/[force]',
+        it displays the displacement; If '[speed]/[force]', it displays the velocity;
+        If '[acceleration]/[force]', it displays the acceleration.
+
+        Parameters
+        ----------
+        percentile : list, optional
+            Sequence of percentiles to compute, which must be between
+            0 and 100 inclusive.
+        conf_interval : list, optional
+            Sequence of confidence intervals to compute, which must be between
+            0 and 100 inclusive.
+        frequency_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units are:
+                '[length]/[force]' - Displays the displacement;
+                '[speed]/[force]' - Displays the velocity;
+                '[acceleration]/[force]' - Displays the acceleration.
+            Default is "m/N" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m/N)
+        phase_units : str, optional
+            Units for the x axis.
+            Default is "rad"
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
+        kwargs : optional
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+
+        Returns
+        -------
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
+        """
+        speed_range = Q_(self.speed_range, "rad/s").to(frequency_units).m
+
+        conf_interval = np.sort(conf_interval)
+        percentile = np.sort(percentile)
+
+        dummy_var = Q_(1, amplitude_units)
+        if dummy_var.check("[length]/[force]"):
+            phase = np.angle(self.freq_resp)
+        elif dummy_var.check("[speed]/[force]"):
+            phase = np.angle(self.velc_resp)
+        elif dummy_var.check("[acceleration]/[force]"):
+            phase = np.angle(self.accl_resp)
+        else:
+            raise ValueError(
+                "Not supported unit. Options are '[length]/[force]', '[speed]/[force]', '[acceleration]/[force]'"
+            )
+
+        phase = Q_(phase, "rad").to(phase_units).m
+
+        fig = go.Figure()
+
+        fig.add_trace(
+            go.Scatter(
+                x=speed_range,
+                y=np.mean(phase, axis=1),
+                opacity=1.0,
+                mode="lines",
+                name="Mean",
+                line=dict(width=3, color="black"),
+                legendgroup="mean",
+                hovertemplate=("Frequency: %{x:.2f}<br>" + "Phase: %{y:.2f}"),
+            )
+        )
+        for i, p in enumerate(percentile):
+            fig.add_trace(
+                go.Scatter(
+                    x=speed_range,
+                    y=np.percentile(phase, p, axis=1),
+                    mode="lines",
+                    opacity=0.6,
+                    line=dict(width=2.5, color=colors2[i]),
+                    name="percentile: {}%".format(p),
+                    legendgroup="percentile{}".format(i),
+                    hovertemplate=("Frequency: %{x:.2f}<br>" + "Phase: %{y:.2f}"),
+                )
+            )
+
+        x = np.concatenate((speed_range, speed_range[::-1]))
+        for i, p in enumerate(conf_interval):
+            p1 = np.percentile(phase, 50 + p / 2, axis=1)
+            p2 = np.percentile(phase, 50 - p / 2, axis=1)
+            fig.add_trace(
+                go.Scatter(
+                    x=x,
+                    y=np.concatenate((p1, p2[::-1])),
+                    mode="lines",
+                    line=dict(width=1, color=colors1[i]),
+                    fill="toself",
+                    fillcolor=colors1[i],
+                    opacity=0.5,
+                    name="confidence interval: {}%".format(p),
+                    legendgroup="conf{}".format(i),
+                    hovertemplate=("Frequency: %{x:.2f}<br>" + "Phase: %{y:.2f}"),
+                )
+            )
+
+        fig.update_xaxes(
+            title_text=f"Frequency ({frequency_units})",
+            range=[np.min(speed_range), np.max(speed_range)],
+        )
+        fig.update_yaxes(title_text=f"Phase ({phase_units})")
+        fig.update_layout(**kwargs)
+
+        return fig
+
+    def plot_polar_bode(
+        self,
+        percentile=[],
+        conf_interval=[],
+        frequency_units="rad/s",
+        amplitude_units="m/N",
+        phase_units="rad",
+        fig=None,
+        **kwargs,
+    ):
+        """Plot stochastic frequency response (polar) using Plotly.
+
+        This method plots the frequency response (polar graph) given an output and
+        an input using Plotly.
+        It is possible to plot displacement, velocity and accelaration responses,
+        depending on the unit entered in 'amplitude_units'. If '[length]/[force]',
+        it displays the displacement; If '[speed]/[force]', it displays the velocity;
+        If '[acceleration]/[force]', it displays the acceleration.
+
+        Parameters
+        ----------
+        percentile : list, optional
+            Sequence of percentiles to compute, which must be between
+            0 and 100 inclusive.
+        conf_interval : list, optional
+            Sequence of confidence intervals to compute, which must be between
+            0 and 100 inclusive.
+        frequency_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units are:
+                '[length]/[force]' - Displays the displacement;
+                '[speed]/[force]' - Displays the velocity;
+                '[acceleration]/[force]' - Displays the acceleration.
+            Default is "m/N" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m/N)
+        phase_units : str, optional
+            Units for the x axis.
+            Default is "rad"
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
+        kwargs : optional
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+
+        Returns
+        -------
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
+        """
+        speed_range = Q_(self.speed_range, "rad/s").to(frequency_units).m
+
+        conf_interval = np.sort(conf_interval)
+        percentile = np.sort(percentile)
+
+        dummy_var = Q_(1, amplitude_units)
+        if dummy_var.check("[length]/[force]"):
+            mag = np.abs(self.freq_resp)
+            mag = Q_(mag, "m/N").to(amplitude_units).m
+            phase = np.angle(self.freq_resp)
+            y_label = "Displacement"
+        elif dummy_var.check("[speed]/[force]"):
+            mag = np.abs(self.velc_resp)
+            mag = Q_(mag, "m/s/N").to(amplitude_units).m
+            phase = np.angle(self.velc_resp)
+            y_label = "Velocity"
+        elif dummy_var.check("[acceleration]/[force]"):
+            mag = np.abs(self.accl_resp)
+            mag = Q_(mag, "m/s**2/N").to(amplitude_units).m
+            phase = np.angle(self.accl_resp)
+            y_label = "Acceleration"
+        else:
+            raise ValueError(
+                "Not supported unit. Options are '[length]/[force]', '[speed]/[force]', '[acceleration]/[force]'"
+            )
+
+        phase = Q_(phase, "rad").to(phase_units).m
+
+        if phase_units in ["rad", "radian", "radians"]:
+            polar_theta_unit = "radians"
+        else:
+            polar_theta_unit = "degrees"
 
         fig = go.Figure()
 
         fig.add_trace(
             go.Scatterpolar(
-                r=np.mean(self.magnitude, axis=1),
-                theta=np.mean(self.phase, axis=1),
-                customdata=self.speed_range,
+                r=np.mean(mag, axis=1),
+                theta=np.mean(phase, axis=1),
+                customdata=speed_range,
                 thetaunit="radians",
                 line=dict(width=3.0, color="black"),
                 name="Mean",
@@ -807,9 +849,9 @@ class ST_FrequencyResponseResults(ST_Results):
         for i, p in enumerate(percentile):
             fig.add_trace(
                 go.Scatterpolar(
-                    r=np.percentile(self.magnitude, p, axis=1),
-                    theta=np.percentile(self.phase, p, axis=1),
-                    customdata=self.speed_range,
+                    r=np.percentile(mag, p, axis=1),
+                    theta=np.percentile(phase, p, axis=1),
+                    customdata=speed_range,
                     thetaunit="radians",
                     opacity=0.6,
                     line=dict(width=2.5, color=colors2[i]),
@@ -824,10 +866,10 @@ class ST_FrequencyResponseResults(ST_Results):
                 )
             )
         for i, p in enumerate(conf_interval):
-            p1 = np.percentile(self.magnitude, 50 + p / 2, axis=1)
-            p2 = np.percentile(self.magnitude, 50 - p / 2, axis=1)
-            p3 = np.percentile(self.phase, 50 + p / 2, axis=1)
-            p4 = np.percentile(self.phase, 50 - p / 2, axis=1)
+            p1 = np.percentile(mag, 50 + p / 2, axis=1)
+            p2 = np.percentile(mag, 50 - p / 2, axis=1)
+            p3 = np.percentile(phase, 50 + p / 2, axis=1)
+            p4 = np.percentile(phase, 50 - p / 2, axis=1)
             fig.add_trace(
                 go.Scatterpolar(
                     r=np.concatenate((p1, p2[::-1])),
@@ -846,27 +888,43 @@ class ST_FrequencyResponseResults(ST_Results):
         fig.update_layout(
             polar=dict(
                 radialaxis=dict(
-                    title_text=r_axis_label,
-                    title_font=dict(family="Arial", size=14),
-                    gridcolor="lightgray",
+                    title=dict(text=f"{y_label} ({amplitude_units})"),
                     exponentformat="power",
                 ),
-                angularaxis=dict(
-                    tickfont=dict(size=14),
-                    gridcolor="lightgray",
-                    linecolor="black",
-                    linewidth=2.5,
-                ),
+                angularaxis=dict(thetaunit=polar_theta_unit),
             ),
+            **kwargs,
         )
 
         return fig
 
-    def plot(self, percentile=[], conf_interval=[], units="mic-pk-pk", **kwargs):
+    def plot(
+        self,
+        percentile=[],
+        conf_interval=[],
+        frequency_units="rad/s",
+        amplitude_units="m/N",
+        phase_units="rad",
+        fig=None,
+        mag_kwargs=None,
+        phase_kwargs=None,
+        polar_kwargs=None,
+        fig_kwargs=None,
+    ):
         """Plot frequency response.
 
         This method plots the frequency and phase response given an output
         and an input.
+
+        This method returns a subplot with:
+            - Frequency vs Amplitude;
+            - Frequency vs Phase Angle;
+            - Polar plot Amplitude vs Phase Angle;
+
+        Amplitude can be displacement, velocity or accelaration responses,
+        depending on the unit entered in 'amplitude_units'. If '[length]/[force]',
+        it displays the displacement; If '[speed]/[force]', it displays the velocity;
+        If '[acceleration]/[force]', it displays the acceleration.
 
         Parameters
         ----------
@@ -876,60 +934,104 @@ class ST_FrequencyResponseResults(ST_Results):
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be
             between 0 and 100 inclusive.
-        units : str, optional
-            Unit system
-            Default is "mic-pk-pk"
-        kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
+        frequency_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units are:
+                '[length]/[force]' - Displays the displacement;
+                '[speed]/[force]' - Displays the velocity;
+                '[acceleration]/[force]' - Displays the acceleration.
+            Default is "m/N" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m/N)
+        phase_units : str, optional
+            Units for the x axis.
+            Default is "rad"
+        mag_kwargs : optional
+            Additional key word arguments can be passed to change the magnitude plot
+            layout only (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
+        phase_kwargs : optional
+            Additional key word arguments can be passed to change the phase plot
+            layout only (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+        polar_kwargs : optional
+            Additional key word arguments can be passed to change the polar plot
+            layout only (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+        fig_kwargs : optional
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...). This kwargs override "mag_kwargs",
+            "phase_kwargs" and "polar_kwargs" dictionaries.
+            *See Plotly Python make_subplots Reference for more information.
 
         Returns
         -------
-        subplots : Plotly graph_objects.make_subplots()
+        fig : Plotly graph_objects.make_subplots()
             Plotly figure with amplitude vs frequency phase angle vs frequency.
         """
-        fig0 = self.plot_magnitude(percentile, conf_interval, units, **kwargs)
+        mag_kwargs = {} if mag_kwargs is None else copy.copy(mag_kwargs)
+        phase_kwargs = {} if phase_kwargs is None else copy.copy(phase_kwargs)
+        polar_kwargs = {} if polar_kwargs is None else copy.copy(polar_kwargs)
+        fig_kwargs = {} if fig_kwargs is None else copy.copy(fig_kwargs)
 
-        default_values = dict(showlegend=False)
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
-
-        fig1 = self.plot_phase(percentile, conf_interval, **kwargs)
-        fig2 = self.plot_polar_bode(percentile, conf_interval, units, **kwargs)
-
-        subplots = make_subplots(
-            rows=2, cols=2, specs=[[{}, {"type": "polar", "rowspan": 2}], [{}, None]]
+        fig0 = self.plot_magnitude(
+            percentile,
+            conf_interval,
+            frequency_units,
+            amplitude_units,
+            None,
+            **mag_kwargs,
         )
-        for data in fig0["data"]:
-            subplots.add_trace(data, row=1, col=1)
-        for data in fig1["data"]:
-            subplots.add_trace(data, row=2, col=1)
-        for data in fig2["data"]:
-            subplots.add_trace(data, row=1, col=2)
+        fig1 = self.plot_phase(
+            percentile,
+            conf_interval,
+            frequency_units,
+            amplitude_units,
+            phase_units,
+            None,
+            **phase_kwargs,
+        )
+        fig2 = self.plot_polar_bode(
+            percentile,
+            conf_interval,
+            frequency_units,
+            amplitude_units,
+            phase_units,
+            None,
+            **polar_kwargs,
+        )
 
-        subplots.update_xaxes(fig0.layout.xaxis, row=1, col=1)
-        subplots.update_yaxes(fig0.layout.yaxis, row=1, col=1)
-        subplots.update_xaxes(fig1.layout.xaxis, row=2, col=1)
-        subplots.update_yaxes(fig1.layout.yaxis, row=2, col=1)
-        subplots.update_layout(
-            plot_bgcolor="white",
-            polar_bgcolor="white",
-            width=1800,
-            height=900,
+        if fig is None:
+            fig = make_subplots(
+                rows=2,
+                cols=2,
+                specs=[[{}, {"type": "polar", "rowspan": 2}], [{}, None]],
+            )
+
+        for data in fig0["data"]:
+            fig.add_trace(data, row=1, col=1)
+        for data in fig1["data"]:
+            data.showlegend = False
+            fig.add_trace(data, row=2, col=1)
+        for data in fig2["data"]:
+            data.showlegend = False
+            fig.add_trace(data, row=1, col=2)
+
+        fig.update_xaxes(fig0.layout.xaxis, row=1, col=1)
+        fig.update_yaxes(fig0.layout.yaxis, row=1, col=1)
+        fig.update_xaxes(fig1.layout.xaxis, row=2, col=1)
+        fig.update_yaxes(fig1.layout.yaxis, row=2, col=1)
+        fig.update_layout(
             polar=dict(
                 radialaxis=fig2.layout.polar.radialaxis,
                 angularaxis=fig2.layout.polar.angularaxis,
             ),
-            legend=dict(
-                font=dict(family="sans-serif", size=14),
-                bgcolor="white",
-                bordercolor="black",
-                borderwidth=2,
-            ),
+            **fig_kwargs,
         )
 
-        return subplots
+        return fig
 
 
 class ST_TimeResponseResults(ST_Results):
@@ -937,14 +1039,16 @@ class ST_TimeResponseResults(ST_Results):
 
     Parameters
     ----------
-    time_range : 1-dimensional array
+    t : 1-dimensional array
         Time array.
     yout : array
         System response.
     xout : array
         Time evolution of the state vector.
-    nodes_list: array
+    nodes: array
         list with nodes from a rotor model.
+    link_nodes: array
+        list with nodes created with "n_link" from a rotor model.
     nodes_pos: array
         Rotor nodes axial positions.
     number_dof : int
@@ -956,18 +1060,27 @@ class ST_TimeResponseResults(ST_Results):
         The figure object with the plot.
     """
 
-    def __init__(self, time_range, yout, xout, number_dof, nodes_list, nodes_pos):
-        self.time_range = time_range
+    def __init__(self, t, yout, xout, number_dof, nodes, link_nodes, nodes_pos):
+        self.t = t
         self.yout = yout
         self.xout = xout
-        self.nodes_list = nodes_list
+        self.nodes = nodes
+        self.link_nodes = link_nodes
         self.nodes_pos = nodes_pos
         self.number_dof = number_dof
 
     def plot_1d(
-        self, probe, percentile=[], conf_interval=[], fig=None, *args, **kwargs
+        self,
+        probe,
+        percentile=[],
+        conf_interval=[],
+        probe_units="rad",
+        displacement_units="m",
+        time_units="s",
+        fig=None,
+        **kwargs,
     ):
-        """Plot time response.
+        """Plot stochastic time response.
 
         This method plots the time response given a tuple of probes with their nodes
         and orientations.
@@ -975,24 +1088,33 @@ class ST_TimeResponseResults(ST_Results):
         Parameters
         ----------
         probe : list of tuples
-            List with tuples (node, orientation angle).
+            List with tuples (node, orientation angle, tag).
             node : int
                 indicate the node where the probe is located.
-            orientation : float,
+            orientation : float
                 probe orientation angle about the shaft. The 0 refers to +X direction.
+            tag : str, optional
+                probe tag to be displayed at the legend.
         percentile : list, optional
             Sequence of percentiles to compute, which must be
             between 0 and 100 inclusive.
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be
             between 0 and 100 inclusive.
+        probe_units : str, option
+            Units for probe orientation.
+            Default is "rad".
+        displacement_units : str, optional
+            Displacement units.
+            Default is 'm'.
+        time_units : str
+            Time units.
+            Default is 's'.
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
-        args : optional
-            Additional plot axes
         kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
 
         Returns
@@ -1000,20 +1122,25 @@ class ST_TimeResponseResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
+        nodes = self.nodes
+        link_nodes = self.link_nodes
+        ndof = self.number_dof
+
         if fig is None:
             fig = go.Figure()
 
-        default_values = dict(mode="lines")
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
 
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
-
         for i, p in enumerate(probe):
-            dofx = p[0] * self.number_dof
-            dofy = p[0] * self.number_dof + 1
-            angle = p[1]
+            fix_dof = (p[0] - nodes[-1] - 1) * ndof // 2 if p[0] in link_nodes else 0
+            dofx = ndof * p[0] - fix_dof
+            dofy = ndof * p[0] + 1 - fix_dof
+            angle = Q_(p[1], probe_units).to("rad").m
+            try:
+                probe_tag = p[2]
+            except IndexError:
+                probe_tag = f"Probe {i+1} - Node {p[0]}"
 
             # fmt: off
             operator = np.array(
@@ -1032,52 +1159,66 @@ class ST_TimeResponseResults(ST_Results):
 
             fig.add_trace(
                 go.Scatter(
-                    x=self.time_range,
-                    y=np.mean(probe_resp, axis=0),
+                    x=Q_(self.t, "s").to(time_units).m,
+                    y=Q_(np.mean(probe_resp, axis=0), "m").to(displacement_units).m,
+                    mode="lines",
                     opacity=1.0,
-                    name=f"Probe {i + 1} - Mean",
+                    name=f"{probe_tag} - Mean",
                     line=dict(width=3.0),
                     hovertemplate=("Time: %{x:.3f}<br>" + "Amplitude: %{y:.2e}"),
-                    **kwargs,
                 )
             )
             for j, p in enumerate(percentile):
                 fig.add_trace(
                     go.Scatter(
-                        x=self.time_range,
-                        y=np.percentile(probe_resp, p, axis=0),
+                        x=Q_(self.t, "s").to(time_units).m,
+                        y=Q_(np.percentile(probe_resp, p, axis=0), "m")
+                        .to(displacement_units)
+                        .m,
+                        # y=np.percentile(probe_resp, p, axis=0),
+                        mode="lines",
                         opacity=0.6,
                         line=dict(width=2.5),
-                        name=f"Probe {i + 1} - percentile: {p}%",
+                        name=f"{probe_tag} - percentile: {p}%",
                         hovertemplate=("Time: %{x:.3f}<br>" + "Amplitude: %{y:.2e}"),
-                        **kwargs,
                     )
                 )
 
-            x = np.concatenate((self.time_range, self.time_range[::-1]))
+            x = np.concatenate((self.t, self.t[::-1]))
             for j, p in enumerate(conf_interval):
                 p1 = np.percentile(probe_resp, 50 + p / 2, axis=0)
                 p2 = np.percentile(probe_resp, 50 - p / 2, axis=0)
                 fig.add_trace(
                     go.Scatter(
-                        x=x,
-                        y=np.concatenate((p1, p2[::-1])),
-                        line=dict(width=1),
+                        x=Q_(x, "s").to(time_units).m,
+                        y=Q_(np.concatenate((p1, p2[::-1])), "m")
+                        .to(displacement_units)
+                        .m,
+                        mode="lines",
+                        line=dict(width=1, color=colors1[j]),
                         fill="toself",
                         fillcolor=colors1[j],
                         opacity=0.5,
-                        name=f"Probe {i + 1} - confidence interval: {p}%",
+                        name=f"{probe_tag} - confidence interval: {p}%",
                         hovertemplate=("Time: %{x:.3f}<br>" + "Amplitude: %{y:.2e}"),
-                        **kwargs,
                     )
                 )
 
-        fig.update_xaxes(title_text="<b>Time (s)</b>")
-        fig.update_yaxes(title_text="<b>Amplitude</b>")
+        fig.update_xaxes(title_text=f"Time ({time_units})")
+        fig.update_yaxes(title_text=f"Amplitude ({displacement_units})")
+        fig.update_layout(**kwargs)
 
         return fig
 
-    def plot_2d(self, node, percentile=[], conf_interval=[], fig=None, *args, **kwargs):
+    def plot_2d(
+        self,
+        node,
+        percentile=[],
+        conf_interval=[],
+        displacement_units="m",
+        fig=None,
+        **kwargs,
+    ):
         """Plot orbit response (2D).
 
         This function plots orbits for a given node on the rotor system in a 2D view.
@@ -1092,13 +1233,14 @@ class ST_TimeResponseResults(ST_Results):
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be
             between 0 and 100 inclusive.
+        displacement_units : str, optional
+            Displacement units.
+            Default is 'm'.
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
-        args : optional
-            Additional plot axes
         kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
 
         Returns
@@ -1106,73 +1248,91 @@ class ST_TimeResponseResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
+        nodes = self.nodes
+        link_nodes = self.link_nodes
         ndof = self.number_dof
-        default_values = dict(mode="lines")
+
+        fix_dof = (node - nodes[-1] - 1) * ndof // 2 if node in link_nodes else 0
+        dofx = ndof * node - fix_dof
+        dofy = ndof * node + 1 - fix_dof
+
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
-
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
 
         if fig is None:
             fig = go.Figure()
 
         fig.add_trace(
             go.Scatter(
-                x=np.mean(self.yout[..., ndof * node], axis=0),
-                y=np.mean(self.yout[..., ndof * node + 1], axis=0),
+                x=Q_(np.mean(self.yout[..., dofx], axis=0), "m")
+                .to(displacement_units)
+                .m,
+                y=Q_(np.mean(self.yout[..., dofy], axis=0), "m")
+                .to(displacement_units)
+                .m,
+                mode="lines",
                 opacity=1.0,
                 name="Mean",
                 line=dict(width=3, color="black"),
-                hovertemplate=(
-                    "X - Amplitude: %{x:.2e}<br>" + "Y - Amplitude: %{y:.2e}"
-                ),
-                **kwargs,
+                hovertemplate="X - Amplitude: %{x:.2e}<br>" + "Y - Amplitude: %{y:.2e}",
             )
         )
+
         for i, p in enumerate(percentile):
+            p1 = np.percentile(self.yout[..., dofx], p, axis=0)
+            p2 = np.percentile(self.yout[..., dofy], p, axis=0)
+
             fig.add_trace(
                 go.Scatter(
-                    x=np.percentile(self.yout[..., ndof * node], p, axis=0),
-                    y=np.percentile(self.yout[..., ndof * node + 1], p, axis=0),
+                    x=Q_(p1, "m").to(displacement_units).m,
+                    y=Q_(p2, "m").to(displacement_units).m,
+                    mode="lines",
                     opacity=0.6,
                     line=dict(width=2.5, color=colors2[i]),
                     name="percentile: {}%".format(p),
-                    hovertemplate=(
-                        "X - Amplitude: %{x:.2e}<br>" + "Y - Amplitude: %{y:.2e}"
-                    ),
-                    **kwargs,
+                    hovertemplate="X - Amplitude: %{x:.2e}<br>"
+                    + "Y - Amplitude: %{y:.2e}",
                 )
             )
 
         for i, p in enumerate(conf_interval):
-            p1 = np.percentile(self.yout[..., ndof * node], 50 + p / 2, axis=0)
-            p2 = np.percentile(self.yout[..., ndof * node], 50 - p / 2, axis=0)
-            p3 = np.percentile(self.yout[..., ndof * node + 1], 50 + p / 2, axis=0)
-            p4 = np.percentile(self.yout[..., ndof * node + 1], 50 - p / 2, axis=0)
+            p1 = np.percentile(self.yout[..., dofx], 50 + p / 2, axis=0)
+            p2 = np.percentile(self.yout[..., dofx], 50 - p / 2, axis=0)
+            p3 = np.percentile(self.yout[..., dofy], 50 + p / 2, axis=0)
+            p4 = np.percentile(self.yout[..., dofy], 50 - p / 2, axis=0)
+
             fig.add_trace(
                 go.Scatter(
-                    x=np.concatenate((p1, p2[::-1])),
-                    y=np.concatenate((p3, p4[::-1])),
+                    x=Q_(np.concatenate((p1, p2[::-1])), "m").to(displacement_units).m,
+                    y=Q_(np.concatenate((p3, p4[::-1])), "m").to(displacement_units).m,
+                    mode="lines",
                     line=dict(width=1, color=colors1[i]),
                     fill="toself",
                     fillcolor=colors1[i],
                     opacity=0.5,
                     name="confidence interval: {}%".format(p),
-                    hovertemplate=(
-                        "X - Amplitude: %{x:.2e}<br>" + "Y - Amplitude: %{y:.2e}"
-                    ),
-                    **kwargs,
+                    hovertemplate="X - Amplitude: %{x:.2e}<br>"
+                    + "Y - Amplitude: %{y:.2e}",
                 )
             )
 
-        fig.update_xaxes(title_text="<b>Amplitude</b>")
-        fig.update_yaxes(title_text="<b>Amplitude</b>")
-        fig.update_layout(title="<b>Rotor Orbit: node {}</b>".format(node)),
+        fig.update_xaxes(title_text=f"Amplitude ({displacement_units}) - X direction")
+        fig.update_yaxes(title_text=f"Amplitude ({displacement_units}) - Y direction")
+        fig.update_layout(
+            title=dict(text="Response for node {}".format(node)), **kwargs
+        )
 
         return fig
 
-    def plot_3d(self, percentile=[], conf_interval=[], fig=None, *args, **kwargs):
+    def plot_3d(
+        self,
+        percentile=[],
+        conf_interval=[],
+        displacement_units="m",
+        rotor_length_units="m",
+        fig=None,
+        **kwargs,
+    ):
         """Plot orbit response (3D).
 
         This function plots orbits for each node on the rotor system in a 3D view.
@@ -1185,13 +1345,17 @@ class ST_TimeResponseResults(ST_Results):
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be
             between 0 and 100 inclusive.
+        displacement_units : str
+            Displacement units.
+            Default is 'm'.
+        rotor_length_units : str
+            Rotor Length units.
+            Default is 'm'.
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
-        args : optional
-            Additional plot axes
         kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. hoverlabel_align="center", ...).
             *See Plotly Python Figure Reference for more information.
 
         Returns
@@ -1199,13 +1363,12 @@ class ST_TimeResponseResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
+        nodes_pos = self.nodes_pos
+        nodes = self.nodes
         ndof = self.number_dof
-        default_values = dict(mode="lines")
+
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
-
-        for k, v in default_values.items():
-            kwargs.setdefault(k, v)
 
         if fig is None:
             fig = go.Figure()
@@ -1213,21 +1376,29 @@ class ST_TimeResponseResults(ST_Results):
         line = np.zeros(len(self.nodes_pos))
         fig.add_trace(
             go.Scatter3d(
-                x=self.nodes_pos,
+                x=Q_(nodes_pos, "m").to(rotor_length_units).m,
                 y=line,
                 z=line,
+                mode="lines",
                 line=dict(width=2.0, color="black", dash="dashdot"),
                 showlegend=False,
-                mode="lines",
             )
         )
-        for j, n in enumerate(self.nodes_list):
+        for j, n in enumerate(nodes):
+            dofx = ndof * n
+            dofy = ndof * n + 1
+
             x = np.ones(self.yout.shape[1]) * self.nodes_pos[n]
             fig.add_trace(
                 go.Scatter3d(
-                    x=x,
-                    y=np.mean(self.yout[..., ndof * n], axis=0),
-                    z=np.mean(self.yout[..., ndof * n + 1], axis=0),
+                    x=Q_(x, "m").to(rotor_length_units).m,
+                    y=Q_(np.mean(self.yout[..., dofx], axis=0), "m")
+                    .to(displacement_units)
+                    .m,
+                    z=Q_(np.mean(self.yout[..., dofy], axis=0), "m")
+                    .to(displacement_units)
+                    .m,
+                    mode="lines",
                     line=dict(width=5, color="black"),
                     name="Mean",
                     legendgroup="mean",
@@ -1237,18 +1408,20 @@ class ST_TimeResponseResults(ST_Results):
                         + "X - Amplitude: %{y:.2e}<br>"
                         + "Y - Amplitude: %{z:.2e}"
                     ),
-                    **kwargs,
                 )
             )
             for i, p in enumerate(percentile):
+                p1 = np.percentile(self.yout[..., dofx], p, axis=0)
+                p2 = np.percentile(self.yout[..., dofy], p, axis=0)
                 fig.add_trace(
                     go.Scatter3d(
-                        x=x,
-                        y=np.percentile(self.yout[..., ndof * n], p, axis=0),
-                        z=np.percentile(self.yout[..., ndof * n + 1], p, axis=0),
+                        x=Q_(x, "m").to(rotor_length_units).m,
+                        y=Q_(p1, "m").to(displacement_units).m,
+                        z=Q_(p2, "m").to(displacement_units).m,
+                        mode="lines",
                         opacity=1.0,
                         name="percentile: {}%".format(p),
-                        line=dict(width=3, color=colors1[i]),
+                        line=dict(width=3, color=colors2[i]),
                         legendgroup="perc{}".format(p),
                         showlegend=True if j == 0 else False,
                         hovertemplate=(
@@ -1256,37 +1429,20 @@ class ST_TimeResponseResults(ST_Results):
                             + "X - Amplitude: %{y:.2e}<br>"
                             + "Y - Amplitude: %{z:.2e}"
                         ),
-                        **kwargs,
                     )
                 )
+
             for i, p in enumerate(conf_interval):
+                p1 = np.percentile(self.yout[..., dofx], 50 + p / 2, axis=0)
+                p2 = np.percentile(self.yout[..., dofx], 50 - p / 2, axis=0)
+                p3 = np.percentile(self.yout[..., dofy], 50 + p / 2, axis=0)
+                p4 = np.percentile(self.yout[..., dofy], 50 - p / 2, axis=0)
                 fig.add_trace(
                     go.Scatter3d(
-                        x=x,
-                        y=np.percentile(self.yout[..., ndof * n], 50 + p / 2, axis=0),
-                        z=np.percentile(
-                            self.yout[..., ndof * n + 1], 50 + p / 2, axis=0
-                        ),
-                        line=dict(width=3.5, color=colors1[i]),
-                        opacity=0.6,
-                        name="confidence interval: {}%".format(p),
-                        legendgroup="conf_interval{}".format(p),
-                        showlegend=True if j == 0 else False,
-                        hovertemplate=(
-                            "Nodal Position: %{x:.2f}<br>"
-                            + "X - Amplitude: %{y:.2e}<br>"
-                            + "Y - Amplitude: %{z:.2e}"
-                        ),
-                        **kwargs,
-                    )
-                )
-                fig.add_trace(
-                    go.Scatter3d(
-                        x=x,
-                        y=np.percentile(self.yout[..., ndof * n], 50 - p / 2, axis=0),
-                        z=np.percentile(
-                            self.yout[..., ndof * n + 1], 50 - p / 2, axis=0
-                        ),
+                        x=Q_(x, "m").to(rotor_length_units).m,
+                        y=Q_(p1, "m").to(displacement_units).m,
+                        z=Q_(p3, "m").to(displacement_units).m,
+                        mode="lines",
                         line=dict(width=3.5, color=colors1[i]),
                         opacity=0.6,
                         name="confidence interval: {}%".format(p),
@@ -1297,17 +1453,45 @@ class ST_TimeResponseResults(ST_Results):
                             + "X - Amplitude: %{y:.2e}<br>"
                             + "Y - Amplitude: %{z:.2e}"
                         ),
-                        **kwargs,
+                    )
+                )
+                fig.add_trace(
+                    go.Scatter3d(
+                        x=x,
+                        y=Q_(p2, "m").to(displacement_units).m,
+                        z=Q_(p4, "m").to(displacement_units).m,
+                        mode="lines",
+                        line=dict(width=3.5, color=colors1[i]),
+                        opacity=0.6,
+                        name="confidence interval: {}%".format(p),
+                        legendgroup="conf_interval{}".format(p),
+                        showlegend=False,
+                        hovertemplate=(
+                            "Nodal Position: %{x:.2f}<br>"
+                            + "X - Amplitude: %{y:.2e}<br>"
+                            + "Y - Amplitude: %{z:.2e}"
+                        ),
                     )
                 )
 
         fig.update_layout(
             scene=dict(
-                xaxis=dict(title=dict(text="<b>Rotor Length</b>"), showspikes=False),
-                yaxis=dict(title=dict(text="<b>Amplitude - X</b>"), showspikes=False),
-                zaxis=dict(title=dict(text="<b>Amplitude - Y</b>"), showspikes=False),
+                xaxis=dict(
+                    title=dict(text=f"Rotor Length ({rotor_length_units})"),
+                    showspikes=False,
+                ),
+                yaxis=dict(
+                    title=dict(text=f"Amplitude - X ({displacement_units})"),
+                    showspikes=False,
+                ),
+                zaxis=dict(
+                    title=dict(text=f"Amplitude - Y ({displacement_units})"),
+                    showspikes=False,
+                ),
             ),
+            **kwargs,
         )
+
         return fig
 
 
@@ -1320,12 +1504,16 @@ class ST_ForcedResponseResults(ST_Results):
         Array with the force response for each node for each frequency.
     frequency_range : array
         Array with the frequencies.
-    magnitude : array
-        Magnitude of the frequency response for node for each frequency.
-    phase : array
-        Phase of the frequency response for node for each frequency.
+    velc_resp : array
+        Array with the forced response (velocity) for each node for each frequency.
+    accl_resp : array
+        Array with the forced response (acceleration) for each node for each frequency.
     number_dof = int
         Number of degrees of freedom per shaft element's node.
+    nodes : list
+        List of shaft nodes.
+    link_nodes : list
+        List of n_link nodes.
 
     Returns
     -------
@@ -1333,48 +1521,176 @@ class ST_ForcedResponseResults(ST_Results):
         Plotly figure with amplitude vs frequency phase angle vs frequency.
     """
 
-    def __init__(self, forced_resp, magnitude, phase, frequency_range, number_dof):
+    def __init__(
+        self,
+        forced_resp,
+        velc_resp,
+        accl_resp,
+        frequency_range,
+        number_dof,
+        nodes,
+        link_nodes,
+    ):
         self.forced_resp = forced_resp
-        self.magnitude = magnitude
-        self.phase = phase
+        self.velc_resp = velc_resp
+        self.accl_resp = accl_resp
         self.frequency_range = frequency_range
         self.number_dof = number_dof
+        self.nodes = nodes
+        self.link_nodes = link_nodes
+
+        self.default_units = {
+            "[length]": ["m", "forced_resp"],
+            "[length] / [time]": ["m/s", "velc_resp"],
+            "[length] / [time] ** 2": ["m/s**2", "accl_resp"],
+        }
+
+    def _calculate_major_axis_per_node(self, node, angle, amplitude_units="m"):
+        """Calculate the major axis for a node for each frequency.
+
+        Parameters
+        ----------
+        node : float
+            A node from the rotor model.
+        angle : float, str
+            The orientation angle of the axis.
+            Options are:
+                float : angle in rad capture the response in a probe orientation;
+                str : "major" to capture the response for the major axis;
+                str : "minor" to capture the response for the minor axis.
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units dimensionality are:
+                '[length]' - Displays the displacement;
+                '[speed]' - Displays the velocity;
+                '[acceleration]' - Displays the acceleration.
+            Default is "m" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
+
+        Returns
+        -------
+        major_axis_vector : np.ndarray
+            major_axis_vector[:, 0, :] = axis angle
+            major_axis_vector[:, 1, :] = axis vector response for the input angle
+            major_axis_vector[:, 2, :] = phase response for the input angle
+        """
+        ndof = self.number_dof
+        nodes = self.nodes
+        link_nodes = self.link_nodes
+
+        unit_type = str(Q_(1, amplitude_units).dimensionality)
+        try:
+            response = self.__dict__[self.default_units[unit_type][1]]
+        except KeyError:
+            raise ValueError(
+                "Not supported unit. Dimensionality options are '[length]', '[speed]', '[acceleration]'"
+            )
+
+        size = response.shape[0]
+        major_axis_vector = np.zeros(
+            (size, 3, len(self.frequency_range)), dtype=complex
+        )
+
+        fix_dof = (node - nodes[-1] - 1) * ndof // 2 if node in link_nodes else 0
+        dofx = ndof * node - fix_dof
+        dofy = ndof * node + 1 - fix_dof
+
+        # Relative angle between probes (90°)
+        Rel_ang = np.exp(1j * np.pi / 2)
+
+        for j in range(size):
+            for i, f in enumerate(self.frequency_range):
+
+                # Foward and Backward vectors
+                fow = response[j, dofx, i] / 2 + Rel_ang * response[j, dofy, i] / 2
+                back = (
+                    np.conj(response[j, dofx, i]) / 2
+                    + Rel_ang * np.conj(response[j, dofy, i]) / 2
+                )
+
+                ang_fow = np.angle(fow)
+                if ang_fow < 0:
+                    ang_fow += 2 * np.pi
+
+                ang_back = np.angle(back)
+                if ang_back < 0:
+                    ang_back += 2 * np.pi
+
+                if angle == "major":
+                    # Major axis angle
+                    axis_angle = (ang_back - ang_fow) / 2
+                    if axis_angle > np.pi:
+                        axis_angle -= np.pi
+
+                elif angle == "minor":
+                    # Minor axis angle
+                    axis_angle = (ang_back - ang_fow + np.pi) / 2
+                    if axis_angle > np.pi:
+                        axis_angle -= np.pi
+
+                else:
+                    axis_angle = angle
+
+                major_axis_vector[j, 0, i] = axis_angle
+                major_axis_vector[j, 1, i] = np.abs(
+                    fow * np.exp(1j * axis_angle) + back * np.exp(-1j * axis_angle)
+                )
+                major_axis_vector[j, 2, i] = np.angle(
+                    fow * np.exp(1j * axis_angle) + back * np.exp(-1j * axis_angle)
+                )
+
+        return major_axis_vector
 
     def plot_magnitude(
         self,
         probe,
         percentile=[],
         conf_interval=[],
+        probe_units="rad",
+        frequency_units="rad/s",
+        amplitude_units="m",
         fig=None,
-        units="mic-pk-pk",
         **kwargs,
     ):
-        """Plot frequency response.
+        """Plot stochastic frequency response.
 
         This method plots the unbalance response magnitude.
 
         Parameters
         ----------
         probe : list of tuples
-            List with tuples (node, orientation angle).
+            List with tuples (node, orientation angle, tag).
             node : int
                 indicate the node where the probe is located.
-            orientation : float,
+            orientation : float
                 probe orientation angle about the shaft. The 0 refers to +X direction.
+            tag : str, optional
+                probe tag to be displayed at the legend.
         percentile : list, optional
             Sequence of percentiles to compute, which must be between
             0 and 100 inclusive.
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be between
             0% and 100% inclusive.
+        probe_units : str, option
+            Units for probe orientation.
+            Default is "rad".
+        frequency_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units dimensionality are:
+                '[length]' - Displays the displacement;
+                '[speed]' - Displays the velocity;
+                '[acceleration]' - Displays the acceleration.
+            Default is "m" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
-        units : str, optional
-            Unit system
-            Default is "mic-pk-pk".
         kwargs : optional
-            Additional key word arguments can be passed to change the plot layout
-            (e.g. width=800, height=600, ...).
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
 
         Returns
@@ -1382,12 +1698,15 @@ class ST_ForcedResponseResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             Bokeh plot axes with magnitude plot.
         """
-        if units == "m":
-            y_axis_label = "<b>Amplitude (m)</b>"
-        elif units == "mic-pk-pk":
-            y_axis_label = "<b>Amplitude (μ pk-pk)</b>"
-        else:
-            y_axis_label = "<b>Amplitude (dB)</b>"
+        frequency_range = Q_(self.frequency_range, "rad/s").to(frequency_units).m
+
+        unit_type = str(Q_(1, amplitude_units).dimensionality)
+        try:
+            base_unit = self.default_units[unit_type][0]
+        except KeyError:
+            raise ValueError(
+                "Not supported unit. Dimensionality options are '[length]', '[speed]', '[acceleration]'"
+            )
 
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
@@ -1397,100 +1716,136 @@ class ST_ForcedResponseResults(ST_Results):
 
         color_i = 0
         color_p = 0
+
         for i, p in enumerate(probe):
-            dofx = p[0] * self.number_dof
-            dofy = p[0] * self.number_dof + 1
-            angle = p[1]
+            angle = Q_(p[1], probe_units).to("rad").m
+            vector = self._calculate_major_axis_per_node(
+                node=p[0], angle=angle, amplitude_units=amplitude_units
+            )[:, 1, :]
+            try:
+                probe_tag = p[2]
+            except IndexError:
+                probe_tag = f"Probe {i+1} - Node {p[0]}"
 
-            # fmt: off
-            operator = np.array(
-                [[np.cos(angle), - np.sin(angle)],
-                 [np.cos(angle), + np.sin(angle)]]
-            )
-
-            probe_resp = np.zeros_like(self.magnitude[:, :, 0])
-            for j, mag in enumerate(self.magnitude):
-                _probe_resp = operator @ np.vstack((mag[:, dofx], mag[:, dofy]))
-                probe_resp[j] = np.sqrt((_probe_resp[0] * np.cos(angle)) ** 2 +
-                                        (_probe_resp[1] * np.sin(angle)) ** 2)
-            # fmt: on
             fig.add_trace(
                 go.Scatter(
-                    x=self.frequency_range,
-                    y=np.mean(probe_resp, axis=0),
+                    x=frequency_range,
+                    y=Q_(np.mean(np.abs(vector), axis=0), base_unit)
+                    .to(amplitude_units)
+                    .m,
                     opacity=1.0,
                     mode="lines",
                     line=dict(width=3, color=list(tableau_colors)[i]),
-                    name=f"Probe {i + 1} - Mean",
-                    legendgroup=f"Probe {i + 1} - Mean",
+                    name=f"{probe_tag} - Mean",
+                    legendgroup=f"{probe_tag} - Mean",
                     hovertemplate="Frequency: %{x:.2f}<br>Amplitude: %{y:.2e}",
                 )
             )
             for j, p in enumerate(percentile):
                 fig.add_trace(
                     go.Scatter(
-                        x=self.frequency_range,
-                        y=np.percentile(probe_resp, p, axis=0),
+                        x=frequency_range,
+                        y=Q_(np.percentile(np.abs(vector), p, axis=0), base_unit)
+                        .to(amplitude_units)
+                        .m,
                         opacity=0.6,
                         mode="lines",
                         line=dict(width=2.5, color=colors1[color_p]),
-                        name=f"Probe {i + 1} - percentile: {p}%",
-                        legendgroup=f"Probe {i + 1} - percentile: {p}%",
+                        name=f"{probe_tag} - percentile: {p}%",
+                        legendgroup=f"{probe_tag} - percentile: {p}%",
                         hovertemplate="Frequency: %{x:.2f}<br>Amplitude: %{y:.2e}",
                     )
                 )
                 color_p += 1
 
-            x = np.concatenate((self.frequency_range, self.frequency_range[::-1]))
+            x = np.concatenate((frequency_range, frequency_range[::-1]))
             for j, p in enumerate(conf_interval):
-                p1 = np.percentile(probe_resp, 50 + p / 2, axis=0)
-                p2 = np.percentile(probe_resp, 50 - p / 2, axis=0)
+                p1 = np.percentile(np.abs(vector), 50 + p / 2, axis=0)
+                p2 = np.percentile(np.abs(vector), 50 - p / 2, axis=0)
+
                 fig.add_trace(
                     go.Scatter(
                         x=x,
-                        y=np.concatenate((p1, p2[::-1])),
+                        y=Q_(np.concatenate((p1, p2[::-1])), base_unit)
+                        .to(amplitude_units)
+                        .m,
                         mode="lines",
                         line=dict(width=1, color=colors2[color_i]),
                         fill="toself",
                         fillcolor=colors2[color_i],
                         opacity=0.5,
-                        name=f"Probe {i + 1} - confidence interval: {p}%",
-                        legendgroup=f"Probe {i + 1} - confidence interval: {p}%",
+                        name=f"{probe_tag} - confidence interval: {p}%",
+                        legendgroup=f"{probe_tag} - confidence interval: {p}%",
                         hovertemplate="Frequency: %{x:.2f}<br>Amplitude: %{y:.2e}",
                     )
                 )
                 color_i += 1
 
-        fig.update_xaxes(title_text="<b>Frequency (rad/s)</b>")
-        fig.update_yaxes(title_text=y_axis_label)
+        fig.update_xaxes(
+            title_text=f"Frequency ({frequency_units})",
+            range=[np.min(frequency_range), np.max(frequency_range)],
+        )
+        fig.update_yaxes(
+            title_text=f"Amplitude ({amplitude_units})", exponentformat="power"
+        )
         fig.update_layout(**kwargs)
 
         return fig
 
-    def plot_phase(self, probe, percentile=[], conf_interval=[], fig=None, **kwargs):
-        """Plot frequency response.
+    def plot_phase(
+        self,
+        probe,
+        percentile=[],
+        conf_interval=[],
+        probe_units="rad",
+        frequency_units="rad/s",
+        amplitude_units="m",
+        phase_units="rad",
+        fig=None,
+        **kwargs,
+    ):
+        """Plot stochastic frequency response.
 
         This method plots the phase response given a set of probes.
 
         Parameters
         ----------
         probe : list of tuples
-            List with tuples (node, orientation angle).
+            List with tuples (node, orientation angle, tag).
             node : int
                 indicate the node where the probe is located.
-            orientation : float,
+            orientation : float
                 probe orientation angle about the shaft. The 0 refers to +X direction.
+            tag : str, optional
+                probe tag to be displayed at the legend.
         percentile : list, optional
             Sequence of percentiles to compute, which must be between
             0 and 100 inclusive.
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be between
             0 and 100 inclusive.
+        probe_units : str, option
+            Units for probe orientation.
+            Default is "rad".
+        frequency_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units dimensionality are:
+                '[length]' - Displays the displacement;
+                '[speed]' - Displays the velocity;
+                '[acceleration]' - Displays the acceleration.
+            Default is "m" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
+        phase_units : str, optional
+            Units for the x axis.
+            Default is "rad"
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         kwargs : optional
-            Additional key word arguments can be passed to change the plot layout
-            (e.g. width=800, height=600, ...).
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
 
         Returns
@@ -1498,6 +1853,8 @@ class ST_ForcedResponseResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
+        frequency_range = Q_(self.frequency_range, "rad/s").to(frequency_units).m
+
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
 
@@ -1506,44 +1863,49 @@ class ST_ForcedResponseResults(ST_Results):
 
         color_p = 0
         color_i = 0
+
+        x = np.concatenate((frequency_range, frequency_range[::-1]))
         for i, p in enumerate(probe):
-            probe_phase = np.zeros_like(self.phase[:, :, 0])
-            for j, phs in enumerate(self.phase):
-                aux_phase = phs[:, p[0] * self.number_dof]
-                probe_phase[j] = np.array(
-                    [i + 2 * np.pi if i < 0 else i for i in aux_phase]
-                )
-                angle = p[1]
-                probe_phase[j] = probe_phase[j] - angle
+            angle = Q_(p[1], probe_units).to("rad").m
+            vector = self._calculate_major_axis_per_node(
+                node=p[0], angle=angle, amplitude_units=amplitude_units
+            )[:, 2, :]
+
+            probe_phase = np.real(vector)
+            probe_phase = Q_(probe_phase, "rad").to(phase_units).m
+
+            try:
+                probe_tag = p[2]
+            except IndexError:
+                probe_tag = f"Probe {i+1} - Node {p[0]}"
 
             fig.add_trace(
                 go.Scatter(
-                    x=self.frequency_range,
+                    x=frequency_range,
                     y=np.mean(probe_phase, axis=0),
                     opacity=1.0,
                     mode="lines",
                     line=dict(width=3, color=list(tableau_colors)[i]),
-                    name=f"Probe {i + 1} - Mean",
-                    legendgroup=f"Probe {i + 1} - Mean",
+                    name=f"{probe_tag} - Mean",
+                    legendgroup=f"{probe_tag} - Mean",
                     hovertemplate="Frequency: %{x:.2f}<br>Phase: %{y:.2f}",
                 )
             )
             for j, p in enumerate(percentile):
                 fig.add_trace(
                     go.Scatter(
-                        x=self.frequency_range,
+                        x=frequency_range,
                         y=np.percentile(probe_phase, p, axis=0),
                         opacity=0.6,
                         mode="lines",
                         line=dict(width=2.5, color=colors1[color_p]),
-                        name=f"Probe {i + 1} - percentile: {p}%",
-                        legendgroup=f"Probe {i + 1} - percentile: {p}%",
+                        name=f"{probe_tag} - percentile: {p}%",
+                        legendgroup=f"{probe_tag} - percentile: {p}%",
                         hovertemplate="Frequency: %{x:.2f}<br>Phase: %{y:.2f}",
                     )
                 )
                 color_p += 1
 
-            x = np.concatenate((self.frequency_range, self.frequency_range[::-1]))
             for j, p in enumerate(conf_interval):
                 p1 = np.percentile(probe_phase, 50 + p / 2, axis=0)
                 p2 = np.percentile(probe_phase, 50 - p / 2, axis=0)
@@ -1556,16 +1918,19 @@ class ST_ForcedResponseResults(ST_Results):
                         fill="toself",
                         fillcolor=colors2[color_i],
                         opacity=0.5,
-                        name=f"Probe {i + 1} - confidence interval: {p}%",
-                        legendgroup=f"Probe {i + 1} - confidence interval: {p}%",
+                        name=f"{probe_tag} - confidence interval: {p}%",
+                        legendgroup=f"{probe_tag} - confidence interval: {p}%",
                         hovertemplate="Frequency: %{x:.2f}<br>Phase: %{y:.2f}",
                     )
                 )
                 color_i += 1
 
-        fig.update_xaxes(title_text="<b>Frequency (rad/s)</b>")
-        fig.update_yaxes(title_text="<b>Phase Angle (rad)</b>")
-        fig.update_layout(**kwargs),
+        fig.update_xaxes(
+            title_text=f"Frequency ({frequency_units})",
+            range=[np.min(frequency_range), np.max(frequency_range)],
+        )
+        fig.update_yaxes(title_text=f"Phase ({phase_units})")
+        fig.update_layout(**kwargs)
 
         return fig
 
@@ -1574,8 +1939,11 @@ class ST_ForcedResponseResults(ST_Results):
         probe,
         percentile=[],
         conf_interval=[],
+        probe_units="rad",
+        frequency_units="rad/s",
+        amplitude_units="m",
+        phase_units="rad",
         fig=None,
-        units="mic-pk-pk",
         **kwargs,
     ):
         """Plot polar forced response using Plotly.
@@ -1583,23 +1951,39 @@ class ST_ForcedResponseResults(ST_Results):
         Parameters
         ----------
         probe : list of tuples
-            List with tuples (node, orientation angle).
+            List with tuples (node, orientation angle, tag).
             node : int
                 indicate the node where the probe is located.
-            orientation : float,
+            orientation : float
                 probe orientation angle about the shaft. The 0 refers to +X direction.
+            tag : str, optional
+                probe tag to be displayed at the legend.
         percentile : list, optional
             Sequence of percentiles to compute, which must be between
             0 and 100 inclusive.
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be between
             0 and 100 inclusive.
+        probe_units : str, option
+            Units for probe orientation.
+            Default is "rad".
+        frequency_units : str, optional
+            Units for the x axis.
+            Default is "rad/s"
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units dimensionality are:
+                '[length]' - Displays the displacement;
+                '[speed]' - Displays the velocity;
+                '[acceleration]' - Displays the acceleration.
+            Default is "m" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
+        phase_units : str, optional
+            Units for the x axis.
+            Default is "rad"
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
-        units : str
-            Magnitude unit system.
-            Default is "mic-pk-pk"
-        polar_kwargs : optional
+        kwargs : optional
             Additional key word arguments can be passed to change the plot layout only
             (e.g. width=1000, height=800, ...).
             *See Plotly Python Figure Reference for more information.
@@ -1609,58 +1993,58 @@ class ST_ForcedResponseResults(ST_Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
+        frequency_range = Q_(self.frequency_range, "rad/s").to(frequency_units).m
+
         conf_interval = np.sort(conf_interval)
         percentile = np.sort(percentile)
 
-        if units == "m":
-            r_axis_label = "<b>Amplitude (m)</b>"
-        elif units == "mic-pk-pk":
-            r_axis_label = "<b>Amplitude (μ pk-pk)</b>"
+        unit_type = str(Q_(1, amplitude_units).dimensionality)
+        try:
+            base_unit = self.default_units[unit_type][0]
+        except KeyError:
+            raise ValueError(
+                "Not supported unit. Dimensionality options are '[length]', '[speed]', '[acceleration]'"
+            )
+
+        if phase_units in ["rad", "radian", "radians"]:
+            polar_theta_unit = "radians"
         else:
-            r_axis_label = "<b>Amplitude (dB)</b>"
+            polar_theta_unit = "degrees"
 
         if fig is None:
             fig = go.Figure()
 
         color_p = 0
         color_i = 0
+
         for i, p in enumerate(probe):
-            dofx = p[0] * self.number_dof
-            dofy = p[0] * self.number_dof + 1
-            angle = p[1]
+            angle = Q_(p[1], probe_units).to("rad").m
 
-            # fmt: off
-            operator = np.array(
-                [[np.cos(angle), - np.sin(angle)],
-                 [np.cos(angle), + np.sin(angle)]]
-            )
+            mag = self._calculate_major_axis_per_node(
+                node=p[0], angle=angle, amplitude_units=amplitude_units
+            )[:, 1, :]
+            probe_phase = self._calculate_major_axis_per_node(
+                node=p[0], angle=angle, amplitude_units=amplitude_units
+            )[:, 2, :]
 
-            probe_resp = np.zeros_like(self.magnitude[:, :, 0])
-            for j, mag in enumerate(self.magnitude):
-                _probe_resp = operator @ np.vstack((mag[:, dofx], mag[:, dofy]))
-                probe_resp[j] = np.sqrt((_probe_resp[0] * np.cos(angle)) ** 2 +
-                                        (_probe_resp[1] * np.sin(angle)) ** 2)
-            # fmt: on
+            probe_phase = np.real(probe_phase)
+            probe_phase = Q_(probe_phase, "rad").to(phase_units).m
 
-            probe_phase = np.zeros_like(self.phase[:, :, 0])
-            for j, phs in enumerate(self.phase):
-                aux_phase = phs[:, p[0] * self.number_dof]
-                probe_phase[j] = np.array(
-                    [i + 2 * np.pi if i < 0 else i for i in aux_phase]
-                )
-                angle = p[1]
-                probe_phase[j] = probe_phase[j] - angle
+            try:
+                probe_tag = p[2]
+            except IndexError:
+                probe_tag = f"Probe {i+1} - Node {p[0]}"
 
             fig.add_trace(
                 go.Scatterpolar(
-                    r=np.mean(probe_resp, axis=0),
+                    r=Q_(np.mean(np.abs(mag), axis=0), base_unit).to(amplitude_units).m,
                     theta=np.mean(probe_phase, axis=0),
-                    customdata=self.frequency_range,
-                    thetaunit="radians",
+                    customdata=frequency_range,
+                    thetaunit=polar_theta_unit,
                     mode="lines",
                     line=dict(width=3.0, color=list(tableau_colors)[i]),
-                    name=f"Probe {i + 1} - Mean",
-                    legendgroup=f"Probe {i + 1} - Mean",
+                    name=f"{probe_tag} - Mean",
+                    legendgroup=f"{probe_tag} - Mean",
                     hovertemplate=(
                         "<b>Amplitude: %{r:.2e}</b><br>"
                         + "<b>Phase: %{theta:.2f}</b><br>"
@@ -1671,14 +2055,17 @@ class ST_ForcedResponseResults(ST_Results):
             for j, p in enumerate(percentile):
                 fig.add_trace(
                     go.Scatterpolar(
-                        r=np.percentile(probe_resp, p, axis=0),
+                        r=Q_(np.percentile(np.abs(mag), p, axis=0), base_unit)
+                        .to(amplitude_units)
+                        .m,
                         theta=np.percentile(probe_phase, p, axis=0),
-                        customdata=self.frequency_range,
-                        thetaunit="radians",
+                        customdata=frequency_range,
+                        thetaunit=polar_theta_unit,
                         opacity=0.6,
+                        mode="lines",
                         line=dict(width=2.5, color=colors1[color_p]),
-                        name=f"Probe {i + 1} - percentile: {p}%",
-                        legendgroup=f"Probe {i + 1} - percentile{p}",
+                        name=f"{probe_tag} - percentile: {p}%",
+                        legendgroup=f"{probe_tag} - percentile{p}",
                         hovertemplate=(
                             "<b>Amplitude: %{r:.2e}</b><br>"
                             + "<b>Phase: %{theta:.2f}</b><br>"
@@ -1689,15 +2076,18 @@ class ST_ForcedResponseResults(ST_Results):
                 color_p += 1
 
             for j, p in enumerate(conf_interval):
-                p1 = np.percentile(probe_resp, 50 + p / 2, axis=0)
-                p2 = np.percentile(probe_resp, 50 - p / 2, axis=0)
+                # fmt: off
+                p1 = Q_(np.percentile(np.abs(mag), 50 + p / 2, axis=0), base_unit).to(amplitude_units).m
+                p2 = Q_(np.percentile(np.abs(mag), 50 - p / 2, axis=0), base_unit).to(amplitude_units).m
                 p3 = np.percentile(probe_phase, 50 + p / 2, axis=0)
                 p4 = np.percentile(probe_phase, 50 - p / 2, axis=0)
+                # fmt: on
                 fig.add_trace(
                     go.Scatterpolar(
                         r=np.concatenate((p1, p2[::-1])),
                         theta=np.concatenate((p3, p4[::-1])),
-                        thetaunit="radians",
+                        thetaunit=polar_theta_unit,
+                        mode="lines",
                         line=dict(width=1, color=colors2[color_i]),
                         fill="toself",
                         fillcolor=colors2[color_i],
@@ -1710,8 +2100,10 @@ class ST_ForcedResponseResults(ST_Results):
 
         fig.update_layout(
             polar=dict(
-                radialaxis=dict(title_text=r_axis_label, exponentformat="E"),
-                angularaxis=dict(exponentformat="E"),
+                radialaxis=dict(
+                    title=dict(text=f"Amplitude ({amplitude_units})"),
+                ),
+                angularaxis=dict(thetaunit=polar_theta_unit),
             ),
             **kwargs,
         )
@@ -1723,30 +2115,68 @@ class ST_ForcedResponseResults(ST_Results):
         probe,
         percentile=[],
         conf_interval=[],
-        fig=None,
-        units="mic-pk-pk",
-        **kwargs,
+        probe_units="rad",
+        frequency_units="rad/s",
+        amplitude_units="m",
+        phase_units="rad",
+        mag_kwargs=None,
+        phase_kwargs=None,
+        polar_kwargs=None,
+        subplot_kwargs=None,
     ):
-        """Plot frequency response.
+        """Plot stochastic forced response using Plotly.
 
-        This method plots the frequency and phase response given a set of probes.
+        This method plots the forced response given a set of probes.
 
         Parameters
         ----------
-        dof : int
-            Degree of freedom to observe the response.
+        probe : list of tuples
+            List with tuples (node, orientation angle, tag).
+            node : int
+                indicate the node where the probe is located.
+            orientation : float
+                probe orientation angle about the shaft. The 0 refers to +X direction.
+            tag : str, optional
+                probe tag to be displayed at the legend.
         percentile : list, optional
             Sequence of percentiles to compute, which must be
             between 0 and 100 inclusive.
         conf_interval : list, optional
             Sequence of confidence intervals to compute, which must be
             between 0 and 100 inclusive.
-        units : str, optional
-            Unit system
-            Default is "mic-pk-pk"
-        kwargs : optional
-            Additional key word arguments can be passed to change the plot
-            (e.g. line=dict(width=4.0, color="royalblue"), opacity=1.0, ...)
+        probe_units : str, option
+            Units for probe orientation.
+            Default is "rad".
+        frequency_units : str, optional
+            Frequency units.
+            Default is "rad/s"
+        amplitude_units : str, optional
+            Units for the y axis.
+            Acceptable units dimensionality are:
+                '[length]' - Displays the displacement;
+                '[speed]' - Displays the velocity;
+                '[acceleration]' - Displays the acceleration.
+            Default is "m" 0 to peak.
+            To use peak to peak use the prefix 'pkpk_' (e.g. pkpk_m)
+        phase_units : str, optional
+            Phase units.
+            Default is "rad"
+        mag_kwargs : optional
+            Additional key word arguments can be passed to change the magnitude plot
+            layout only (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+        phase_kwargs : optional
+            Additional key word arguments can be passed to change the phase plot
+            layout only (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+        polar_kwargs : optional
+            Additional key word arguments can be passed to change the polar plot
+            layout only (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+        subplot_kwargs : optional
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...). This kwargs override "mag_kwargs" and
+            "phase_kwargs" dictionaries.
             *See Plotly Python Figure Reference for more information.
 
         Returns
@@ -1754,16 +2184,26 @@ class ST_ForcedResponseResults(ST_Results):
         subplots : Plotly graph_objects.make_subplots()
             Plotly figure with amplitude vs frequency phase angle vs frequency.
         """
-        # fmt: off
-        fig0 = self.plot_magnitude(probe, percentile, conf_interval, units=units, **kwargs)
-        fig1 = self.plot_phase(probe, percentile, conf_interval, **kwargs)
-        fig2 = self.plot_polar_bode(probe, percentile, conf_interval, units=units, **kwargs)
+        mag_kwargs = {} if mag_kwargs is None else copy.copy(mag_kwargs)
+        phase_kwargs = {} if phase_kwargs is None else copy.copy(phase_kwargs)
+        polar_kwargs = {} if polar_kwargs is None else copy.copy(polar_kwargs)
+        subplot_kwargs = {} if subplot_kwargs is None else copy.copy(subplot_kwargs)
 
-        if fig is None:
-            fig = make_subplots(
-                rows=2, cols=2, specs=[[{}, {"type": "polar", "rowspan": 2}], [{}, None]]
-            )
+        # fmt: off
+        fig0 = self.plot_magnitude(
+            probe, percentile, conf_interval, probe_units, frequency_units, amplitude_units, None, **mag_kwargs
+        )
+        fig1 = self.plot_phase(
+            probe, percentile, conf_interval, probe_units, frequency_units, amplitude_units, phase_units, None, **phase_kwargs
+        )
+        fig2 = self.plot_polar_bode(
+            probe, percentile, conf_interval, probe_units, frequency_units, amplitude_units, phase_units, None, **polar_kwargs,
+        )
         # fmt: on
+
+        fig = make_subplots(
+            rows=2, cols=2, specs=[[{}, {"type": "polar", "rowspan": 2}], [{}, None]]
+        )
 
         for data in fig0["data"]:
             data.showlegend = False

--- a/ross/stochastic/st_results.py
+++ b/ross/stochastic/st_results.py
@@ -337,7 +337,6 @@ class ST_CampbellResults(ST_Results):
                     line=dict(width=3, color=colors1[j]),
                     legendgroup="mean{}".format(j),
                     hovertemplate=("Frequency: %{x:.3f}<br>" + "Log Dec: %{y:.3f}"),
-                    **kwargs,
                 )
             )
 
@@ -351,7 +350,6 @@ class ST_CampbellResults(ST_Results):
                         name="percentile: {}%".format(p),
                         legendgroup="percentile{}{}".format(j, i),
                         hoverinfo="none",
-                        **kwargs,
                     )
                 )
 
@@ -369,7 +367,6 @@ class ST_CampbellResults(ST_Results):
                         name="confidence interval: {}% - Mode {}".format(p, j + 1),
                         legendgroup="conf{}{}".format(j, i),
                         hoverinfo="none",
-                        **kwargs,
                     )
                 )
 

--- a/ross/stochastic/st_shaft_element.py
+++ b/ross/stochastic/st_shaft_element.py
@@ -6,6 +6,7 @@ analysis.
 from ross.shaft_element import ShaftElement
 from ross.stochastic.st_materials import ST_Material
 from ross.stochastic.st_results_elements import plot_histogram
+from ross.units import Q_, check_units
 
 __all__ = ["ST_ShaftElement", "st_shaft_example"]
 
@@ -84,6 +85,7 @@ class ST_ShaftElement:
     5
     """
 
+    @check_units
     def __init__(
         self,
         L,
@@ -338,6 +340,10 @@ def st_shaft_example():
     from ross.materials import steel
 
     elm = ST_ShaftElement(
-        L=[1.0, 1.1], idl=0.0, odl=[0.1, 0.2], material=steel, is_random=["L", "odl"]
+        L=[1.0, 1.1],
+        idl=0.0,
+        odl=[0.1, 0.2],
+        material=steel,
+        is_random=["L", "odl"],
     )
     return elm

--- a/ross/tests/test_stochastic_rotor_assembly.py
+++ b/ross/tests/test_stochastic_rotor_assembly.py
@@ -48,7 +48,11 @@ def rotor1():
 ###############################################################################
 def test_st_shaft_elements_odd_length():
     tim0 = ST_ShaftElement(
-        L=[1, 1.1], idl=0, odl=[0.1, 0.2], material=steel, is_random=["L", "odl"]
+        L=[1, 1.1],
+        idl=0,
+        odl=[0.1, 0.2],
+        material=steel,
+        is_random=["L", "odl"],
     )
     tim1 = ST_ShaftElement(
         L=[1, 1.1, 1.2],
@@ -78,17 +82,33 @@ def test_st_disk_elements_odd_length():
 
 
 def test_st_bearing_elements_odd_length():
-    tim0 = ShaftElement(L=0.25, idl=0, odl=0.05, material=steel)
-    tim1 = ShaftElement(L=0.25, idl=0, odl=0.05, material=steel)
+    tim0 = ShaftElement(
+        L=0.25,
+        idl=0,
+        odl=0.05,
+        material=steel,
+    )
+    tim1 = ShaftElement(
+        L=0.25,
+        idl=0,
+        odl=0.05,
+        material=steel,
+    )
     shaft_elm = [tim0, tim1]
 
     disk0 = DiskElement(n=1, m=20, Id=1, Ip=1)
 
     brg0 = ST_BearingElement(
-        n=0, kxx=[1e6, 2e6], cxx=[1e3, 2e3], is_random=["kxx", "cxx"]
+        n=0,
+        kxx=[1e6, 2e6],
+        cxx=[1e3, 2e3],
+        is_random=["kxx", "cxx"],
     )
     brg1 = ST_BearingElement(
-        n=2, kxx=[1e6, 2e6, 3e6], cxx=[1e3, 2e3, 3e3], is_random=["kxx", "cxx"]
+        n=2,
+        kxx=[1e6, 2e6, 3e6],
+        cxx=[1e3, 2e3, 3e3],
+        is_random=["kxx", "cxx"],
     )
 
     with pytest.raises(ValueError) as ex:
@@ -118,7 +138,11 @@ def test_st_point_mass_elements_odd_length():
 
 def test_elements_odd_length():
     tim0 = ST_ShaftElement(
-        L=[1, 1.1], idl=0, odl=[0.1, 0.2], material=steel, is_random=["L", "odl"]
+        L=[1, 1.1],
+        idl=0,
+        odl=[0.1, 0.2],
+        material=steel,
+        is_random=["L", "odl"],
     )
     shaft_elm = [tim0, tim0]
 
@@ -127,10 +151,16 @@ def test_elements_odd_length():
     disks = [disk0, disk1]
 
     brg0 = ST_BearingElement(
-        n=0, kxx=[1e6, 2e6], cxx=[1e3, 2e3], is_random=["kxx", "cxx"]
+        n=0,
+        kxx=[1e6, 2e6],
+        cxx=[1e3, 2e3],
+        is_random=["kxx", "cxx"],
     )
     brg1 = ST_BearingElement(
-        n=2, kxx=[1e6, 2e6], cxx=[1e3, 2e3], is_random=["kxx", "cxx"]
+        n=2,
+        kxx=[1e6, 2e6],
+        cxx=[1e3, 2e3],
+        is_random=["kxx", "cxx"],
     )
     bearings = [brg0, brg1]
 
@@ -257,7 +287,7 @@ def test_run_freq_response(rotor1):
     speed_range = np.linspace(0, 300, 21)
     inp = 13
     out = 13
-    results = rotor1.run_freq_response(speed_range, inp, out)
+    results = rotor1.run_freq_response(inp, out, speed_range)
 
     # fmt: off
     magnitude = np.array(
@@ -313,10 +343,11 @@ def test_run_freq_response(rotor1):
     )
     # fmt: on
 
-    assert results.magnitude.shape == (21, 2)
-    assert results.phase.shape == (21, 2)
-    assert_allclose(results.magnitude, magnitude, atol=1e-6)
-    assert_allclose(results.phase, phase, atol=1e-6)
+    assert results.freq_resp.shape == (21, 2)
+    assert results.velc_resp.shape == (21, 2)
+    assert results.accl_resp.shape == (21, 2)
+    assert_allclose(np.abs(results.freq_resp), magnitude, atol=1e-6)
+    assert_allclose(np.angle(results.freq_resp), phase, atol=1e-6)
 
 
 def test_run_unbalance_response(rotor1):
@@ -407,12 +438,12 @@ def test_run_unbalance_response(rotor1):
     )
     # fmt: on
 
-    assert results.forced_resp.shape == (2, 21, 28)
-    assert results.magnitude.shape == (2, 21, 28)
-    assert results.phase.shape == (2, 21, 28)
-    assert_allclose(results.forced_resp[0, :8, :8], forced_resp, atol=1e-8)
-    assert_allclose(results.magnitude[0, :8, :8], magnitude, atol=1e-8)
-    assert_allclose(results.phase[0, :8, :8], phase, atol=1e-8)
+    assert results.forced_resp.shape == (2, 28, 21)
+    assert results.velc_resp.shape == (2, 28, 21)
+    assert results.accl_resp.shape == (2, 28, 21)
+    assert_allclose(results.forced_resp[0, :8, :8].T, forced_resp, atol=1e-8)
+    assert_allclose(np.abs(results.forced_resp[0, :8, :8]).T, magnitude, atol=1e-8)
+    assert_allclose(np.angle(results.forced_resp[0, :8, :8]).T, phase, atol=1e-8)
 
 
 def test_time_response(rotor1):


### PR DESCRIPTION
This PR does extensive changes to stochastic ROSS module.

- Add units support to st_rotor_assembly.py and st_results.py file.
- Add units support to elements and materials
- Update methods and classes to match ROSS and Stochastic ROSS syntax.
- Improve documentation.
