### PR TITLE
WIP - Nomeclature standarization for cylindrical bearing

### DIFF
--- a/ross/fluid_flow/cylindrical.py
+++ b/ross/fluid_flow/cylindrical.py
@@ -73,7 +73,6 @@ class THDCylindrical:
     n_gap : int
         Number of volumes in recess zone.
 
-
     Returns
     -------
     A THDCylindrical object.


### PR DESCRIPTION
Standardizing the nomenclature for the cylindrical bearing model. Additional PRs will be made for the radial and thrust THD tilting pad models.