### PR TITLE
Remove isort

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Code Lint 
         run: |
           black --check ross
-          isort ross --check-only
         if: success()
       - name: Coverage and Deployment
         run: codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,6 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 20.8b1
+  - repo: https://github.com/psf/black
+    rev: 21.9b0
     hooks:
-    - id: black
-      language_version: python3
-
--   repo: https://github.com/timothycrosley/isort
-    rev: ''
-    hooks:
-      - id: isort
-      
+      - id: black
+        language_version: python3 

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -4,7 +4,6 @@ This module defines the BearingElement classes which will be used to represent t
 bearings and seals. There are 7 different classes to represent bearings options,
 and 2 element options with 8 or 12 degrees of freedom.
 """
-# fmt: off
 import os
 import warnings
 from inspect import signature
@@ -16,12 +15,11 @@ from scipy import interpolate as interpolate
 
 from ross.element import Element
 from ross.fluid_flow import fluid_flow as flow
-from ross.fluid_flow.fluid_flow_coefficients import \
-    calculate_stiffness_and_damping_coefficients
+from ross.fluid_flow.fluid_flow_coefficients import (
+    calculate_stiffness_and_damping_coefficients,
+)
 from ross.units import Q_, check_units
 from ross.utils import read_table_file
-
-# fmt: on
 
 __all__ = [
     "BearingElement",

--- a/ross/fluid_flow/fluid_flow.py
+++ b/ross/fluid_flow/fluid_flow.py
@@ -1,18 +1,17 @@
-# fmt: off
 import sys
 
 import numpy as np
 import scipy as sp
 
 from ross.fluid_flow.fluid_flow_coefficients import find_equilibrium_position
-from ross.fluid_flow.fluid_flow_geometry import (calculate_attitude_angle,
-                                                 calculate_eccentricity_ratio,
-                                                 calculate_rotor_load,
-                                                 external_radius_function,
-                                                 internal_radius_function,
-                                                 modified_sommerfeld_number)
-
-# fmt: on
+from ross.fluid_flow.fluid_flow_geometry import (
+    calculate_attitude_angle,
+    calculate_eccentricity_ratio,
+    calculate_rotor_load,
+    external_radius_function,
+    internal_radius_function,
+    modified_sommerfeld_number,
+)
 
 
 class FluidFlow:

--- a/ross/fluid_flow/fluid_flow_coefficients.py
+++ b/ross/fluid_flow/fluid_flow_coefficients.py
@@ -5,11 +5,7 @@ import numpy as np
 from scipy import integrate
 from scipy.optimize import least_squares
 
-# fmt: off
-from ross.fluid_flow.fluid_flow_geometry import (move_rotor_center,
-                                                 move_rotor_center_abs)
-
-# fmt: on
+from ross.fluid_flow.fluid_flow_geometry import move_rotor_center, move_rotor_center_abs
 
 
 def calculate_oil_film_force(fluid_flow_object, force_type=None):

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1,4 +1,3 @@
-# fmt: off
 import inspect
 import sys
 import warnings
@@ -20,24 +19,35 @@ from scipy.interpolate import UnivariateSpline
 from scipy.optimize import newton
 from scipy.sparse import linalg as las
 
-from ross.bearing_seal_element import (BallBearingElement, BearingElement,
-                                       BearingElement6DoF, BearingFluidFlow,
-                                       MagneticBearingElement,
-                                       RollerBearingElement, SealElement)
+from ross.bearing_seal_element import (
+    BallBearingElement,
+    BearingElement,
+    BearingElement6DoF,
+    BearingFluidFlow,
+    MagneticBearingElement,
+    RollerBearingElement,
+    SealElement,
+)
 from ross.defects import Crack, MisalignmentFlex, MisalignmentRigid, Rubbing
 from ross.disk_element import DiskElement, DiskElement6DoF
 from ross.materials import steel
 from ross.point_mass import PointMass
-from ross.results import (CampbellResults, ConvergenceResults,
-                          CriticalSpeedResults, ForcedResponseResults,
-                          FrequencyResponseResults, Level1Results,
-                          ModalResults, StaticResults, SummaryResults,
-                          TimeResponseResults, UCSResults)
+from ross.results import (
+    CampbellResults,
+    ConvergenceResults,
+    CriticalSpeedResults,
+    ForcedResponseResults,
+    FrequencyResponseResults,
+    Level1Results,
+    ModalResults,
+    StaticResults,
+    SummaryResults,
+    TimeResponseResults,
+    UCSResults,
+)
 from ross.shaft_element import ShaftElement, ShaftElement6DoF
 from ross.units import Q_, check_units
 from ross.utils import intersection
-
-# fmt: on
 
 __all__ = ["Rotor", "CoAxialRotor", "rotor_example", "coaxrotor_example"]
 

--- a/ross/stochastic/st_bearing_seal_element.py
+++ b/ross/stochastic/st_bearing_seal_element.py
@@ -2,17 +2,15 @@
 
 This module creates an instance of random bearing for stochastic analysis.
 """
-# fmt: off
 import numpy as np
 
 from ross.bearing_seal_element import BearingElement
 from ross.fluid_flow import fluid_flow as flow
-from ross.fluid_flow.fluid_flow_coefficients import \
-    calculate_stiffness_and_damping_coefficients
+from ross.fluid_flow.fluid_flow_coefficients import (
+    calculate_stiffness_and_damping_coefficients,
+)
 from ross.stochastic.st_results_elements import plot_histogram
 from ross.units import check_units
-
-# fmt: on
 
 __all__ = ["ST_BearingElement", "st_bearing_example"]
 

--- a/ross/stochastic/st_rotor_assembly.py
+++ b/ross/stochastic/st_rotor_assembly.py
@@ -2,7 +2,6 @@
 
 This module creates random rotor instances and run stochastic analysis.
 """
-# fmt: off
 from collections.abc import Iterable
 
 import numpy as np
@@ -11,14 +10,14 @@ from ross.rotor_assembly import Rotor
 from ross.stochastic.st_bearing_seal_element import ST_BearingElement
 from ross.stochastic.st_disk_element import ST_DiskElement
 from ross.stochastic.st_point_mass import ST_PointMass
-from ross.stochastic.st_results import (ST_CampbellResults,
-                                        ST_ForcedResponseResults,
-                                        ST_FrequencyResponseResults,
-                                        ST_TimeResponseResults)
+from ross.stochastic.st_results import (
+    ST_CampbellResults,
+    ST_ForcedResponseResults,
+    ST_FrequencyResponseResults,
+    ST_TimeResponseResults,
+)
 from ross.stochastic.st_shaft_element import ST_ShaftElement
 from ross.units import check_units
-
-# fmt: on
 
 __all__ = ["ST_Rotor", "st_rotor_example"]
 

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -1,4 +1,3 @@
-# fmt: off
 import os
 from pathlib import Path
 from tempfile import tempdir
@@ -7,12 +6,14 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from ross.bearing_seal_element import (BallBearingElement, BearingElement,
-                                       BearingElement6DoF, BearingFluidFlow,
-                                       MagneticBearingElement,
-                                       RollerBearingElement)
-
-# fmt: on
+from ross.bearing_seal_element import (
+    BallBearingElement,
+    BearingElement,
+    BearingElement6DoF,
+    BearingFluidFlow,
+    MagneticBearingElement,
+    RollerBearingElement,
+)
 
 
 @pytest.fixture

--- a/ross/tests/test_fluid_flow.py
+++ b/ross/tests/test_fluid_flow.py
@@ -1,4 +1,3 @@
-# fmt: off
 import math
 
 import numpy as np
@@ -9,15 +8,21 @@ from plotly import graph_objects as go
 from ross.fluid_flow import fluid_flow as flow
 from ross.fluid_flow.fluid_flow import fluid_flow_example2
 from ross.fluid_flow.fluid_flow_coefficients import (
-    calculate_oil_film_force, calculate_short_damping_matrix,
+    calculate_oil_film_force,
+    calculate_short_damping_matrix,
     calculate_short_stiffness_matrix,
-    calculate_stiffness_and_damping_coefficients, find_equilibrium_position)
+    calculate_stiffness_and_damping_coefficients,
+    find_equilibrium_position,
+)
 from ross.fluid_flow.fluid_flow_geometry import move_rotor_center
 from ross.fluid_flow.fluid_flow_graphics import (
-    plot_eccentricity, plot_pressure_surface, plot_pressure_theta,
-    plot_pressure_theta_cylindrical, plot_pressure_z, plot_shape)
-
-# fmt: on
+    plot_eccentricity,
+    plot_pressure_surface,
+    plot_pressure_theta,
+    plot_pressure_theta_cylindrical,
+    plot_pressure_z,
+    plot_shape,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
Black and isort do not agree on how to sort imports, this will cause
conflicting changes between these tools. With isort 5 it is possible to
have some configuration so that we can use both, but I believe just
using black is a more simple and easy approach.
