### PR TITLE
Add speed_range and whirl directions to run_critical_speeds()

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -165,9 +165,9 @@ class CriticalSpeedResults(Results):
 
     Parameters
     ----------
-    wn : array
+    _wn : array
         Undamped critical speeds array.
-    wd : array
+    _wd : array
         Undamped critical speeds array.
     log_dec : array
         Logarithmic decrement for each critical speed.
@@ -177,9 +177,9 @@ class CriticalSpeedResults(Results):
         Whirl direction for each critical speed. Can be forward, backward or mixed.
     """
 
-    def __init__(self, wn, wd, log_dec, damping_ratio, whirl_direction):
-        self._wn = wn
-        self._wd = wd
+    def __init__(self, _wn, _wd, log_dec, damping_ratio, whirl_direction):
+        self._wn = _wn
+        self._wd = _wd
         self.log_dec = log_dec
         self.damping_ratio = damping_ratio
         self.whirl_direction = whirl_direction
@@ -190,7 +190,7 @@ class CriticalSpeedResults(Results):
         Parameters
         ----------
         frequency_units : str, optional
-            Units critical speeds.
+            Critical speeds units.
             Default is rad/s
 
         Returns
@@ -206,7 +206,7 @@ class CriticalSpeedResults(Results):
         Parameters
         ----------
         frequency_units : str, optional
-            Units critical speeds.
+            Critical speeds units.
             Default is rad/s
 
         Returns

--- a/ross/results.py
+++ b/ross/results.py
@@ -173,13 +173,48 @@ class CriticalSpeedResults(Results):
         Logarithmic decrement for each critical speed.
     damping_ratio : array
         Damping ratio for each critical speed.
+    whirl_direction : array
+        Whirl direction for each critical speed. Can be forward, backward or mixed.
     """
 
-    def __init__(self, wn, wd, log_dec, damping_ratio):
-        self.wn = wn
-        self.wd = wd
+    def __init__(self, wn, wd, log_dec, damping_ratio, whirl_direction):
+        self._wn = wn
+        self._wd = wd
         self.log_dec = log_dec
         self.damping_ratio = damping_ratio
+        self.whirl_direction = whirl_direction
+
+    def wn(self, frequency_units="rad/s"):
+        """Convert units for undamped critical speeds.
+
+        Parameters
+        ----------
+        frequency_units : str, optional
+            Units critical speeds.
+            Default is rad/s
+
+        Returns
+        -------
+        wn : array
+            Undamped critical speeds array.
+        """
+        return Q_(self.__dict__["_wn"], "rad/s").to(frequency_units).m
+
+    def wd(self, frequency_units="rad/s"):
+        """Convert units for damped critical speeds.
+
+        Parameters
+        ----------
+        frequency_units : str, optional
+            Units critical speeds.
+            Default is rad/s
+
+        Returns
+        -------
+        wd : array
+            Undamped critical speeds array.
+        """
+        return Q_(self.__dict__["_wd"], "rad/s").to(frequency_units).m
 
 
 class ModalResults(Results):
@@ -1080,7 +1115,7 @@ class FrequencyResponseResults(Results):
     speed_range : array
         Array with the speed range in rad/s.
     number_dof : int
-        Number of degrees of freedom per node
+        Number of degrees of freedom per node.
 
     Returns
     -------
@@ -1273,8 +1308,8 @@ class FrequencyResponseResults(Results):
 
         if fig is None:
             fig = go.Figure()
-
         idx = len(fig.data)
+
         fig.add_trace(
             go.Scatter(
                 x=frequency_range,
@@ -3556,9 +3591,10 @@ class TimeResponseResults(Results):
         fig=None,
         **kwargs,
     ):
-        """Plot time response for a single DoF using Plotly.
+        """Plot time response.
 
-        This function will take a rotor object and plot its time response using Plotly.
+        This method plots the time response given a tuple of probes with their nodes
+        and orientations.
 
         Parameters
         ----------

--- a/ross/tests/test_results.py
+++ b/ross/tests/test_results.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
-from ross.rotor_assembly import *
 from ross.results import *
+from ross.rotor_assembly import *
 
 
 @pytest.fixture
@@ -35,8 +35,8 @@ def test_save_load_criticalspeed(rotor1):
     response.save(file)
     response2 = CriticalSpeedResults.load(file)
 
-    assert response2.wn.all() == response.wn.all()
-    assert response2.wd.all() == response.wd.all()
+    assert response2._wn.all() == response._wn.all()
+    assert response2._wd.all() == response._wd.all()
     assert response2.log_dec.all() == response.log_dec.all()
     assert response2.damping_ratio.all() == response.damping_ratio.all()
 
@@ -58,7 +58,10 @@ def test_save_load_modal(rotor1):
     assert response2.ndof == response.ndof
     assert np.array(response2.nodes).all() == np.array(response.nodes).all()
     assert np.array(response2.nodes_pos).all() == np.array(response.nodes_pos).all()
-    assert np.array(response2.shaft_elements_length).all() == np.array(response.shaft_elements_length).all()
+    assert (
+        np.array(response2.shaft_elements_length).all()
+        == np.array(response.shaft_elements_length).all()
+    )
 
 
 def test_save_load_freqresponse(rotor1):

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -961,13 +961,13 @@ def test_run_critical_speed(rotor5, rotor6):
     log_dec6 = np.zeros_like(wd6)
     damping_ratio6 = np.zeros_like(wd6)
 
-    assert_almost_equal(results5.wd, wd5, decimal=4)
-    assert_almost_equal(results5.wn, wn5, decimal=4)
+    assert_almost_equal(results5._wd, wd5, decimal=4)
+    assert_almost_equal(results5._wn, wn5, decimal=4)
     assert_almost_equal(results5.log_dec, log_dec5, decimal=4)
     assert_almost_equal(results5.damping_ratio, damping_ratio5, decimal=4)
 
-    assert_almost_equal(results6.wd, wd6, decimal=4)
-    assert_almost_equal(results6.wn, wn6, decimal=4)
+    assert_almost_equal(results6._wd, wd6, decimal=4)
+    assert_almost_equal(results6._wn, wn6, decimal=4)
     assert_almost_equal(results6.log_dec, log_dec6, decimal=4)
     assert_almost_equal(results6.damping_ratio, damping_ratio6, decimal=4)
 


### PR DESCRIPTION
Users will be able to set bounds where to catch the critical speeds.
Add option to return the whirl direction for each critical speed.
Add option to change `wn` and `wd` units.

Examples of how to use `run_critical_speeds()`

```python
        >>> import ross as rs
        >>> rotor = rs.rotor_example()

        # Finding the first Nth critical speeds
        >>> results = rotor.run_critical_speed(num_modes=8)
        >>> np.round(results.wd())
        array([ 92.,  96., 271., 300.])
        >>> np.round(results.wn())
        array([ 92.,  96., 271., 300.])

        # Finding the critical speeds within a speed range
        >>> results = rotor.run_critical_speed(speed_range=(100, 1000))
        >>> np.round(results.wd())
        array([271., 300., 636., 867.])

        # Changing output units
        >>> np.round(results.wd("rpm"))
        array([2590., 2868., 6074., 8278.])

        # Retrieving whirl directions
        >>> results.whirl_direction # doctest: +ELLIPSIS
        array([...
```