### PR TITLE
Fix ucs map

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -4115,6 +4115,10 @@ class UCSResults(Results):
         rotor_wn = self.wn
         bearing0 = self.bearing
         intersection_points = self.intersection_points
+        if bearing0.frequency is None:
+            frequency_range = np.linspace(rotor_wn.min(), rotor_wn.max(), 10)
+        else:
+            frequency_range = bearing0.frequency
 
         if fig is None:
             fig = go.Figure()
@@ -4129,16 +4133,12 @@ class UCSResults(Results):
             Q_(intersection_points["y"], "rad/s").to(frequency_units).m
         )
         bearing_kxx_stiffness = (
-            Q_(bearing0.kxx.interpolated(bearing0.frequency), "N/m")
-            .to(stiffness_units)
-            .m
+            Q_(bearing0.kxx_interpolated(frequency_range), "N/m").to(stiffness_units).m
         )
         bearing_kyy_stiffness = (
-            Q_(bearing0.kyy.interpolated(bearing0.frequency), "N/m")
-            .to(stiffness_units)
-            .m
+            Q_(bearing0.kyy_interpolated(frequency_range), "N/m").to(stiffness_units).m
         )
-        bearing_frequency = Q_(bearing0.frequency, "rad/s").to(frequency_units).m
+        bearing_frequency = Q_(frequency_range, "rad/s").to(frequency_units).m
 
         for j in range(rotor_wn.shape[0]):
             fig.add_trace(

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2209,7 +2209,12 @@ class Rotor(object):
 
         # if bearing does not have constant coefficient, check intersection points
         if bearing0.frequency is None:
-            bearing_frequency = np.linspace(rotor_wn.min(), rotor_wn.max(), 10)
+            bearing_frequency_margin = rotor_wn.min() * 0.1
+            bearing_frequency = np.linspace(
+                rotor_wn.min() - bearing_frequency_margin,
+                rotor_wn.max() + bearing_frequency_margin,
+                10,
+            )
         else:
             bearing_frequency = bearing0.frequency
         for j in range(rotor_wn.shape[0]):

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1530,7 +1530,7 @@ def test_global_index():
     assert pointmass[1].dof_global_index["y_8"] == 31
 
 
-def test_distincts_dof_elements_error():
+def test_distinct_dof_elements_error():
     with pytest.raises(Exception):
         i_d = 0
         o_d = 0.05
@@ -1684,6 +1684,25 @@ def rotor8():
     return Rotor(shaft_elem, [disk0, disk1], [bearing0, bearing1])
 
 
+def test_ucs_calc_rotor2(rotor2):
+    ucs_results = rotor2.run_ucs()
+    expected_intersection_points_y = [
+        215.37072557303264,
+        215.37072557303264,
+        598.024741157381,
+        598.024741157381,
+        3956.224979518562,
+        3956.224979518562,
+        4965.289823255782,
+        4965.289823255782,
+    ]
+    assert_allclose(
+        ucs_results.intersection_points["y"], expected_intersection_points_y
+    )
+    fig = ucs_results.plot()
+    assert_allclose(fig.data[4]["y"], expected_intersection_points_y)
+
+
 def test_ucs_calc(rotor8):
     exp_stiffness_range = np.array([1000000.0, 1832980.710832, 3359818.286284])
     exp_rotor_wn = np.array([86.658114, 95.660573, 101.868254])
@@ -1700,6 +1719,36 @@ def test_ucs_calc(rotor8):
     assert_allclose(
         ucs_results.intersection_points["y"][:3], exp_intersection_points_y, rtol=1e-3
     )
+
+
+def test_ucs_rotor9(rotor9):
+    ucs_results = rotor9.run_ucs(num_modes=32)
+    fig = ucs_results.plot()
+    expected_x = np.array(
+        [
+            1.00000000e06,
+            1.83298071e06,
+            3.35981829e06,
+            6.15848211e06,
+            1.12883789e07,
+            2.06913808e07,
+            3.79269019e07,
+            6.95192796e07,
+            1.27427499e08,
+            2.33572147e08,
+            4.28133240e08,
+            7.84759970e08,
+            1.43844989e09,
+            2.63665090e09,
+            4.83293024e09,
+            8.85866790e09,
+            1.62377674e10,
+            2.97635144e10,
+            5.45559478e10,
+            1.00000000e11,
+        ]
+    )
+    assert_allclose(fig.data[0]["x"], expected_x)
 
 
 def test_pickle(rotor8):


### PR DESCRIPTION
Fix calculation of bearing stiffness for plotting 

Since we have removed the Coefficient class we no long calculate the
bearing coefficient with bearing.kxx.interpolated. Now we use
bearing.kxx_interpolated.

Fix number of modes

It was only possible to plot 4 modes. Now we can change the num_modes
which is the number of calculated modes, and we will have that value
divided by 4 being plotted.
Value is divided by 4 because for each pair of eigenvalues calculated
we have one wn, and we show only the forward mode in the plots,
therefore we have num_modes / 2 / 2.