### PR TITLE
Update docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3
 
 -   repo: https://github.com/timothycrosley/isort
     rev: ''

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,15 +11,9 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile examples
+.PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-tutorial: 
-	tools/nb_to_doc.py examples/tutorial
-
-examples:
-	tools/nb_to_doc.py examples/example_05_08_01 examples/example_05_08_02 examples/example_05_09_01 examples/example_05_09_02 examples/example_05_09_04 examples/example_05_09_05 examples/example_05_09_06 examples/example_05_09_09

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,3 +17,6 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# To build the docs without running the notebooks do:
+# make NBSPHINX_EXECUTE="never" html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,8 +98,11 @@ pygments_style = "abap"
 # a list of builtin themes.
 #
 nbsphinx_allow_errors = True
-nbsphinx_kernel_name = 'python3'
-nbsphinx_execute = 'always'
+nbsphinx_kernel_name = "python3"
+try:
+    nbsphinx_execute = os.environ["NBSPHINX_EXECUTE"]
+except KeyError:
+    nbsphinx_execute = "always"
 html_theme = "bootstrap"
 htlm_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -272,4 +272,4 @@ epub_exclude_files = ["search.html"]
 
 # -- Extension configuration -------------------------------------------------
 def setup(app):
-    app.add_stylesheet("style.css")
+    app.add_css_file("style.css")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,8 @@ pygments_style = "abap"
 # a list of builtin themes.
 #
 nbsphinx_allow_errors = True
+nbsphinx_kernel_name = 'python3'
+nbsphinx_execute = 'always'
 html_theme = "bootstrap"
 htlm_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 

--- a/docs/sphinxext/sphinx_copybutton/__init__.py
+++ b/docs/sphinxext/sphinx_copybutton/__init__.py
@@ -39,6 +39,6 @@ def setup(app):
     app.connect("builder-inited", scb_static_path)
 
     # Add relevant code to headers
-    app.add_stylesheet("sphinx_copybutton.css")
-    app.add_javascript("sphinx_copybutton.js")
-    app.add_javascript(clipboard_js_url)
+    app.add_css_file("sphinx_copybutton.css")
+    app.add_js_file("sphinx_copybutton.js")
+    app.add_js_file(clipboard_js_url)

--- a/ross/stochastic/st_results_elements.py
+++ b/ross/stochastic/st_results_elements.py
@@ -12,8 +12,6 @@ from scipy.stats import gaussian_kde
 
 from ross.plotly_theme import tableau_colors
 
-pio.renderers.default = "browser"
-
 
 def plot_histogram(
     attribute_dict, label={}, var_list=[], histogram_kwargs=None, plot_kwargs=None


### PR DESCRIPTION
This PR updates some aspects of the building process.
Now we are setting the variable `nbsphinx_execute='always` so that we run 
all notebooks during the docs building process. 
It avoids having notebooks that have non working code in our documentation. 
It also solves the problem of getting some notebooks without the cell output.