### PR TITLE
Fix np objects conversion

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -1050,6 +1050,7 @@ class SealElement(BearingElement):
         n_link=None,
         scale_factor=1.0,
         color="#77ACA2",
+        **kwargs,
     ):
         super().__init__(
             n=n,

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -408,6 +408,12 @@ class BearingElement(Element):
                 brg_data[k] = brg_data[k].item()
             elif isinstance(v, np.ndarray):
                 brg_data[k] = brg_data[k].tolist()
+            # case for a container with np.float (e.g. list(np.float))
+            else:
+                try:
+                    brg_data[k] = [i.item() for i in brg_data[k]]
+                except (TypeError, AttributeError):
+                    pass
 
         data[f"{self.__class__.__name__}_{self.tag}"] = brg_data
 

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -403,22 +403,11 @@ class BearingElement(Element):
             brg_data.pop(p)
 
         # change np.array to lists so that we can save in .toml as list(floats)
-        params = [
-            "kxx",
-            "kyy",
-            "kxy",
-            "kyx",
-            "cxx",
-            "cyy",
-            "cxy",
-            "cyx",
-            "frequency",
-        ]
-        for p in params:
-            try:
-                brg_data[p] = [float(i) for i in brg_data[p]]
-            except TypeError:
-                pass
+        for k, v in brg_data.items():
+            if isinstance(v, np.generic):
+                brg_data[k] = brg_data[k].item()
+            elif isinstance(v, np.ndarray):
+                brg_data[k] = brg_data[k].tolist()
 
         data[f"{self.__class__.__name__}_{self.tag}"] = brg_data
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2624,7 +2624,11 @@ class Rotor(object):
             if el_name == "parameters":
                 continue
             class_name = el_name.split("_")[0]
-            elements.append(globals()[class_name].read_toml_data(el_data))
+            try:
+                elements.append(globals()[class_name].read_toml_data(el_data))
+            except KeyError:
+                import rossxl as rsxl
+                elements.append(getattr(rsxl, class_name).read_toml_data(el_data))
 
         shaft_elements = []
         disk_elements = []

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2628,6 +2628,7 @@ class Rotor(object):
                 elements.append(globals()[class_name].read_toml_data(el_data))
             except KeyError:
                 import rossxl as rsxl
+
                 elements.append(getattr(rsxl, class_name).read_toml_data(el_data))
 
         shaft_elements = []


### PR DESCRIPTION
Numpy objects have to be converted to native types before saving to .toml.
This fixes some cases where the conversion was not being done.