### PR TITLE
Fix bug in static analysis with bearing and disk in the same node

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -3139,7 +3139,7 @@ class StaticResults(Results):
         if fig is None:
             fig = go.Figure()
 
-        shaft_end = max([sublist[-1] for sublist in self.nodes_pos])
+        shaft_end = self.nodes_pos[-1]
         shaft_end = Q_(shaft_end, "m").to(rotor_length_units).m
 
         # fig - plot centerline
@@ -3154,26 +3154,20 @@ class StaticResults(Results):
             )
         )
 
-        count = 0
-        for deformation, Vx, Bm, nodes, nodes_pos, Vx_axis in zip(
-            self.deformation, self.Vx, self.Bm, self.nodes, self.nodes_pos, self.Vx_axis
-        ):
-
-            fig.add_trace(
-                go.Scatter(
-                    x=Q_(nodes_pos, "m").to(rotor_length_units).m,
-                    y=Q_(deformation, "m").to(deformation_units).m,
-                    mode="lines",
-                    line_shape="spline",
-                    line_smoothing=1.0,
-                    name=f"Shaft {count}",
-                    showlegend=True,
-                    hovertemplate=(
-                        f"Rotor Length ({rotor_length_units}): %{{x:.2f}}<br>Displacement ({deformation_units}): %{{y:.2e}}"
-                    ),
-                )
+        fig.add_trace(
+            go.Scatter(
+                x=Q_(self.nodes_pos, "m").to(rotor_length_units).m,
+                y=Q_(self.deformation, "m").to(deformation_units).m,
+                mode="lines",
+                line_shape="spline",
+                line_smoothing=1.0,
+                name=f"Shaft",
+                showlegend=True,
+                hovertemplate=(
+                    f"Rotor Length ({rotor_length_units}): %{{x:.2f}}<br>Displacement ({deformation_units}): %{{y:.2e}}"
+                ),
             )
-            count += 1
+        )
 
         fig.update_xaxes(title_text=f"Rotor Length ({rotor_length_units})")
         fig.update_yaxes(title_text=f"Deformation ({deformation_units})")

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2844,7 +2844,7 @@ class Rotor(object):
         self.bearing_forces_tag = bearing_force_tag
         self.disk_forces_tag = disk_force_tag
 
-        self.w_shaft = [sum(self.df_shaft["m"]) * (-g)]
+        self.w_shaft = sum(self.df_shaft["m"]) * (-g)
 
         results = StaticResults(
             displacement_y,

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2714,9 +2714,9 @@ class Rotor(object):
         >>> rotor = rs.rotor_example()
         >>> static = rotor.run_static()
         >>> rotor.bearing_forces_nodal
-        {'node_0': 432.4, 'node_6': 432.4}
-        >>> rotor.bearing_forces_tag
-        {'Bearing 0': 432.4, 'Bearing 1': 432.4}
+        {'node_0': 432...
+        >>> rotor.bearing_forces_tag # doctest: +ELLIPSIS
+        {'Bearing 0': 432...
 
         Plotting static deformation
         >>> fig = static.plot_deformation()
@@ -2799,9 +2799,11 @@ class Rotor(object):
 
         for bearing in aux_rotor.bearing_elements:
             bearing_force_nodal[f"node_{bearing.n:d}"] = reaction_forces[bearing.n]
+            bearing_force_tag[f"{bearing.tag}"] = reaction_forces[bearing.n]
 
         for disk in aux_rotor.disk_elements:
             disk_force_nodal[f"node_{disk.n:d}"] = -disk.m * g
+            disk_force_tag[f"{disk.tag}"] = -disk.m * g
 
         nodal_forces_y = aux_nodal_forces[1 :: self.number_dof] - nodal_shaft_weight
         elm_forces_y = np.zeros_like(elm_weight)

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -565,6 +565,7 @@ class Rotor(object):
         else:
             return False
 
+    @check_units
     def run_modal(self, speed, num_modes=12, sparse=True):
         """Run modal analysis.
 
@@ -1205,6 +1206,7 @@ class Rotor(object):
 
         return idx
 
+    @check_units
     def _eigen(
         self, speed, num_modes=12, frequency=None, sorted_=True, A=None, sparse=True
     ):
@@ -1217,10 +1219,10 @@ class Rotor(object):
 
         Parameters
         ----------
-        speed : float
-            Rotor speed.
-        frequency: float
-            Excitation frequency.
+        speed : float, pint.Quantity
+            Rotor speed. Default unit is rad/s.
+        frequency: float, pint.Quantity
+            Excitation frequency. Default units is rad/s.
         sorted_ : bool, optional
             Sort considering the imaginary part (wd)
             Default is True

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -12,6 +12,7 @@ from ross.materials import steel
 from ross.point_mass import *
 from ross.rotor_assembly import *
 from ross.shaft_element import *
+from ross.units import Q_
 
 
 @pytest.fixture
@@ -286,6 +287,10 @@ def test_evals_sorted_rotor2(rotor2):
     modal2_10000 = rotor2.run_modal(speed=10000)
     assert_allclose(modal2_10000.evalues, evals_sorted_w_10000, rtol=1e-1)
 
+    # test run_modal with Q_
+    modal2_10000 = rotor2.run_modal(speed=Q_(95492.96585513721, "RPM"))
+    assert_allclose(modal2_10000.evalues, evals_sorted_w_10000, rtol=1e-1)
+
 
 @pytest.fixture
 def rotor3():
@@ -543,7 +548,6 @@ def test_freq_response(rotor4):
 
 
 def test_freq_response_w_force(rotor4):
-    # modal4 = rotor4.run_modal(0)
     F0 = np.array(
         [
             [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -635,7 +635,7 @@ def test_static_analysis_rotor3(rotor3):
     static = rotor3.run_static()
 
     assert_almost_equal(
-        static.deformation[0],
+        static.deformation,
         np.array(
             [
                 -4.94274533e-12,
@@ -650,7 +650,7 @@ def test_static_analysis_rotor3(rotor3):
         decimal=6,
     )
     assert_almost_equal(
-        static.Vx[0],
+        static.Vx,
         np.array(
             [
                 -494.2745,
@@ -670,7 +670,7 @@ def test_static_analysis_rotor3(rotor3):
         decimal=3,
     )
     assert_almost_equal(
-        static.Bm[0],
+        static.Bm,
         np.array(
             [
                 0.0,
@@ -727,7 +727,7 @@ def test_static_analysis_rotor5(rotor5):
     static = rotor5.run_static()
 
     assert_almost_equal(
-        static.deformation[0],
+        static.deformation,
         np.array(
             [
                 8.12651626e-04,
@@ -746,7 +746,7 @@ def test_static_analysis_rotor5(rotor5):
         decimal=6,
     )
     assert_almost_equal(
-        static.Vx[0],
+        static.Vx,
         np.array(
             [
                 0.0,
@@ -774,7 +774,7 @@ def test_static_analysis_rotor5(rotor5):
         decimal=3,
     )
     assert_almost_equal(
-        static.Bm[0],
+        static.Bm,
         np.array(
             [
                 0.0,
@@ -847,7 +847,7 @@ def test_static_analysis_rotor6(rotor6):
     static = rotor6.run_static()
 
     assert_almost_equal(
-        static.deformation[0],
+        static.deformation,
         np.array(
             [
                 -1.03951876e-04,
@@ -866,7 +866,7 @@ def test_static_analysis_rotor6(rotor6):
         decimal=6,
     )
     assert_almost_equal(
-        static.Vx[0],
+        static.Vx,
         np.array(
             [
                 -0.0,
@@ -894,7 +894,7 @@ def test_static_analysis_rotor6(rotor6):
         decimal=3,
     )
     assert_almost_equal(
-        static.Bm[0],
+        static.Bm,
         np.array(
             [
                 0.0,
@@ -957,8 +957,27 @@ def test_static_bearing_with_disks(rotor3):
     )
 
     static = rotor.run_static()
+
     assert_allclose(sum(static.bearing_forces.values()), rotor.m * 9.8065)
     assert_almost_equal(static.bearing_forces["node_0"], 504.08103349786404)
+    expected_deformation = np.array(
+        [
+            -5.04081033e-18,
+            -4.51249080e-04,
+            -7.88420862e-04,
+            -9.18114186e-04,
+            -8.08560214e-04,
+            -4.68788883e-04,
+            -5.56171636e-18,
+        ]
+    )
+
+    assert_allclose(static.deformation, expected_deformation)
+
+    # test plot
+    fig = static.plot_deformation()
+
+    assert_allclose(fig.data[1]["y"], expected_deformation)
 
 
 def test_run_critical_speed(rotor5, rotor6):

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -925,12 +925,14 @@ def test_static_analysis_rotor6(rotor6):
 
 def test_static_analysis_rotor9(rotor9):
     static = rotor9.run_static()
-    assert_almost_equal(static.bearing_forces["node_7"], 1216.3)
+    assert_allclose(sum(static.bearing_forces.values()), rotor9.m * 9.8065)
+    assert_almost_equal(static.bearing_forces["node_7"], 1216.2827567768297)
 
 
 def test_static_analysis_high_stiffness(rotor2):
     static = rotor2.run_static()
-    assert_almost_equal(static.bearing_forces["node_0"], 197.4)
+    assert_allclose(sum(static.bearing_forces.values()), rotor2.m * 9.8065)
+    assert_almost_equal(static.bearing_forces["node_0"], 197.39100421969422)
     stf = 1e14
     bearing0 = BearingElement(0, kxx=stf, cxx=0)
     bearing1 = BearingElement(2, kxx=stf, cxx=0)
@@ -940,7 +942,8 @@ def test_static_analysis_high_stiffness(rotor2):
         bearing_elements=[bearing0, bearing1],
     )
     static = rotor2.run_static()
-    assert_almost_equal(static.bearing_forces["node_0"], 197.4)
+    assert_allclose(sum(static.bearing_forces.values()), rotor2.m * 9.8065)
+    assert_almost_equal(static.bearing_forces["node_0"], 197.39100421969422)
 
 
 def test_static_bearing_with_disks(rotor3):
@@ -954,7 +957,8 @@ def test_static_bearing_with_disks(rotor3):
     )
 
     static = rotor.run_static()
-    assert static.bearing_forces["node_0"] != 494.3
+    assert_allclose(sum(static.bearing_forces.values()), rotor.m * 9.8065)
+    assert_almost_equal(static.bearing_forces["node_0"], 504.08103349786404)
 
 
 def test_run_critical_speed(rotor5, rotor6):

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -943,6 +943,20 @@ def test_static_analysis_high_stiffness(rotor2):
     assert_almost_equal(static.bearing_forces["node_0"], 197.4)
 
 
+def test_static_bearing_with_disks(rotor3):
+    # this test is related to #845, where a bearing is added at the same node as a disk
+    disk0 = DiskElement(n=0, m=1, Id=0, Ip=0)
+    disks = rotor3.disk_elements + [disk0]
+    rotor = Rotor(
+        shaft_elements=rotor3.shaft_elements,
+        bearing_elements=rotor3.bearing_elements,
+        disk_elements=disks,
+    )
+
+    static = rotor.run_static()
+    assert static.bearing_forces["node_0"] != 494.3
+
+
 def test_run_critical_speed(rotor5, rotor6):
     results5 = rotor5.run_critical_speed(num_modes=12, rtol=0.005)
     results6 = rotor6.run_critical_speed(num_modes=12, rtol=0.005)

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -634,61 +634,67 @@ def test_mesh_convergence(rotor3):
 def test_static_analysis_rotor3(rotor3):
     static = rotor3.run_static()
 
-    assert_almost_equal(
+    fig = static.plot_free_body_diagram()
+    assert list(fig.select_annotations())[7]["text"] == "Shaft weight = 225.6N"
+
+    expected_deformation = np.array(
+        [
+            -4.942745e-18,
+            -4.512491e-04,
+            -7.884209e-04,
+            -9.181142e-04,
+            -8.085602e-04,
+            -4.687889e-04,
+            -5.561716e-18,
+        ]
+    )
+
+    assert_allclose(
         static.deformation,
-        np.array(
-            [
-                -4.94274533e-12,
-                -4.51249085e-04,
-                -7.88420867e-04,
-                -9.18114192e-04,
-                -8.08560219e-04,
-                -4.68788888e-04,
-                -5.56171636e-12,
-            ]
-        ),
-        decimal=6,
+        expected_deformation,
     )
-    assert_almost_equal(
-        static.Vx,
-        np.array(
-            [
-                -494.2745,
-                -456.6791,
-                -456.6791,
-                -419.0837,
-                -99.4925,
-                -61.8971,
-                -61.8971,
-                -24.3017,
-                480.9808,
-                518.5762,
-                518.5762,
-                556.1716,
-            ]
-        ),
-        decimal=3,
+    fig = static.plot_deformation()
+    assert_allclose(fig.data[1]["y"], expected_deformation)
+
+    expected_vx = np.array(
+        [
+            -494.274533,
+            -456.679111,
+            -456.679111,
+            -419.083689,
+            -99.492525,
+            -61.897103,
+            -61.897103,
+            -24.301681,
+            480.980792,
+            518.576214,
+            518.576214,
+            556.171636,
+        ]
     )
-    assert_almost_equal(
-        static.Bm,
-        np.array(
-            [
-                0.0,
-                -118.8692,
-                -118.8692,
-                -228.3396,
-                -228.3396,
-                -248.5133,
-                -248.5133,
-                -259.2881,
-                -259.2881,
-                -134.3435,
-                -134.3435,
-                0.0,
-            ]
-        ),
-        decimal=3,
+    assert_allclose(static.Vx, expected_vx)
+    fig = static.plot_shearing_force()
+    assert_allclose((fig.data[1]["y"]), expected_vx)
+
+    expected_moment = np.array(
+        [
+            0.0,
+            -118.8692056,
+            -118.8692056,
+            -228.3395557,
+            -228.3395557,
+            -248.5132592,
+            -248.5132592,
+            -259.2881072,
+            -259.2881072,
+            -134.3434813,
+            -134.3434813,
+            0.0,
+        ]
     )
+    assert_almost_equal(static.Bm, expected_moment)
+    fig = static.plot_bending_moment()
+    assert_allclose((fig.data[1]["y"]), expected_moment)
 
 
 @pytest.fixture
@@ -974,9 +980,8 @@ def test_static_bearing_with_disks(rotor3):
 
     assert_allclose(static.deformation, expected_deformation)
 
-    # test plot
+    # test plots
     fig = static.plot_deformation()
-
     assert_allclose(fig.data[1]["y"], expected_deformation)
 
 


### PR DESCRIPTION
This PR fixes the issues that we had with the static analysis when we added a bearing and a disk to the same node. 
It also changes the code to work with only one rotor, since this covers most of the cases and makes the code easier to maintain.

- Add failing test to represent issue #845
- Remove check for coaxial rotor
- Remove if block for multiple rotors
- Fix bearing reaction forces
- [x] Fix doctests
- [x] Add tests for the plots
- [x] Fix plots
- [x] Fix shear force
- [x] Fix moment

