### PR TITLE
Fix plot rotor without disks

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1963,20 +1963,21 @@ class Rotor(object):
         # plot disk elements
 
         # calculate scale factor if disks have scale_factor='mass'
-        if all([disk.scale_factor == "mass" for disk in self.disk_elements]):
-            max_mass = max([disk.m for disk in self.disk_elements])
+        if self.disk_elements:
+            if all([disk.scale_factor == "mass" for disk in self.disk_elements]):
+                max_mass = max([disk.m for disk in self.disk_elements])
+                for disk in self.disk_elements:
+                    f = disk.m / max_mass
+                    disk._scale_factor_calculated = (1 - f) * 0.5 + f * 1.0
+
             for disk in self.disk_elements:
-                f = disk.m / max_mass
-                disk._scale_factor_calculated = (1 - f) * 0.5 + f * 1.0
+                scale_factor = disk.scale_factor
+                if scale_factor == "mass":
+                    scale_factor = disk._scale_factor_calculated
+                step = scale_factor * mean_od
 
-        for disk in self.disk_elements:
-            scale_factor = disk.scale_factor
-            if scale_factor == "mass":
-                scale_factor = disk._scale_factor_calculated
-            step = scale_factor * mean_od
-
-            position = (nodes_pos[disk.n], nodes_o_d[disk.n] / 2, step)
-            fig = disk._patch(position, fig)
+                position = (nodes_pos[disk.n], nodes_o_d[disk.n] / 2, step)
+                fig = disk._patch(position, fig)
 
         # plot bearings
         for bearing in self.bearing_elements:

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -42,7 +42,7 @@ def rotor1():
     )
 
     shaft_elm = [tim0, tim1]
-    return Rotor(shaft_elm, [], [])
+    return Rotor(shaft_elm)
 
 
 def test_index_eigenvalues_rotor1(rotor1):
@@ -1775,3 +1775,11 @@ def test_plot_rotor(rotor8):
     ]
     assert_allclose(actual_x[:4], expected_x[:4])
     assert_allclose(actual_y[:4], expected_y[:4])
+
+
+def test_plot_rotor_without_disk(rotor1):
+    fig = rotor1.plot_rotor()
+    expected_element_y = np.array(
+        [0.0, 0.025, 0.025, 0.0, 0.0, -0.0, -0.025, -0.025, -0.0, -0.0]
+    )
+    assert_allclose(fig.data[-1]["y"], expected_element_y)


### PR DESCRIPTION
If a rotor model was created without a disk, the loop used to calculate
the scale factor based on the mass would fail.

Closes #856.
