### PR TITLE
Remove setup.py <3.10 version restriction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ DESCRIPTION = "ROSS: Rotordynamic Open Source Software"
 URL = "https://github.com/ross-rotordynamics/ross"
 EMAIL = "raphaelts@gmail.com"
 AUTHOR = "ROSS developers"
-REQUIRES_PYTHON = ">=3.7.0, <3.10"
+REQUIRES_PYTHON = ">=3.7.0"
 VERSION = version("ross/__init__.py")
 
 # What packages are required for this module to be executed?


### PR DESCRIPTION
This change aims to avoid error when installing it in python env version 3.10.6