### PR TITLE
Remove python 3.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -5,11 +5,11 @@
 ## Install Python
 
 The first step is to install Python. Since ROSS requires several packages to be installed besides Python, such as
-numpy and scipy, we recommend installing [Anaconda](https://www.anaconda.com/distribution/) (version 3.6 or higher) which is a
+numpy and scipy, we recommend installing [Anaconda](https://www.anaconda.com/distribution/) (version 3.7 or higher) which is a
 scientific Python distribution that aims to simplify package management and deployment. It contains Python and a large
 number of packages that are commonly used.
 Alternatively, you may refer to the [Python website](http://www.python.org/).
-ROSS code is tested in Python 3.6 and higher.
+ROSS code is tested in Python 3.7 and higher.
 
 ## Install ROSS
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ toml>=0.10.1
 pandas>=0.23
 plotly>=4.7.0
 xlrd
-pint
+pint>=0.18

--- a/ross/units.py
+++ b/ross/units.py
@@ -9,7 +9,7 @@ import pint
 
 new_units_path = Path(__file__).parent / "new_units.txt"
 ureg = pint.get_application_registry()
-if isinstance(ureg, pint.registry.LazyRegistry):
+if isinstance(ureg.get(), pint.registry.LazyRegistry):
     ureg = pint.UnitRegistry()
     ureg.load_definitions(str(new_units_path))
     # set ureg to make pickle possible

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ DESCRIPTION = "ROSS: Rotordynamic Open Source Software"
 URL = "https://github.com/ross-rotordynamics/ross"
 EMAIL = "raphaelts@gmail.com"
 AUTHOR = "ROSS developers"
-REQUIRES_PYTHON = ">=3.6.0"
+REQUIRES_PYTHON = ">=3.7.0"
 VERSION = version("ross/__init__.py")
 
 # What packages are required for this module to be executed?

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ DESCRIPTION = "ROSS: Rotordynamic Open Source Software"
 URL = "https://github.com/ross-rotordynamics/ross"
 EMAIL = "raphaelts@gmail.com"
 AUTHOR = "ROSS developers"
-REQUIRES_PYTHON = ">=3.7.0"
+REQUIRES_PYTHON = ">=3.7.0, <3.10"
 VERSION = version("ross/__init__.py")
 
 # What packages are required for this module to be executed?


### PR DESCRIPTION
Since we are now using pint 0.18 which requires python 3.7+, we can no
longer support python 3.6.