### PR TITLE
Add critical mode plots to ucs

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -4066,14 +4066,17 @@ class UCSResults(Results):
     intersection_points : array
         Points where there is a intersection between undamped natural frequency and
         the bearing stiffness.
+    critical_points_modal : list
+        List with modal results for each critical (intersection) point.
     """
 
     def __init__(
-        self, stiffness_range, stiffness_log, wn, bearing, intersection_points
+        self, stiffness_range, stiffness_log, wn, bearing, intersection_points, critical_points_modal
     ):
         self.stiffness_range = stiffness_range
         self.stiffness_log = stiffness_log
         self.wn = wn
+        self.critical_points_modal = critical_points_modal
         self.bearing = bearing
         self.intersection_points = intersection_points
 

--- a/ross/results.py
+++ b/ross/results.py
@@ -4059,6 +4059,10 @@ class UCSResults(Results):
     stiffness_log : tuple, optional
         Evenly numbers spaced evenly on a log scale to create a better visualization
         (see np.logspace).
+    bearing_frequency_range : tuple, optional
+        The bearing frequency range used to calculate the intersection points.
+        In some cases bearing coefficients will have to be extrapolated.
+        The default is None. In this case the bearing frequency attribute is used.
     wn : array
         Undamped natural frequencies array.
     bearing : ross.BearingElement
@@ -4074,6 +4078,7 @@ class UCSResults(Results):
         self,
         stiffness_range,
         stiffness_log,
+        bearing_frequency_range,
         wn,
         bearing,
         intersection_points,
@@ -4081,6 +4086,7 @@ class UCSResults(Results):
     ):
         self.stiffness_range = stiffness_range
         self.stiffness_log = stiffness_log
+        self.bearing_frequency_range = bearing_frequency_range
         self.wn = wn
         self.critical_points_modal = critical_points_modal
         self.bearing = bearing
@@ -4124,10 +4130,7 @@ class UCSResults(Results):
         rotor_wn = self.wn
         bearing0 = self.bearing
         intersection_points = copy.copy(self.intersection_points)
-        if bearing0.frequency is None:
-            frequency_range = np.linspace(rotor_wn.min(), rotor_wn.max(), 10)
-        else:
-            frequency_range = bearing0.frequency
+        bearing_frequency_range = self.bearing_frequency_range
 
         if fig is None:
             fig = go.Figure()
@@ -4142,12 +4145,12 @@ class UCSResults(Results):
             Q_(intersection_points["y"], "rad/s").to(frequency_units).m
         )
         bearing_kxx_stiffness = (
-            Q_(bearing0.kxx_interpolated(frequency_range), "N/m").to(stiffness_units).m
+            Q_(bearing0.kxx_interpolated(bearing_frequency_range), "N/m").to(stiffness_units).m
         )
         bearing_kyy_stiffness = (
-            Q_(bearing0.kyy_interpolated(frequency_range), "N/m").to(stiffness_units).m
+            Q_(bearing0.kyy_interpolated(bearing_frequency_range), "N/m").to(stiffness_units).m
         )
-        bearing_frequency = Q_(frequency_range, "rad/s").to(frequency_units).m
+        bearing_frequency = Q_(bearing_frequency_range, "rad/s").to(frequency_units).m
 
         for j in range(rotor_wn.shape[0]):
             fig.add_trace(

--- a/ross/results.py
+++ b/ross/results.py
@@ -1727,11 +1727,7 @@ class ForcedResponseResults(Results):
         }
 
     def data_magnitude(
-        self,
-        probe,
-        probe_units="rad",
-        frequency_units="rad/s",
-        amplitude_units="m",
+        self, probe, probe_units="rad", frequency_units="rad/s", amplitude_units="m",
     ):
         """Return the forced response (magnitude) in DataFrame format.
 
@@ -2912,8 +2908,7 @@ class ForcedResponseResults(Results):
 
         fig.update_xaxes(title_text=f"Rotor Length ({rotor_length_units})")
         fig.update_yaxes(
-            title_text=f"Bending Moment ({moment_units})",
-            title_font=dict(size=12),
+            title_text=f"Bending Moment ({moment_units})", title_font=dict(size=12),
         )
         fig.update_layout(**kwargs)
 
@@ -3039,11 +3034,7 @@ class ForcedResponseResults(Results):
                 text=f"Deflected Shape<br>Speed = {speed_str} {frequency_units}",
             ),
             legend=dict(
-                orientation="h",
-                xanchor="center",
-                yanchor="bottom",
-                x=0.5,
-                y=-0.3,
+                orientation="h", xanchor="center", yanchor="bottom", x=0.5, y=-0.3,
             ),
             **subplot_kwargs,
         )
@@ -3204,9 +3195,7 @@ class StaticResults(Results):
         row = rows = 1
         if fig is None:
             fig = make_subplots(
-                rows=rows,
-                cols=cols,
-                subplot_titles=["Free-Body Diagram"],
+                rows=rows, cols=cols, subplot_titles=["Free-Body Diagram"],
             )
 
         y_start = 5.0
@@ -4071,7 +4060,13 @@ class UCSResults(Results):
     """
 
     def __init__(
-        self, stiffness_range, stiffness_log, wn, bearing, intersection_points, critical_points_modal
+        self,
+        stiffness_range,
+        stiffness_log,
+        wn,
+        bearing,
+        intersection_points,
+        critical_points_modal,
     ):
         self.stiffness_range = stiffness_range
         self.stiffness_log = stiffness_log
@@ -4081,11 +4076,7 @@ class UCSResults(Results):
         self.intersection_points = intersection_points
 
     def plot(
-        self,
-        fig=None,
-        stiffness_units="N/m",
-        frequency_units="rad/s",
-        **kwargs,
+        self, fig=None, stiffness_units="N/m", frequency_units="rad/s", **kwargs,
     ):
         """Plot undamped critical speed map.
 
@@ -4200,6 +4191,137 @@ class UCSResults(Results):
         fig.update_layout(title=dict(text="Undamped Critical Speed Map"), **kwargs)
 
         return fig
+
+    def plot_mode_2d(
+        self,
+        critical_mode,
+        evec=None,
+        fig=None,
+        frequency_type="wd",
+        title=None,
+        length_units="m",
+        frequency_units="rad/s",
+        **kwargs,
+    ):
+        """Plot (2D view) the mode shape.
+
+        Parameters
+        ----------
+        critical_mode : int
+            The n'th critical mode.
+        evec : array
+            Array containing the system eigenvectors
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
+        frequency_type : str, optional
+            "wd" calculates de map for the damped natural frequencies.
+            "wn" calculates de map for the undamped natural frequencies.
+            Defaults is "wd".
+        title : str, optional
+            A brief title to the mode shape plot, it will be displayed above other
+            relevant data in the plot area. It does not modify the figure layout from
+            Plotly.
+        length_units : str, optional
+            length units.
+            Default is 'm'.
+        frequency_units : str, optional
+            Frequency units that will be used in the plot title.
+            Default is rad/s.
+        kwargs : optional
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+
+        Returns
+        -------
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
+        """
+        modal_critical = self.critical_points_modal[critical_mode]
+        # select nearest forward
+        forward_frequencies = modal_critical.wd[
+            modal_critical.whirl_direction() == "Forward"
+        ]
+        idx_forward = (np.abs(forward_frequencies - modal_critical.speed)).argmin()
+        forward_frequency = forward_frequencies[idx_forward]
+        idx = (np.abs(modal_critical.wd - forward_frequency)).argmin()
+        fig = modal_critical.plot_mode_2d(
+            idx,
+            evec=evec,
+            fig=fig,
+            frequency_type=frequency_type,
+            title=title,
+            length_units=length_units,
+            frequency_units=frequency_units,
+            **kwargs,
+        )
+
+        return fig
+
+    def plot_mode_3d(
+        self,
+        critical_mode,
+        evec=None,
+        fig=None,
+        frequency_type="wd",
+        title=None,
+        length_units="m",
+        frequency_units="rad/s",
+        **kwargs,
+    ):
+        """Plot (3D view) the mode shapes.
+
+        Parameters
+        ----------
+        critical_mode : int
+            The n'th critical mode.
+            Default is None
+        evec : array
+            Array containing the system eigenvectors
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
+        frequency_type : str, optional
+            "wd" calculates de map for the damped natural frequencies.
+            "wn" calculates de map for the undamped natural frequencies.
+            Defaults is "wd".
+        title : str, optional
+            A brief title to the mode shape plot, it will be displayed above other
+            relevant data in the plot area. It does not modify the figure layout from
+            Plotly.
+        length_units : str, optional
+            length units.
+            Default is 'm'.
+        frequency_units : str, optional
+            Frequency units that will be used in the plot title.
+            Default is rad/s.
+        kwargs : optional
+            Additional key word arguments can be passed to change the plot layout only
+            (e.g. width=1000, height=800, ...).
+            *See Plotly Python Figure Reference for more information.
+
+        Returns
+        -------
+        fig : Plotly graph_objects.Figure()
+            The figure object with the plot.
+        """
+        modal_critical = self.critical_points_modal[critical_mode]
+        # select nearest forward
+        forward_frequencies = modal_critical.wd[
+            modal_critical.whirl_direction() == "Forward"
+        ]
+        idx_forward = (np.abs(forward_frequencies - modal_critical.speed)).argmin()
+        forward_frequency = forward_frequencies[idx_forward]
+        idx = (np.abs(modal_critical.wd - forward_frequency)).argmin()
+        fig = modal_critical.plot_mode_3d(
+            idx,
+            evec=evec,
+            fig=fig,
+            frequency_type=frequency_type,
+            title=title,
+            length_units=length_units,
+            frequency_units=frequency_units,
+            **kwargs,
+        )
 
 
 class Level1Results(Results):

--- a/ross/results.py
+++ b/ross/results.py
@@ -4145,10 +4145,14 @@ class UCSResults(Results):
             Q_(intersection_points["y"], "rad/s").to(frequency_units).m
         )
         bearing_kxx_stiffness = (
-            Q_(bearing0.kxx_interpolated(bearing_frequency_range), "N/m").to(stiffness_units).m
+            Q_(bearing0.kxx_interpolated(bearing_frequency_range), "N/m")
+            .to(stiffness_units)
+            .m
         )
         bearing_kyy_stiffness = (
-            Q_(bearing0.kyy_interpolated(bearing_frequency_range), "N/m").to(stiffness_units).m
+            Q_(bearing0.kyy_interpolated(bearing_frequency_range), "N/m")
+            .to(stiffness_units)
+            .m
         )
         bearing_frequency = Q_(bearing_frequency_range, "rad/s").to(frequency_units).m
 

--- a/ross/results.py
+++ b/ross/results.py
@@ -4114,7 +4114,7 @@ class UCSResults(Results):
         stiffness_log = self.stiffness_log
         rotor_wn = self.wn
         bearing0 = self.bearing
-        intersection_points = self.intersection_points
+        intersection_points = copy.copy(self.intersection_points)
         if bearing0.frequency is None:
             frequency_range = np.linspace(rotor_wn.min(), rotor_wn.max(), 10)
         else:

--- a/ross/results.py
+++ b/ross/results.py
@@ -1727,7 +1727,11 @@ class ForcedResponseResults(Results):
         }
 
     def data_magnitude(
-        self, probe, probe_units="rad", frequency_units="rad/s", amplitude_units="m",
+        self,
+        probe,
+        probe_units="rad",
+        frequency_units="rad/s",
+        amplitude_units="m",
     ):
         """Return the forced response (magnitude) in DataFrame format.
 
@@ -2908,7 +2912,8 @@ class ForcedResponseResults(Results):
 
         fig.update_xaxes(title_text=f"Rotor Length ({rotor_length_units})")
         fig.update_yaxes(
-            title_text=f"Bending Moment ({moment_units})", title_font=dict(size=12),
+            title_text=f"Bending Moment ({moment_units})",
+            title_font=dict(size=12),
         )
         fig.update_layout(**kwargs)
 
@@ -3034,7 +3039,11 @@ class ForcedResponseResults(Results):
                 text=f"Deflected Shape<br>Speed = {speed_str} {frequency_units}",
             ),
             legend=dict(
-                orientation="h", xanchor="center", yanchor="bottom", x=0.5, y=-0.3,
+                orientation="h",
+                xanchor="center",
+                yanchor="bottom",
+                x=0.5,
+                y=-0.3,
             ),
             **subplot_kwargs,
         )
@@ -3195,7 +3204,9 @@ class StaticResults(Results):
         row = rows = 1
         if fig is None:
             fig = make_subplots(
-                rows=rows, cols=cols, subplot_titles=["Free-Body Diagram"],
+                rows=rows,
+                cols=cols,
+                subplot_titles=["Free-Body Diagram"],
             )
 
         y_start = 5.0
@@ -4076,7 +4087,11 @@ class UCSResults(Results):
         self.intersection_points = intersection_points
 
     def plot(
-        self, fig=None, stiffness_units="N/m", frequency_units="rad/s", **kwargs,
+        self,
+        fig=None,
+        stiffness_units="N/m",
+        frequency_units="rad/s",
+        **kwargs,
     ):
         """Plot undamped critical speed map.
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2170,6 +2170,9 @@ class Rotor(object):
             else:
                 stiffness_range = (6, 11)
 
+        if bearing_frequency_range:
+            bearing_frequency_range = np.linspace(bearing_frequency_range[0], bearing_frequency_range[1], 30)
+
         stiffness_log = np.logspace(*stiffness_range, num=num)
         # for each pair of eigenvalues calculated we have one wn, and we show only
         # the forward mode in the plots, therefore we have num_modes / 2 / 2
@@ -2260,6 +2263,7 @@ class Rotor(object):
         results = UCSResults(
             stiffness_range,
             stiffness_log,
+            bearing_frequency_range,
             rotor_wn,
             bearing0,
             intersection_points,

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2117,7 +2117,12 @@ class Rotor(object):
         return results
 
     def run_ucs(
-        self, stiffness_range=None, num_modes=16, num=20, synchronous=False, **kwargs,
+        self,
+        stiffness_range=None,
+        num_modes=16,
+        num=20,
+        synchronous=False,
+        **kwargs,
     ):
         """Run Undamped Critical Speeds analyzes.
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2241,13 +2241,6 @@ class Rotor(object):
 
             modal_critical = rotor_critical.run_modal(speed=speed)
 
-            # select nearest forward
-            forward_frequencies = modal_critical.wd[
-                modal_critical.whirl_direction() == "Forward"
-            ]
-            idx_forward = (np.abs(forward_frequencies - speed)).argmin()
-            forward_frequency = forward_frequencies[idx_forward]
-            idx = (np.abs(modal_critical.wd - forward_frequency)).argmin()
             critical_points_modal.append(modal_critical)
 
         results = UCSResults(

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2171,7 +2171,9 @@ class Rotor(object):
                 stiffness_range = (6, 11)
 
         if bearing_frequency_range:
-            bearing_frequency_range = np.linspace(bearing_frequency_range[0], bearing_frequency_range[1], 30)
+            bearing_frequency_range = np.linspace(
+                bearing_frequency_range[0], bearing_frequency_range[1], 30
+            )
 
         stiffness_log = np.logspace(*stiffness_range, num=num)
         # for each pair of eigenvalues calculated we have one wn, and we show only

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2133,7 +2133,10 @@ class Rotor(object):
         Parameters
         ----------
         stiffness_range : tuple, optional
-            Tuple with (start, end) for stiffness range.
+            Tuple with (start, end) for stiffness range in a log scale.
+            In linear space, the sequence starts at ``base ** start``
+            (`base` to the power of `start`) and ends with ``base ** stop``
+            (see `endpoint` below). Here base is 10.0.
         num : int
             Number of steps in the range.
             Default is 20.


### PR DESCRIPTION
A list with critical points modal analysis results has been added to the ucs results object.
Methods to plot the 2d and 3d mode shapes have also been added to the results object.