### PR TITLE
fix plot docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,9 +108,6 @@ except KeyError:
     nbsphinx_execute = "always"
 html_theme = "bootstrap"
 htlm_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
-html_js_files = [
-    "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"
-]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -285,3 +282,6 @@ epub_exclude_files = ["search.html"]
 # -- Extension configuration -------------------------------------------------
 def setup(app):
     app.add_css_file("style.css")
+    app.add_js_file(
+        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"
+    )


### PR DESCRIPTION
- Fix add of js file

Previous code is used when we build documentation using readthedocs,
which is not the case for ROSS.

Related to #759 .