### PR TITLE
Fix static analysis

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        informational: true
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2722,14 +2722,15 @@ class Rotor(object):
 
         aux_brg = []
         for elm in self.bearing_elements:
-            if elm.n not in self.nodes:
-                pass
-            elif elm.n_link in self.nodes:
-                aux_brg.append(
-                    BearingElement(n=elm.n, n_link=elm.n_link, kxx=1e14, cxx=0)
-                )
-            else:
-                aux_brg.append(BearingElement(n=elm.n, kxx=1e14, cxx=0))
+            if not isinstance(elm, SealElement):
+                if elm.n not in self.nodes:
+                    pass
+                elif elm.n_link in self.nodes:
+                    aux_brg.append(
+                        BearingElement(n=elm.n, n_link=elm.n_link, kxx=1e14, cxx=0)
+                    )
+                else:
+                    aux_brg.append(BearingElement(n=elm.n, kxx=1e14, cxx=0))
 
         if isinstance(self, CoAxialRotor):
             aux_rotor = CoAxialRotor(self.shafts, self.disk_elements, aux_brg)

--- a/ross/tests/data/rotor.toml
+++ b/ross/tests/data/rotor.toml
@@ -1,0 +1,2262 @@
+[parameters]
+
+["ShaftElement_ShaftElement 0"]
+L = 0.035500000000000004
+idl = 0.1409954
+odl = 0.151003
+idr = 0.1409954
+odr = 0.151003
+n = 0
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 0"
+
+["ShaftElement_ShaftElement 1"]
+L = 0.036000000000000004
+idl = 0.1409954
+odl = 0.151003
+idr = 0.1409954
+odr = 0.151003
+n = 1
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 1"
+
+["ShaftElement_ShaftElement 2"]
+L = 0.054000000000000006
+idl = 0.0
+odl = 0.08
+idr = 0.0
+odr = 0.08
+n = 2
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 2"
+
+["ShaftElement_ShaftElement 3"]
+L = 0.043000000000000003
+idl = 0.0
+odl = 0.08
+idr = 0.0
+odr = 0.08
+n = 3
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 3"
+
+["ShaftElement_ShaftElement 4"]
+L = 0.0165
+idl = 0.0
+odl = 0.088
+idr = 0.0
+odr = 0.088
+n = 4
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 4"
+
+["ShaftElement_ShaftElement 5"]
+L = 0.014
+idl = 0.0
+odl = 0.088
+idr = 0.0
+odr = 0.088
+n = 5
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 5"
+
+["ShaftElement_ShaftElement 6"]
+L = 0.036500000000000005
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 6
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 6"
+
+["ShaftElement_ShaftElement 7"]
+L = 0.051
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 7
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 7"
+
+["ShaftElement_ShaftElement 8"]
+L = 0.025
+idl = 0.0
+odl = 0.103
+idr = 0.0
+odr = 0.103
+n = 8
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 8"
+
+["ShaftElement_ShaftElement 9"]
+L = 0.025
+idl = 0.103
+odl = 0.13799999999999998
+idr = 0.103
+odr = 0.13799999999999998
+n = 8
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 9"
+
+["ShaftElement_ShaftElement 10"]
+L = 0.016
+idl = 0.0
+odl = 0.085
+idr = 0.0
+odr = 0.085
+n = 9
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 10"
+
+["ShaftElement_ShaftElement 11"]
+L = 0.016
+idl = 0.085
+odl = 0.13799999999999998
+idr = 0.085
+odr = 0.13799999999999998
+n = 9
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 11"
+
+["ShaftElement_ShaftElement 12"]
+L = 0.0242
+idl = 0.0
+odl = 0.104
+idr = 0.0
+odr = 0.104
+n = 10
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 12"
+
+["ShaftElement_ShaftElement 13"]
+L = 0.0242
+idl = 0.104
+odl = 0.174
+idr = 0.104
+odr = 0.174
+n = 10
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 13"
+
+["ShaftElement_ShaftElement 14"]
+L = 0.0045000000000000005
+idl = 0.0
+odl = 0.0982
+idr = 0.0
+odr = 0.0982
+n = 11
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 14"
+
+["ShaftElement_ShaftElement 15"]
+L = 0.0045000000000000005
+idl = 0.0982
+odl = 0.174
+idr = 0.0982
+odr = 0.174
+n = 11
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 15"
+
+["ShaftElement_ShaftElement 16"]
+L = 0.01257
+idl = 0.0
+odl = 0.104
+idr = 0.0
+odr = 0.104
+n = 12
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 16"
+
+["ShaftElement_ShaftElement 17"]
+L = 0.01257
+idl = 0.104
+odl = 0.174
+idr = 0.104
+odr = 0.174
+n = 12
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 17"
+
+["ShaftElement_ShaftElement 18"]
+L = 0.02
+idl = 0.0
+odl = 0.10600000000000001
+idr = 0.0
+odr = 0.10600000000000001
+n = 13
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 18"
+
+["ShaftElement_ShaftElement 19"]
+L = 0.02
+idl = 0.10600000000000001
+odl = 0.184
+idr = 0.10600000000000001
+odr = 0.184
+n = 13
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 19"
+
+["ShaftElement_ShaftElement 20"]
+L = 0.06273000000000001
+idl = 0.0
+odl = 0.10800000000000001
+idr = 0.0
+odr = 0.10800000000000001
+n = 14
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 20"
+
+["ShaftElement_ShaftElement 21"]
+L = 0.06273000000000001
+idl = 0.10800000000000001
+odl = 0.184
+idr = 0.10800000000000001
+odr = 0.184
+n = 14
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 21"
+
+["ShaftElement_ShaftElement 22"]
+L = 0.038
+idl = 0.0
+odl = 0.11
+idr = 0.0
+odr = 0.11
+n = 15
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 22"
+
+["ShaftElement_ShaftElement 23"]
+L = 0.038
+idl = 0.11
+odl = 0.184
+idr = 0.11
+odr = 0.184
+n = 15
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 23"
+
+["ShaftElement_ShaftElement 24"]
+L = 0.038
+idl = 0.0
+odl = 0.122
+idr = 0.0
+odr = 0.122
+n = 16
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 24"
+
+["ShaftElement_ShaftElement 25"]
+L = 0.038
+idl = 0.122
+odl = 0.13899999999999998
+idr = 0.122
+odr = 0.13899999999999998
+n = 16
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 25"
+
+["ShaftElement_ShaftElement 26"]
+L = 0.030000000000000002
+idl = 0.0
+odl = 0.135
+idr = 0.0
+odr = 0.135
+n = 17
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 26"
+
+["ShaftElement_ShaftElement 27"]
+L = 0.030000000000000002
+idl = 0.135
+odl = 0.175
+idr = 0.135
+odr = 0.175
+n = 17
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 27"
+
+["ShaftElement_ShaftElement 28"]
+L = 0.053000000000000005
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 18
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 28"
+
+["ShaftElement_ShaftElement 29"]
+L = 0.053000000000000005
+idl = 0.11770000000000001
+odl = 0.1965
+idr = 0.11770000000000001
+odr = 0.1965
+n = 18
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 29"
+
+["ShaftElement_ShaftElement 30"]
+L = 0.01949
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 19
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 30"
+
+["ShaftElement_ShaftElement 31"]
+L = 0.01949
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 19
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 31"
+
+["ShaftElement_ShaftElement 32"]
+L = 0.013510000000000003
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 20
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 32"
+
+["ShaftElement_ShaftElement 33"]
+L = 0.013510000000000003
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 20
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 33"
+
+["ShaftElement_ShaftElement 34"]
+L = 0.0495
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 21
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 34"
+
+["ShaftElement_ShaftElement 35"]
+L = 0.01959
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 22
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 35"
+
+["ShaftElement_ShaftElement 36"]
+L = 0.01959
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 22
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 36"
+
+["ShaftElement_ShaftElement 37"]
+L = 0.012410000000000001
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 23
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 37"
+
+["ShaftElement_ShaftElement 38"]
+L = 0.012410000000000001
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 23
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 38"
+
+["ShaftElement_ShaftElement 39"]
+L = 0.049
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 24
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 39"
+
+["ShaftElement_ShaftElement 40"]
+L = 0.019700000000000002
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 25
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 40"
+
+["ShaftElement_ShaftElement 41"]
+L = 0.019700000000000002
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 25
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 41"
+
+["ShaftElement_ShaftElement 42"]
+L = 0.0123
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 26
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 42"
+
+["ShaftElement_ShaftElement 43"]
+L = 0.0123
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 26
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 43"
+
+["ShaftElement_ShaftElement 44"]
+L = 0.0495
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 27
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 44"
+
+["ShaftElement_ShaftElement 45"]
+L = 0.019829999999999997
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 28
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 45"
+
+["ShaftElement_ShaftElement 46"]
+L = 0.019829999999999997
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 28
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 46"
+
+["ShaftElement_ShaftElement 47"]
+L = 0.011670000000000002
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 29
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 47"
+
+["ShaftElement_ShaftElement 48"]
+L = 0.011670000000000002
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 29
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 48"
+
+["ShaftElement_ShaftElement 49"]
+L = 0.0495
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 30
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 49"
+
+["ShaftElement_ShaftElement 50"]
+L = 0.01998
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 31
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 50"
+
+["ShaftElement_ShaftElement 51"]
+L = 0.01998
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 31
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 51"
+
+["ShaftElement_ShaftElement 52"]
+L = 0.01202
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 32
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 52"
+
+["ShaftElement_ShaftElement 53"]
+L = 0.01202
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 32
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 53"
+
+["ShaftElement_ShaftElement 54"]
+L = 0.0495
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 33
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 54"
+
+["ShaftElement_ShaftElement 55"]
+L = 0.020100000000000003
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 34
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 55"
+
+["ShaftElement_ShaftElement 56"]
+L = 0.020100000000000003
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 34
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 56"
+
+["ShaftElement_ShaftElement 57"]
+L = 0.012399999999999998
+idl = 0.0
+odl = 0.12234999999999999
+idr = 0.0
+odr = 0.12234999999999999
+n = 35
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 57"
+
+["ShaftElement_ShaftElement 58"]
+L = 0.012399999999999998
+idl = 0.12234999999999999
+odl = 0.127
+idr = 0.12234999999999999
+odr = 0.127
+n = 35
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 58"
+
+["ShaftElement_ShaftElement 59"]
+L = 0.056999999999999995
+idl = 0.0
+odl = 0.11770000000000001
+idr = 0.0
+odr = 0.11770000000000001
+n = 36
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 59"
+
+["ShaftElement_ShaftElement 60"]
+L = 0.026
+idl = 0.0
+odl = 0.135
+idr = 0.0
+odr = 0.135
+n = 37
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 60"
+
+["ShaftElement_ShaftElement 61"]
+L = 0.026
+idl = 0.135
+odl = 0.175
+idr = 0.135
+odr = 0.175
+n = 37
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 61"
+
+["ShaftElement_ShaftElement 62"]
+L = 0.038
+idl = 0.0
+odl = 0.122
+idr = 0.0
+odr = 0.122
+n = 38
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 62"
+
+["ShaftElement_ShaftElement 63"]
+L = 0.038
+idl = 0.122
+odl = 0.13899999999999998
+idr = 0.122
+odr = 0.13899999999999998
+n = 38
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 63"
+
+["ShaftElement_ShaftElement 64"]
+L = 0.038
+idl = 0.0
+odl = 0.11
+idr = 0.0
+odr = 0.11
+n = 39
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 64"
+
+["ShaftElement_ShaftElement 65"]
+L = 0.038
+idl = 0.11
+odl = 0.184
+idr = 0.11
+odr = 0.184
+n = 39
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 65"
+
+["ShaftElement_ShaftElement 66"]
+L = 0.06273000000000001
+idl = 0.0
+odl = 0.10800000000000001
+idr = 0.0
+odr = 0.10800000000000001
+n = 40
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 66"
+
+["ShaftElement_ShaftElement 67"]
+L = 0.06273000000000001
+idl = 0.10800000000000001
+odl = 0.184
+idr = 0.10800000000000001
+odr = 0.184
+n = 40
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 67"
+
+["ShaftElement_ShaftElement 68"]
+L = 0.02
+idl = 0.0
+odl = 0.10600000000000001
+idr = 0.0
+odr = 0.10600000000000001
+n = 41
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 68"
+
+["ShaftElement_ShaftElement 69"]
+L = 0.02
+idl = 0.10600000000000001
+odl = 0.184
+idr = 0.10600000000000001
+odr = 0.184
+n = 41
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 69"
+
+["ShaftElement_ShaftElement 70"]
+L = 0.01257
+idl = 0.0
+odl = 0.104
+idr = 0.0
+odr = 0.104
+n = 42
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 70"
+
+["ShaftElement_ShaftElement 71"]
+L = 0.01257
+idl = 0.104
+odl = 0.174
+idr = 0.104
+odr = 0.174
+n = 42
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 71"
+
+["ShaftElement_ShaftElement 72"]
+L = 0.0045000000000000005
+idl = 0.0
+odl = 0.0982
+idr = 0.0
+odr = 0.0982
+n = 43
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 72"
+
+["ShaftElement_ShaftElement 73"]
+L = 0.0045000000000000005
+idl = 0.0982
+odl = 0.174
+idr = 0.0982
+odr = 0.174
+n = 43
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 73"
+
+["ShaftElement_ShaftElement 74"]
+L = 0.0242
+idl = 0.0
+odl = 0.104
+idr = 0.0
+odr = 0.104
+n = 44
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 74"
+
+["ShaftElement_ShaftElement 75"]
+L = 0.0242
+idl = 0.104
+odl = 0.174
+idr = 0.104
+odr = 0.174
+n = 44
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 75"
+
+["ShaftElement_ShaftElement 76"]
+L = 0.016
+idl = 0.0
+odl = 0.085
+idr = 0.0
+odr = 0.085
+n = 45
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 76"
+
+["ShaftElement_ShaftElement 77"]
+L = 0.016
+idl = 0.085
+odl = 0.13799999999999998
+idr = 0.085
+odr = 0.13799999999999998
+n = 45
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 77"
+
+["ShaftElement_ShaftElement 78"]
+L = 0.025
+idl = 0.0
+odl = 0.103
+idr = 0.0
+odr = 0.103
+n = 46
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 78"
+
+["ShaftElement_ShaftElement 79"]
+L = 0.025
+idl = 0.103
+odl = 0.13799999999999998
+idr = 0.103
+odr = 0.13799999999999998
+n = 46
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 79"
+
+["ShaftElement_ShaftElement 80"]
+L = 0.051
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 47
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 80"
+
+["ShaftElement_ShaftElement 81"]
+L = 0.050499999999999996
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 48
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 81"
+
+["ShaftElement_ShaftElement 82"]
+L = 0.036375000000000005
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 49
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 82"
+
+["ShaftElement_ShaftElement 83"]
+L = 0.036375000000000005
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 50
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 83"
+
+["ShaftElement_ShaftElement 84"]
+L = 0.013500000000000002
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 51
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 84"
+
+["ShaftElement_ShaftElement 85"]
+L = 0.034999999999999996
+idl = 0.0
+odl = 0.09000000000000001
+idr = 0.0
+odr = 0.09000000000000001
+n = 52
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 85"
+
+["ShaftElement_ShaftElement 86"]
+L = 0.034999999999999996
+idl = 0.09000000000000001
+odl = 0.245
+idr = 0.09000000000000001
+odr = 0.245
+n = 52
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 86"
+
+["ShaftElement_ShaftElement 87"]
+L = 0.024
+idl = 0.0
+odl = 0.0872
+idr = 0.0
+odr = 0.0872
+n = 53
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 87"
+
+["ShaftElement_ShaftElement 88"]
+L = 0.024
+idl = 0.0872
+odl = 0.112
+idr = 0.0872
+odr = 0.112
+n = 53
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 88"
+
+["ShaftElement_ShaftElement 89"]
+L = 0.032
+idl = 0.0
+odl = 0.085
+idr = 0.0
+odr = 0.085
+n = 54
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 89"
+
+["ShaftElement_ShaftElement 90"]
+L = 0.032
+idl = 0.085
+odl = 0.113
+idr = 0.085
+odr = 0.113
+n = 54
+axial_force = 0
+torque = 0
+shear_effects = true
+rotary_inertia = true
+gyroscopic = true
+shear_method_calc = "cowper"
+tag = "ShaftElement 90"
+
+["DiskElement_Disk 0"]
+n = 3
+m = 15.119982018530925
+Id = 0.0
+Ip = 0.0
+tag = "Disk 0"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 1"]
+n = 20
+m = 6.909991782278354
+Id = 0.02499983979288977
+Ip = 0.046999698810632776
+tag = "Disk 1"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 2"]
+n = 23
+m = 6.929991758493341
+Id = 0.02499983979288977
+Ip = 0.046999698810632776
+tag = "Disk 2"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 3"]
+n = 26
+m = 6.94999173470833
+Id = 0.02499983979288977
+Ip = 0.047999692402348366
+tag = "Disk 3"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 4"]
+n = 29
+m = 6.979991699030812
+Id = 0.02499983979288977
+Ip = 0.047999692402348366
+tag = "Disk 4"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 5"]
+n = 32
+m = 6.939991746600836
+Id = 0.02499983979288977
+Ip = 0.047999692402348366
+tag = "Disk 5"
+scale_factor = 1
+color = "Firebrick"
+
+["DiskElement_Disk 6"]
+n = 35
+m = 6.959991722815824
+Id = 0.02499983979288977
+Ip = 0.047999692402348366
+tag = "Disk 6"
+scale_factor = 1
+color = "Firebrick"
+
+["BearingElement_Bearing 0"]
+n = 7
+kxx = [ 13798100.0, 29951900.0, 53565699.99999999, 85144200.0, 120733000.0, 159519000.0, 197885000.0, 235239999.99999997, 271250000.0,]
+cxx = [ 102506.0, 127450.0, 144989.0, 153563.0, 155122.0, 150835.0, 145086.0, 141871.0, 140702.0,]
+kyy = [ 13798100.0, 29951900.0, 53565699.99999999, 85144200.0, 120733000.0, 159519000.0, 197885000.0, 235239999.99999997, 271250000.0,]
+kxy = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+kyx = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+cyy = [ 102506.0, 127450.0, 144989.0, 153563.0, 155122.0, 150835.0, 145086.0, 141871.0, 140702.0,]
+cxy = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+cyx = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+tag = "Bearing 0"
+scale_factor = 0.5
+frequency = [ 314.1592653591, 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167,]
+
+["SealElement_Seal 2"]
+n = 18
+kxx = [ 9740880.0, 21497099.999999996, 38963500.0, 61804200.0, 88339700.00000001, 115547000.0, 144098000.00000003, 171305000.0, 197673000.0,]
+cxx = [ 212416.0, 265033.0, 301476.0, 318820.0, 319599.0, 311804.0, 301670.0, 293875.0, 289978.0,]
+kyy = [ 9740880.0, 21497099.999999996, 38963500.0, 61804200.0, 88339700.00000001, 115547000.0, 144098000.00000003, 171305000.0, 197673000.0,]
+kxy = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+kyx = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+cyy = [ 212416.0, 265033.0, 301476.0, 318820.0, 319599.0, 311804.0, 301670.0, 293875.0, 289978.0,]
+cxy = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+cyx = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+tag = "Seal 2"
+scale_factor = 0.3
+frequency = [ 314.1592653591, 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167,]
+
+["SealElement_Seal 8"]
+n = 21
+kxx = [ 298251.102793201, 341553.083464932, 394552.018603807, 458222.132531081, 533166.367271116, 619721.596416625, 718029.641688798, 828087.262141986, 2308865.1768009,]
+cxx = [ 2291.12243345773, 2311.1040718269, 2326.80597091329, 2336.94965058397, 2340.6898099477, 2337.52046884341, 2327.20232641125, 2309.70538908619, 1880.94276136733,]
+kyy = [ 298251.102793201, 341553.083464932, 394552.018603807, 458222.132531081, 533166.367271116, 619721.596416625, 718029.641688798, 828087.262141986, 2308865.1768009,]
+kxy = [ 1242500.2855946, 1622346.60563776, 2019067.07204817, 2429294.4077584, 2850215.15001386, 3279441.40422489, 3714924.05537521, 4154890.25666796, 8114286.71318661,]
+kyx = [ -1242500.2855946, -1622346.60563776, -2019067.07204817, -2429294.4077584, -2850215.15001386, -3279441.40422489, -3714924.05537521, -4154890.25666796, -8114286.71318661,]
+cyy = [ 2291.12243345773, 2311.1040718269, 2326.80597091329, 2336.94965058397, 2340.6898099477, 2337.52046884341, 2327.20232641125, 2309.70538908619, 1880.94276136733,]
+cxy = [ 206.926347739178, 199.422636876644, 176.412369573979, 140.746432758469, 94.9135905607814, 41.0991829034798, -18.775866654557, -83.0260630423863, -671.209405124406,]
+cyx = [ -206.926347739178, -199.422636876644, -176.412369573979, -140.746432758469, -94.9135905607814, -41.0991829034798, 18.775866654557, 83.0260630423863, 671.209405124406,]
+tag = "Seal 8"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 13"]
+n = 22
+kxx = [ 212004.230533674, 228104.197005656, 247866.752578785, 271587.121157548, 299441.94589272, 331521.70676384, 367852.540447444, 408411.467916301, 946059.583744362,]
+cxx = [ 844.704816544965, 845.510119153807, 843.879821457693, 839.45090843711, 832.029915317881, 821.555183438786, 808.067199559831, 791.684638045522, 551.77571052815,]
+kyy = [ 212004.230533674, 228104.197005656, 247866.752578785, 271587.121157548, 299441.94589272, 331521.70676384, 367852.540447444, 408411.467916301, 946059.583744362,]
+kxy = [ 438140.709696468, 570924.881967202, 709603.313478691, 853069.011373774, 1000381.95159242, 1150732.27599602, 1303415.03798806, 1457811.94108399, 2852208.05920669,]
+kyx = [ -438140.709696468, -570924.881967202, -709603.313478691, -853069.011373774, -1000381.95159242, -1150732.27599602, -1303415.03798806, -1457811.94108399, -2852208.05920669,]
+cyy = [ 844.704816544965, 845.510119153807, 843.879821457693, 839.45090843711, 832.029915317881, 821.555183438786, 808.067199559831, 791.684638045522, 551.77571052815,]
+cxy = [ 41.8735664570863, 33.9385369802047, 21.4702902513189, 5.51035377944818, -13.0248291697293, -33.3307978115303, -54.7060168965144, -76.544502427302, -232.737765811523,]
+cyx = [ -41.8735664570863, -33.9385369802047, -21.4702902513189, -5.51035377944818, 13.0248291697293, 33.3307978115303, 54.7060168965144, 76.544502427302, 232.737765811523,]
+tag = "Seal 13"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 7"]
+n = 24
+kxx = [ 252811.630578299, 292779.969788229, 341775.407113344, 400829.381676715, 470611.220647497, 551527.947163869, 643791.437001381, 747466.3932106181, 2165015.37392413,]
+cxx = [ 2237.27062169521, 2262.54451706828, 2284.71266328052, 2302.40907831969, 2314.67941113008, 2320.89559745058, 2320.68980309972, 2313.90150206837, 1988.68376388278,]
+kyy = [ 252811.630578299, 292779.969788229, 341775.407113344, 400829.381676715, 470611.220647497, 551527.947163869, 643791.437001381, 747466.3932106181, 2165015.37392413,]
+kxy = [ 1196154.91738691, 1560429.00166038, 1940945.78963764, 2334594.59072454, 2738754.90307113, 3151186.98050217, 3569954.75170215, 3993371.59388281, 7817904.77114129,]
+kyx = [ -1196154.91738691, -1560429.00166038, -1940945.78963764, -2334594.59072454, -2738754.90307113, -3151186.98050217, -3569954.75170215, -3993371.59388281, -7817904.77114129,]
+cyy = [ 2237.27062169521, 2262.54451706828, 2284.71266328052, 2302.40907831969, 2314.67941113008, 2320.89559745058, 2320.68980309972, 2313.90150206837, 1988.68376388278,]
+cxy = [ 228.5066838492, 228.216282636906, 212.358685620386, 183.537798746503, 144.04734233591, 95.9190515734874, 40.9558585213239, -19.2447358005768, -614.227168738531,]
+cyx = [ -228.5066838492, -228.216282636906, -212.358685620386, -183.537798746503, -144.04734233591, -95.9190515734874, -40.9558585213239, 19.2447358005768, 614.227168738531,]
+tag = "Seal 7"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 12"]
+n = 25
+kxx = [ 180839.024474825, 195355.027554806, 213179.711736108, 234627.751980985, 259899.30178444, 289110.53399467, 322314.274331595, 359514.507333211, 860767.574416809,]
+cxx = [ 828.076214508057, 831.698341316398, 833.420964081016, 832.833200737184, 829.68538941482, 823.855212022527, 815.320735537458, 804.138365393787, 613.175254017714,]
+kyy = [ 180839.024474825, 195355.027554806, 213179.711736108, 234627.751980985, 259899.30178444, 289110.53399467, 322314.274331595, 359514.507333211, 860767.574416809,]
+kxy = [ 424916.756322156, 553193.12733327, 687168.6168166, 825821.555318317, 968280.211140864, 1113789.96941796, 1261690.85775216, 1411401.36210057, 2771413.59584677,]
+kyx = [ -424916.756322156, -553193.12733327, -687168.6168166, -825821.555318317, -968280.211140864, -1113789.96941796, -1261690.85775216, -1411401.36210057, -2771413.59584677,]
+cyy = [ 828.076214508057, 831.698341316398, 833.420964081016, 832.833200737184, 829.68538941482, 823.855212022527, 815.320735537458, 804.138365393787, 613.175254017714,]
+cxy = [ 56.639482846621, 52.6803994392273, 44.0249331997799, 31.6254311839271, 16.3284602522176, -1.11491725585648, -20.0424044945381, -39.8750850779251, -198.229669313471,]
+cyx = [ -56.639482846621, -52.6803994392273, -44.0249331997799, -31.6254311839271, -16.3284602522176, 1.11491725585648, 20.0424044945381, 39.8750850779251, 198.229669313471,]
+tag = "Seal 12"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 6"]
+n = 27
+kxx = [ 205852.667541406, 242366.978579705, 287218.2673746, 341497.431815182, 405944.815928242, 481042.985669013, 567080.222997083, 664196.067389568, 2018342.16604649,]
+cxx = [ 2178.21606571578, 2209.14806245493, 2238.23710142438, 2264.02667383226, 2285.44579131069, 2301.73368540227, 2312.38047214785, 2317.07943041658, 2101.22864360535,]
+kyy = [ 205852.667541406, 242366.978579705, 287218.2673746, 341497.431815182, 405944.815928242, 481042.985669013, 567080.222997083, 664196.067389568, 2018342.16604649,]
+kxy = [ 1147712.75186238, 1495785.8148233, 1859450.35261072, 2235861.74214649, 2622603.49661036, 3017591.3675152, 3419008.72231515, 3825260.09699669, 7510461.330822,]
+kyx = [ -1147712.75186238, -1495785.8148233, -1859450.35261072, -2235861.74214649, -2622603.49661036, -3017591.3675152, -3419008.72231515, -3825260.09699669, -7510461.330822,]
+cyy = [ 2178.21606571578, 2209.14806245493, 2238.23710142438, 2264.02667383226, 2285.44579131069, 2301.73368540227, 2312.38047214785, 2317.07943041658, 2101.22864360535,]
+cxy = [ 250.258153865912, 257.227741725991, 248.537158173789, 226.525141043403, 193.271057301904, 150.636859160072, 100.293246923114, 43.7381624842223, -567.222123721818,]
+cyx = [ -250.258153865912, -257.227741725991, -248.537158173789, -226.525141043403, -193.271057301904, -150.636859160072, -100.293246923114, -43.7381624842223, 567.222123721818,]
+tag = "Seal 6"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 11"]
+n = 28
+kxx = [ 162079.699898803, 175413.041171466, 191782.836082965, 211515.373531839, 234827.564468616, 261855.220747408, 292672.259417268, 327304.284853313, 800601.079718764,]
+cxx = [ 805.360714967088, 810.807324312486, 814.773343900831, 816.814170445135, 816.638103264431, 814.07641475685, 809.059159293008, 801.595062580611, 646.55136163657,]
+kyy = [ 162079.699898803, 175413.041171466, 191782.836082965, 211515.373531839, 234827.564468616, 261855.220747408, 292672.259417268, 327304.284853313, 800601.079718764,]
+kxy = [ 406978.422739746, 529155.447676398, 656706.644009378, 788702.816695279, 924345.338451978, 1062937.9131192, 1203867.36017507, 1346589.781951, 2646350.0643761,]
+kyx = [ -406978.422739746, -529155.447676398, -656706.644009378, -788702.816695279, -924345.338451978, -1062937.9131192, -1203867.36017507, -1346589.781951, -2646350.0643761,]
+cyy = [ 805.360714967088, 810.807324312486, 814.773343900831, 816.814170445135, 816.638103264431, 814.07641475685, 809.059159293008, 801.595062580611, 646.55136163657,]
+cxy = [ 63.6178915228003, 62.1369490163509, 55.9666789064099, 45.9704212310253, 32.9255972926375, 17.5307496744211, 0.409583747581219, -17.8859321380999, -175.328107698497,]
+cyx = [ -63.6178915228003, -62.1369490163509, -55.9666789064099, -45.9704212310253, -32.9255972926375, -17.5307496744211, -0.409583747581219, 17.8859321380999, 175.328107698497,]
+tag = "Seal 11"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 5"]
+n = 30
+kxx = [ 152572.564780079, 185205.802529499, 225423.727870828, 274388.567172405, 332925.027240472, 401604.961161511, 480807.601610557, 570761.855747787, 1858564.83662114,]
+cxx = [ 2114.3239242484, 2151.86018396449, 2189.00202211794, 2224.19825749469, 2256.25109134112, 2284.25181009551, 2307.52812156361, 2325.60282589679, 2236.14986468286,]
+kyy = [ 152572.564780079, 185205.802529499, 225423.727870828, 274388.567172405, 332925.027240472, 401604.961161511, 480807.601610557, 570761.855747787, 1858564.83662114,]
+kxy = [ 1098257.30952438, 1429977.12678861, 1776691.37706298, 2135830.7407142, 2505191.59642991, 2882850.96447124, 3267117.0862745, 3656488.87697799, 7208606.38767389,]
+kyx = [ -1098257.30952438, -1429977.12678861, -1776691.37706298, -2135830.7407142, -2505191.59642991, -2882850.96447124, -3267117.0862745, -3656488.87697799, -7208606.38767389,]
+cyy = [ 2114.3239242484, 2151.86018396449, 2189.00202211794, 2224.19825749469, 2256.25109134112, 2284.25181009551, 2307.52812156361, 2325.60282589679, 2236.14986468286,]
+cxy = [ 276.125157962378, 291.232201189786, 290.488133219166, 275.939934277962, 249.425082886449, 212.610147360682, 167.009160238909, 113.999361057078, -525.407830501088,]
+cyx = [ -276.125157962378, -291.232201189786, -290.488133219166, -275.939934277962, -249.425082886449, -212.610147360682, -167.009160238909, -113.999361057078, 525.407830501088,]
+tag = "Seal 5"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 10"]
+n = 31
+kxx = [ 140049.817601769, 152063.602437156, 166813.832185813, 184639.367211113, 205775.545611855, 230379.77415706, 258549.549695261, 290334.891898862, 732939.091902253,]
+cxx = [ 780.119253662987, 787.684355944009, 794.242332296682, 799.312347070576, 802.55627409239, 803.753118817436, 802.777721491268, 799.582973527294, 685.153719729093,]
+kyy = [ 140049.817601769, 152063.602437156, 166813.832185813, 184639.367211113, 205775.545611855, 230379.77415706, 258549.549695261, 290334.891898862, 732939.091902253,]
+kxy = [ 388401.623689309, 504334.860616662, 625326.20214955, 750542.069249618, 879260.768917699, 1010847.15033575, 1144738.0717901, 1280430.08808057, 2520968.98404806,]
+kyx = [ -388401.623689309, -504334.860616662, -625326.20214955, -750542.069249618, -879260.768917699, -1010847.15033575, -1144738.0717901, -1280430.08808057, -2520968.98404806,]
+cyy = [ 780.119253662987, 787.684355944009, 794.242332296682, 799.312347070576, 802.55627409239, 803.753118817436, 802.777721491268, 799.582973527294, 685.153719729093,]
+cxy = [ 71.9405192865185, 73.2172125105903, 69.7772091351367, 62.3870346967872, 51.7470502670171, 38.4965142422057, 23.2144639309886, 6.42115937619801, -153.589719559604,]
+cyx = [ -71.9405192865185, -73.2172125105903, -69.7772091351367, -62.3870346967872, -51.7470502670171, -38.4965142422057, -23.2144639309886, -6.42115937619801, 153.589719559604,]
+tag = "Seal 10"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 4"]
+n = 33
+kxx = [ 99565.3280288305, 128280.786974181, 163838.557867115, 207478.594722917, 260118.020975725, 322429.13160572, 394893.509217979, 477841.629547027, 1705205.47349929,]
+cxx = [ 2042.80354037266, 2087.34323361495, 2133.05245009602, 2178.28290613318, 2221.70220592325, 2262.23898170276, 2299.0394215401, 2331.43213723079, 2373.99452038876,]
+kyy = [ 99565.3280288305, 128280.786974181, 163838.557867115, 207478.594722917, 260118.020975725, 322429.13160572, 394893.509217979, 477841.629547027, 1705205.47349929,]
+kxy = [ 1045693.89578556, 1360157.4064092, 1689000.07378138, 2029942.27233339, 2381001.43932843, 2740426.4413257, 3106654.74733322, 3478282.16261192, 6889822.23965831,]
+kyx = [ -1045693.89578556, -1360157.4064092, -1689000.07378138, -2029942.27233339, -2381001.43932843, -2740426.4413257, -3106654.74733322, -3478282.16261192, -6889822.23965831,]
+cyy = [ 2042.80354037266, 2087.34323361495, 2133.05245009602, 2178.28290613318, 2221.70220592325, 2262.23898170276, 2299.0394215401, 2331.43213723079, 2373.99452038876,]
+cxy = [ 300.719623259512, 323.676427884606, 330.553298935302, 323.075231492631, 302.810062114474, 271.199333765612, 229.5757085895, 179.173983835812, -506.196065119599,]
+cyx = [ -300.719623259512, -323.676427884606, -330.553298935302, -323.075231492631, -302.810062114474, -271.199333765612, -229.5757085895, -179.173983835812, 506.196065119599,]
+tag = "Seal 4"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 9"]
+n = 34
+kxx = [ 117358.92657379, 128015.751147855, 141102.498057583, 156969.989754583, 175871.907235927, 197988.188305016, 223441.071331206, 252306.609321979, 663772.402239837,]
+cxx = [ 750.949959062333, 760.710326884617, 769.964578233571, 778.19629293504, 785.019902997508, 790.15932800096, 793.430153680943, 794.724300760962, 722.544808720561,]
+kyy = [ 117358.92657379, 128015.751147855, 141102.498057583, 156969.989754583, 175871.907235927, 197988.188305016, 223441.071331206, 252306.609321979, 663772.402239837,]
+kxy = [ 368248.874078639, 477487.487203766, 591452.926163509, 709411.473344204, 830721.103799336, 954812.05503821, 1081173.83156822, 1209345.94547456, 2386511.8788015,]
+kyx = [ -368248.874078639, -477487.487203766, -591452.926163509, -709411.473344204, -830721.103799336, -954812.05503821, -1081173.83156822, -1209345.94547456, -2386511.8788015,]
+cyy = [ 750.949959062333, 760.710326884617, 769.964578233571, 778.19629293504, 785.019902997508, 790.15932800096, 793.430153680943, 794.724300760962, 722.544808720561,]
+cxy = [ 79.8543326386884, 83.81589186923, 83.0331567785093, 78.1681935600569, 69.837391650402, 58.613348963646, 45.0245327033877, 29.554474250066, -136.376148153058,]
+cyx = [ -79.8543326386884, -83.81589186923, -83.0331567785093, -78.1681935600569, -69.837391650402, -58.613348963646, -45.0245327033877, -29.554474250066, 136.376148153058,]
+tag = "Seal 9"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["SealElement_Seal 3"]
+n = 36
+kxx = [ 42736.7276429811, 67214.3361587494, 97775.6346026271, 135757.803441503, 182192.939775206, 237877.364149987, 303419.845206835, 379277.183402673, 1553300.56707975,]
+cxx = [ 1963.22827166158, 2015.78518072991, 2071.30777883873, 2128.0501207825, 2184.53471897006, 2239.50807488773, 2291.90587538764, 2340.82530827392, 2532.59539821632,]
+kyy = [ 42736.7276429811, 67214.3361587494, 97775.6346026271, 135757.803441503, 182192.939775206, 237877.364149987, 303419.845206835, 379277.183402673, 1553300.56707975,]
+kxy = [ 990798.147638428, 1287520.08475897, 1598073.52054941, 1920481.53213523, 2252993.8192709, 2594035.77027586, 2942176.31364923, 3296105.80753795, 6569742.52112397,]
+kyx = [ -990798.147638428, -1287520.08475897, -1598073.52054941, -1920481.53213523, -2252993.8192709, -2594035.77027586, -2942176.31364923, -3296105.80753795, -6569742.52112397,]
+cyy = [ 1963.22827166158, 2015.78518072991, 2071.30777883873, 2128.0501207825, 2184.53471897006, 2239.50807488773, 2291.90587538764, 2340.82530827392, 2532.59539821632,]
+cxy = [ 327.498095371777, 358.733673950888, 373.552265248427, 373.313275236128, 359.267683770068, 332.586462550931, 294.376327892065, 245.689271656646, -511.811286666433,]
+cyx = [ -327.498095371777, -358.733673950888, -373.552265248427, -373.313275236128, -359.267683770068, -332.586462550931, -294.376327892065, -245.689271656646, 511.811286666433,]
+tag = "Seal 3"
+scale_factor = 0.3
+frequency = [ 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167, 2094.395102394,]
+
+["BearingElement_Bearing 1"]
+n = 48
+kxx = [ 13798100.0, 29951900.0, 53565699.99999999, 85144200.0, 120733000.0, 159519000.0, 197885000.0, 235239999.99999997, 271250000.0,]
+cxx = [ 102506.0, 127450.0, 144989.0, 153563.0, 155122.0, 150835.0, 145086.0, 141871.0, 140702.0,]
+kyy = [ 13798100.0, 29951900.0, 53565699.99999999, 85144200.0, 120733000.0, 159519000.0, 197885000.0, 235239999.99999997, 271250000.0,]
+kxy = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+kyx = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+cyy = [ 102506.0, 127450.0, 144989.0, 153563.0, 155122.0, 150835.0, 145086.0, 141871.0, 140702.0,]
+cxy = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+cyx = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,]
+tag = "Bearing 1"
+scale_factor = 0.5
+frequency = [ 314.1592653591, 418.8790204788, 523.5987755985, 628.3185307182, 733.0382858378999, 837.7580409576, 942.4777960773, 1047.197551197, 1151.9173063167,]
+
+["ShaftElement_ShaftElement 0".material]
+name = "shaft_mat_3"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 1".material]
+name = "shaft_mat_3"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 2".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 3".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 4".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 5".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 6".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 7".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 8".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 9".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 10".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 11".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 12".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 13".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 14".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 15".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 16".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 17".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 18".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 19".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 20".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 21".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 22".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 23".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 24".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 25".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 26".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 27".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 28".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 29".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 30".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 31".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 32".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 33".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 34".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 35".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 36".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 37".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 38".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 39".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 40".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 41".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 42".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 43".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 44".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 45".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 46".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 47".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 48".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 49".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 50".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 51".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 52".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 53".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 54".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 55".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 56".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 57".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 58".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 59".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 60".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 61".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 62".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 63".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 64".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 65".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 66".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 67".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 68".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 69".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 70".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 71".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 72".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 73".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 74".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 75".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 76".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 77".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 78".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 79".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 80".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 81".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 82".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 83".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 84".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 85".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 86".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 87".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 88".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"
+
+["ShaftElement_ShaftElement 89".material]
+name = "shaft_mat_1"
+rho = 7833.412
+E = 206842300000.0
+G_s = 82736940000.0
+color = "#525252"
+
+["ShaftElement_ShaftElement 90".material]
+name = "shaft_mat_2"
+rho = 7833.412
+E = 6894.75
+G_s = 6894.75
+color = "#525252"

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -831,6 +831,13 @@ def rotor6():
     return Rotor(shaft_elem, [disk0, disk1], [bearing0, bearing1])
 
 
+@pytest.fixture
+def rotor9():
+    # More complex rotor based on a centrifugal compressor
+    rotor9 = Rotor.load(Path(__file__).parent / "data/rotor.toml")
+    return rotor9
+
+
 def test_static_analysis_rotor6(rotor6):
     static = rotor6.run_static()
 
@@ -909,6 +916,11 @@ def test_static_analysis_rotor6(rotor6):
         ),
         decimal=3,
     )
+
+
+def test_static_analysis_rotor9(rotor9):
+    static = rotor9.run_static()
+    assert_almost_equal(static.bearing_forces["node_7"], 1216.3)
 
 
 def test_run_critical_speed(rotor5, rotor6):


### PR DESCRIPTION
This PR fixes the `run_static` method for rotors with seals.
I have changed the code to make sure that seals are not added to the aux_brg list used in
the static analysis.

Closes #830.