### PR TITLE
fix static stiff

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2749,13 +2749,6 @@ class Rotor(object):
             aux_rotor = Rotor(self.shaft_elements, self.disk_elements, aux_brg)
 
         aux_K = aux_rotor.K(0)
-        for elm in aux_rotor.bearing_elements:
-            if isinstance(elm, SealElement):
-                dofs = list(elm.dof_global_index.values())
-                try:
-                    aux_K[np.ix_(dofs, dofs)] -= elm.K(0)
-                except TypeError:
-                    aux_K[np.ix_(dofs, dofs)] -= elm.K()
 
         df_num = aux_rotor.df["shaft_number"].values
         sh_num = [int(item) for item, count in Counter(df_num).items() if count > 1]

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2732,21 +2732,27 @@ class Rotor(object):
             raise ValueError("Rotor has no bearings")
 
         aux_brg = []
+        aux_brg_1 = []
         for elm in self.bearing_elements:
             if not isinstance(elm, SealElement):
                 if elm.n not in self.nodes:
                     pass
                 elif elm.n_link in self.nodes:
                     aux_brg.append(
-                        BearingElement(n=elm.n, n_link=elm.n_link, kxx=1e14, cxx=0)
+                        BearingElement(n=elm.n, n_link=elm.n_link, kxx=1e20, cxx=0)
+                    )
+                    aux_brg_1.append(
+                        BearingElement(n=elm.n, n_link=elm.n_link, kxx=0, cxx=0)
                     )
                 else:
-                    aux_brg.append(BearingElement(n=elm.n, kxx=1e14, cxx=0))
+                    aux_brg.append(BearingElement(n=elm.n, kxx=1e20, cxx=0))
+                    aux_brg_1.append(BearingElement(n=elm.n, kxx=0, cxx=0))
 
         if isinstance(self, CoAxialRotor):
             aux_rotor = CoAxialRotor(self.shafts, self.disk_elements, aux_brg)
         else:
             aux_rotor = Rotor(self.shaft_elements, self.disk_elements, aux_brg)
+            aux_rotor_1 = Rotor(self.shaft_elements, self.disk_elements, aux_brg_1)
 
         aux_K = aux_rotor.K(0)
 
@@ -2767,7 +2773,7 @@ class Rotor(object):
         disp_y = []
 
         # calculate forces
-        nodal_forces = self.K(0) @ disp
+        nodal_forces = aux_rotor_1.K(0) @ disp
 
         Vx_axis, Vx, Mx = [], [], []
         nodes, nodes_pos = [], []

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -924,6 +924,21 @@ def test_static_analysis_rotor9(rotor9):
     assert_almost_equal(static.bearing_forces["node_7"], 1216.3)
 
 
+def test_static_analysis_high_stiffness(rotor2):
+    static = rotor2.run_static()
+    assert_almost_equal(static.bearing_forces["node_0"], 197.4)
+    stf = 1e14
+    bearing0 = BearingElement(0, kxx=stf, cxx=0)
+    bearing1 = BearingElement(2, kxx=stf, cxx=0)
+    rotor2 = Rotor(
+        shaft_elements=rotor2.shaft_elements,
+        disk_elements=rotor2.disk_elements,
+        bearing_elements=[bearing0, bearing1],
+    )
+    static = rotor2.run_static()
+    assert_almost_equal(static.bearing_forces["node_0"], 197.4)
+
+
 def test_run_critical_speed(rotor5, rotor6):
     results5 = rotor5.run_critical_speed(num_modes=12, rtol=0.005)
     results6 = rotor6.run_critical_speed(num_modes=12, rtol=0.005)


### PR DESCRIPTION
This adds an auxiliary rotor with 0 stiffness in the bearing location
to fix calculations, otherwise, a bearing a rotor with a bearing with
high stiffness would have 0 reaction force at the bearing location.