### PR TITLE
Add .get_application_registry to pint import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,13 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 20.8b1
+  - repo: https://github.com/psf/black
+    rev: 21.9b0
     hooks:
-    - id: black
-      language_version: python3
+      - id: black
+        language_version: python3
 
--   repo: https://github.com/timothycrosley/isort
-    rev: ''
+  - repo: https://github.com/pycqa/isort
+    rev: 5.6.4
     hooks:
       - id: isort
-      
+        args: ["--profile", "black", "--filter-files"]
+

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -7,10 +7,14 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from ross.bearing_seal_element import (BallBearingElement, BearingElement,
-                                       BearingElement6DoF, BearingFluidFlow,
-                                       MagneticBearingElement,
-                                       RollerBearingElement)
+from ross.bearing_seal_element import (
+    BallBearingElement,
+    BearingElement,
+    BearingElement6DoF,
+    BearingFluidFlow,
+    MagneticBearingElement,
+    RollerBearingElement,
+)
 
 # fmt: on
 

--- a/ross/tests/test_units.py
+++ b/ross/tests/test_units.py
@@ -10,8 +10,8 @@ def test_new_units_loaded():
     speed = Q_(1, "RPM")
     assert speed.m == 1
     # check if h is hour instead of planck constant
-    v = Q_(3600, 'm/h')
-    assert v.to('m/s').m == 1
+    v = Q_(3600, "m/h")
+    assert v.to("m/s").m == 1
 
 
 # each possible argument

--- a/ross/tests/test_units.py
+++ b/ross/tests/test_units.py
@@ -8,7 +8,10 @@ from ross.units import Q_, check_units
 
 def test_new_units_loaded():
     speed = Q_(1, "RPM")
-    assert speed.magnitude == 1
+    assert speed.m == 1
+    # check if h is hour instead of planck constant
+    v = Q_(3600, 'm/h')
+    assert v.to('m/s').m == 1
 
 
 # each possible argument

--- a/ross/units.py
+++ b/ross/units.py
@@ -4,16 +4,22 @@ import warnings
 from functools import wraps
 from pathlib import Path
 
-from pint import Quantity, UnitRegistry
+import pint
+
+
+new_units_path = Path(__file__).parent / "new_units.txt"
+ureg = pint.get_application_registry()
+if isinstance(ureg, pint.registry.LazyRegistry):
+    ureg = pint.UnitRegistry()
+    ureg.load_definitions(str(new_units_path))
+    # set ureg to make pickle possible
+    pint.set_application_registry(ureg)
+
+Q_ = ureg.Quantity
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    Quantity([])
-
-new_units_path = Path(__file__).parent / "new_units.txt"
-ureg = UnitRegistry()
-ureg.load_definitions(str(new_units_path))
-Q_ = ureg.Quantity
+    pint.Quantity([])
 
 __all__ = ["Q_", "check_units"]
 


### PR DESCRIPTION
With pint we cannot have two quantities from different registries
interacting. This can lead to problems when we have an application that
uses pint calling a package that also imports pint, since the
application registry will be different from the package registry.

To solve this problem we need to use pint.get_application_registry
within our package, so that the package (ross in this case) can use the
same registry as the application.

One problem that occured after using .get_application_registry is that
it was not possible to use the .load_definitions method, since this
would cause a unit 'redefinition' which is not allowed by pint.

To solve this, after calling .get_application_registry, we check if the
object is an instance of LazyRegistry. Basically, what this means is
that .set_application_registry has not been called by an application, so
we can create a new registry with .UnitRegistry and .load_definitions.
For this to work, we also had to move the call to pint.Quantity([]). Now
it comes after setting the registry, since calling it before would cause
the default registry to be of the UnitRegistry type instead of
LazyRegistry.

After that we use the .set_application_registry method to make the
quantities pickable, which is required by the multiprocessing module.
The check for ureg instance can change in the future, since the code now
in the pint master branch has merged the ApplicationRegistry wrapper.
In this case we can get the instance of the registry by using:

isinstance(ureg.get(), pint.registry.LazyRegistry)