### PR TITLE
Add n_link to SealElement

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -1181,6 +1181,7 @@ class SealElement(BearingElement):
             cyx=cyx,
             cyy=cyy,
             tag=tag,
+            n_link=n_link,
             scale_factor=scale_factor,
             color=color,
         )

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -1165,6 +1165,7 @@ class SealElement(BearingElement):
         frequency=None,
         seal_leakage=None,
         tag=None,
+        n_link=None,
         scale_factor=1.0,
         color="#77ACA2",
     ):


### PR DESCRIPTION
Although we are probably not using this with seals, it keeps consistency
with BearingElement and methods such as .from_table().
