### PR TITLE
Update packages used to build docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: 3.8
+  version: "3.10"
   install:
       - method: pip
         path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,6 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-import sphinx_rtd_theme
 
 html_theme = "sphinx_book_theme"
 html_logo = "_static/ross-logo.svg"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,7 @@
-sphinx==4.3.1
-sphinx_rtd_theme==1.0.0
-myst_nb==0.13.1
-sphinxcontrib-bibtex==2.4.1
-sphinx-copybutton==0.4.0
-numpydoc==1.1.0
-sphinx-book-theme==0.1.7
-linkify-it-py==1.0.2
+sphinx==4.5.0
+myst_nb==0.17.1
+sphinxcontrib-bibtex==2.5.0
+sphinx-copybutton==0.5.1
+numpydoc==1.5.0
+sphinx-book-theme==0.3.3
+linkify-it-py==2.0.0


### PR DESCRIPTION
This updates the versions of the packages used to build the docs and
remove the need to use/update the mistune library which has a CVE for
the version that we were using (0.8.3).)

Closes #940.
