### PR TITLE
Add codecov to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe -m pytest ross"
+  - "%PYTHON%\\python.exe -m pytest ross --cov=ross"
 
 after_test:
   - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,9 @@ build: off
 test_script:
   - "%PYTHON%\\python.exe -m pytest ross"
 
+after_test:
+  - codecov
+
 artifacts:
   - path: dist\*
 


### PR DESCRIPTION
While we do not change the CI from Travis to other (Issue #738) , I'm adding codecov do appveyor, so it can run coverage after testing our code